### PR TITLE
ci: build and publish our own macOS llama.cpp prebuilts daily

### DIFF
--- a/.github/workflows/unsloth-macos-prebuilt.yml
+++ b/.github/workflows/unsloth-macos-prebuilt.yml
@@ -1,0 +1,172 @@
+# Build and publish Unsloth Studio's own macOS llama.cpp prebuilts once per day.
+# Source is ggml-org/llama.cpp (latest release tag); the only change over their
+# macos-cpu build is -DCMAKE_OSX_DEPLOYMENT_TARGET=13.3, so the binaries load on
+# macOS 13.3+ instead of inheriting the runner OS as their minimum. Publishes a
+# macOS-only release on this fork that Unsloth Studio installs from.
+
+name: Unsloth macOS llama.cpp prebuilt
+
+on:
+  schedule:
+    - cron: "13 22 * * *"   # ~3PM San Francisco (UTC; not DST adjusted)
+  workflow_dispatch:
+    inputs:
+      upstream_tag:
+        description: "ggml-org/llama.cpp release tag to build (blank = latest)"
+        required: false
+        default: ""
+
+concurrency:
+  group: unsloth-macos-prebuilt
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  resolve:
+    runs-on: ubuntu-latest
+    outputs:
+      upstream_tag: ${{ steps.r.outputs.upstream_tag }}
+      source_commit: ${{ steps.r.outputs.source_commit }}
+      release_tag: ${{ steps.r.outputs.release_tag }}
+      skip: ${{ steps.r.outputs.skip }}
+    steps:
+      - name: Resolve upstream tag and check idempotency
+        id: r
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          REQ="${{ github.event.inputs.upstream_tag }}"
+          if [ -n "$REQ" ]; then
+            TAG="$REQ"
+          else
+            TAG="$(gh api repos/ggml-org/llama.cpp/releases/latest --jq .tag_name)"
+          fi
+          SHA="$(gh api "repos/ggml-org/llama.cpp/commits/$TAG" --jq .sha)"
+          RTAG="llama-prebuilt-macos-$TAG"
+          SKIP=false
+          if gh release view "$RTAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            SKIP=true
+          fi
+          {
+            echo "upstream_tag=$TAG"
+            echo "source_commit=$SHA"
+            echo "release_tag=$RTAG"
+            echo "skip=$SKIP"
+          } >> "$GITHUB_OUTPUT"
+          echo "upstream=$TAG commit=$SHA release=$RTAG skip=$SKIP"
+
+  build:
+    needs: resolve
+    if: needs.resolve.outputs.skip != 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - build: arm64
+            runner: macos-14
+            defines: "-DGGML_METAL_USE_BF16=ON -DGGML_METAL_EMBED_LIBRARY=ON"
+            expect_arch: arm64
+          - build: x64
+            runner: macos-15-intel
+            defines: "-DGGML_METAL=OFF"
+            expect_arch: x86_64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Clone ggml-org source at ${{ needs.resolve.outputs.upstream_tag }}
+        run: |
+          git clone --depth 1 --branch "${{ needs.resolve.outputs.upstream_tag }}" \
+            https://github.com/ggml-org/llama.cpp src
+
+      - name: Build (deployment target 13.3)
+        working-directory: src
+        run: |
+          set -euo pipefail
+          cmake -B build \
+            ${{ matrix.defines }} \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET=13.3 \
+            -DCMAKE_INSTALL_RPATH='@loader_path' \
+            -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
+            -DLLAMA_FATAL_WARNINGS=ON \
+            -DLLAMA_BUILD_BORINGSSL=ON \
+            -DLLAMA_BUILD_EXAMPLES=OFF -DLLAMA_BUILD_TESTS=OFF -DLLAMA_BUILD_TOOLS=ON \
+            -DLLAMA_BUILD_SERVER=ON -DGGML_RPC=ON
+          cmake --build build --config Release -j "$(sysctl -n hw.logicalcpu)"
+
+      - name: Load gate (minos <= 13.3, arch, launch)
+        run: bash scripts/unsloth/assert_macho_minos.sh src/build/bin "${{ matrix.expect_arch }}" 13.3
+
+      - name: Package
+        working-directory: src
+        run: |
+          set -euo pipefail
+          TAG="${{ needs.resolve.outputs.upstream_tag }}"
+          cp LICENSE build/bin/
+          tar -czf "../llama-${TAG}-bin-macos-${{ matrix.build }}.tar.gz" \
+            -s ",^\.,llama-${TAG}," -C build/bin .
+
+      - uses: actions/upload-artifact@v6
+        with:
+          name: macos-${{ matrix.build }}
+          path: llama-*-bin-macos-${{ matrix.build }}.tar.gz
+          if-no-files-found: error
+
+  publish:
+    needs: [resolve, build]
+    if: needs.resolve.outputs.skip != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - uses: actions/download-artifact@v7
+        with:
+          path: dist
+
+      - name: Stage slice tarballs and source archives
+        run: |
+          set -euo pipefail
+          TAG="${{ needs.resolve.outputs.upstream_tag }}"
+          SHA="${{ needs.resolve.outputs.source_commit }}"
+          mkdir -p assets
+          cp dist/macos-arm64/llama-*-bin-macos-arm64.tar.gz assets/
+          cp dist/macos-x64/llama-*-bin-macos-x64.tar.gz assets/
+          git clone --depth 1 --branch "$TAG" https://github.com/ggml-org/llama.cpp src
+          tar --exclude=.git -czf "assets/llama.cpp-source-${TAG}.tar.gz" -C src .
+          cp "assets/llama.cpp-source-${TAG}.tar.gz" "assets/llama.cpp-source-commit-${SHA}.tar.gz"
+
+      - name: Generate manifest and checksums
+        run: |
+          set -euo pipefail
+          TAG="${{ needs.resolve.outputs.upstream_tag }}"
+          SHA="${{ needs.resolve.outputs.source_commit }}"
+          python3 scripts/unsloth/gen_manifest.py \
+            --upstream-tag "$TAG" \
+            --source-commit "$SHA" \
+            --release-tag "${{ needs.resolve.outputs.release_tag }}" \
+            --out-dir assets \
+            --artifact "macos-arm64:assets/llama-${TAG}-bin-macos-arm64.tar.gz" \
+            --artifact "macos-x64:assets/llama-${TAG}-bin-macos-x64.tar.gz" \
+            --source-archive "assets/llama.cpp-source-${TAG}.tar.gz" \
+            --exact-source-archive "assets/llama.cpp-source-commit-${SHA}.tar.gz"
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TAG="${{ needs.resolve.outputs.upstream_tag }}"
+          RTAG="${{ needs.resolve.outputs.release_tag }}"
+          gh release create "$RTAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --target master \
+            --title "llama.cpp prebuilt macos $TAG" \
+            --notes "Install-ready Unsloth Studio llama.cpp macOS bundles for $TAG." \
+            assets/*

--- a/scripts/unsloth/assert_macho_minos.sh
+++ b/scripts/unsloth/assert_macho_minos.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Pre-publish gate for the Unsloth macOS llama.cpp prebuilt. Fails the build
+# unless every shipped Mach-O declares a minimum macOS <= the pinned deployment
+# target (so it dyld-loads on macOS 13.3+), carries the expected arch slice, and
+# actually launches. This is what keeps a runner/SDK bump from silently shipping
+# a minos=26 binary that fails on older Macs.
+#
+# Usage: assert_macho_minos.sh <bin_dir> <expect_arch> [max_minos]
+#   expect_arch: arm64 | x86_64        max_minos: default 13.3
+set -uo pipefail
+
+BIN_DIR="${1:?bin dir required}"
+EXPECT_ARCH="${2:?expected arch required}"
+MAX_MINOS="${3:-13.3}"
+
+fail() { echo "::error::$*"; exit 1; }
+# Compare dotted major.minor as major*100+minor (13.3 -> 1303).
+ver_key() { local v="${1%%-*}"; awk -F. '{printf "%d", $1*100 + ($2==""?0:$2)}' <<<"$v"; }
+MAX_KEY="$(ver_key "$MAX_MINOS")"
+
+command -v vtool >/dev/null 2>&1 || fail "vtool not found (Xcode command line tools required)"
+
+mapfile -t MACHOS < <(find "$BIN_DIR" -type f \( -name '*.dylib' -o -name 'llama-server' -o -name 'llama-quantize' -o -name 'llama-cli' \) 2>/dev/null)
+[ "${#MACHOS[@]}" -gt 0 ] || fail "no Mach-O binaries found under $BIN_DIR"
+
+for macho in "${MACHOS[@]}"; do
+  minos="$(vtool -show-build "$macho" 2>/dev/null | awk '/minos/{print $2; exit}')"
+  [ -n "$minos" ] || fail "$(basename "$macho") has no LC_BUILD_VERSION/minos"
+  if [ "$(ver_key "$minos")" -gt "$MAX_KEY" ]; then
+    fail "$(basename "$macho") minos=$minos exceeds deployment target $MAX_MINOS"
+  fi
+  if ! lipo -archs "$macho" 2>/dev/null | tr ' ' '\n' | grep -qx "$EXPECT_ARCH"; then
+    fail "$(basename "$macho") is missing the $EXPECT_ARCH slice (got: $(lipo -archs "$macho" 2>/dev/null))"
+  fi
+done
+echo "static check passed: ${#MACHOS[@]} Mach-O files, all minos<=$MAX_MINOS, arch=$EXPECT_ARCH"
+
+# Runtime launch forces dyld to resolve every linked dylib (incl. Metal).
+for tool in llama-cli llama-quantize; do
+  bin="$(find "$BIN_DIR" -type f -name "$tool" 2>/dev/null | head -1)"
+  [ -n "$bin" ] || fail "$tool not found under $BIN_DIR"
+done
+CLI="$(find "$BIN_DIR" -type f -name llama-cli | head -1)"
+QUANT="$(find "$BIN_DIR" -type f -name llama-quantize | head -1)"
+"$CLI" --version   >/dev/null 2>&1 || fail "llama-cli failed to launch (dyld load / symbol error)"
+"$QUANT" --help    >/dev/null 2>&1 || fail "llama-quantize failed to launch (dyld load / symbol error)"
+echo "runtime launch passed: llama-cli --version and llama-quantize --help both ran"

--- a/scripts/unsloth/gen_manifest.py
+++ b/scripts/unsloth/gen_manifest.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Generate the Unsloth Studio llama.cpp release manifest + checksum assets.
+
+Writes llama-prebuilt-manifest.json and llama-prebuilt-sha256.json in the exact
+schema studio/install_llama_prebuilt.py consumes (parse_published_release_bundle /
+parse_approved_release_checksums). Used by unsloth-macos-prebuilt.yml after the
+macOS slices are built and validated, before the release is published.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import hashlib
+import json
+from pathlib import Path
+
+# install_kind -> (manifest bundle_profile, sha256 kind tag)
+SLICE_PROFILES = {
+    "macos-arm64": ("macos-metal-arm64", "macos-arm64-app"),
+    "macos-x64": ("macos-cpu-x64", "macos-x64-app"),
+}
+MANIFEST_ASSET = "llama-prebuilt-manifest.json"
+SHA256_ASSET = "llama-prebuilt-sha256.json"
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def parse_slice(value: str) -> tuple[str, Path]:
+    # "macos-arm64:/path/to/llama-bNNNN-bin-macos-arm64.tar.gz"
+    kind, _, path = value.partition(":")
+    if kind not in SLICE_PROFILES or not path:
+        raise argparse.ArgumentTypeError(f"invalid --artifact {value!r}")
+    return kind, Path(path)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--upstream-tag", required=True, help="e.g. b9439")
+    ap.add_argument("--source-commit", required=True, help="full 40-hex commit sha")
+    ap.add_argument("--release-tag", required=True, help="fork release tag")
+    ap.add_argument("--source-repo", default="ggml-org/llama.cpp")
+    ap.add_argument("--out-dir", required=True, type=Path)
+    ap.add_argument(
+        "--artifact",
+        required=True,
+        action="append",
+        type=parse_slice,
+        metavar="KIND:PATH",
+        help="repeatable, e.g. macos-arm64:llama-b9439-bin-macos-arm64.tar.gz",
+    )
+    ap.add_argument("--source-archive", type=Path, help="llama.cpp-source-<tag>.tar.gz")
+    ap.add_argument(
+        "--exact-source-archive",
+        type=Path,
+        help="llama.cpp-source-commit-<sha>.tar.gz",
+    )
+    args = ap.parse_args()
+
+    commit = args.source_commit.strip().lower()
+    short = commit[:7]
+    repo_url = f"https://github.com/{args.source_repo}"
+    out = args.out_dir
+    out.mkdir(parents=True, exist_ok=True)
+
+    source_fields = {
+        "source_repo": args.source_repo,
+        "source_repo_url": repo_url,
+        "source_ref_kind": "tag",
+        "requested_source_ref": args.upstream_tag,
+        "resolved_source_ref": args.upstream_tag,
+        "source_commit": commit,
+        "source_commit_short": short,
+    }
+
+    # Manifest: one artifacts[] entry per built slice.
+    manifest_artifacts = []
+    checksum_artifacts: dict[str, dict] = {}
+    for kind, path in args.artifact:
+        if not path.is_file():
+            ap.error(f"artifact file not found: {path}")
+        profile, hash_kind = SLICE_PROFILES[kind]
+        name = path.name
+        manifest_artifacts.append(
+            {
+                "asset_name": name,
+                "install_kind": kind,
+                "bundle_profile": profile,
+                "runtime_line": None,
+                "coverage_class": None,
+                "rank": 50,
+            }
+        )
+        checksum_artifacts[name] = {
+            "sha256": sha256_file(path),
+            "repo": "unslothai/llama.cpp",
+            "kind": hash_kind,
+            "upstream_tag": args.upstream_tag,
+            "source_commit": commit,
+            "source_commit_short": short,
+        }
+
+    manifest = {
+        "schema_version": 1,
+        "component": "llama.cpp",
+        "upstream_repo": args.source_repo,
+        "upstream_tag": args.upstream_tag,
+        "generated_at_utc": _dt.datetime.now(_dt.timezone.utc).isoformat(
+            timespec="seconds"
+        ),
+        **source_fields,
+        "artifacts": manifest_artifacts,
+    }
+    manifest_path = out / MANIFEST_ASSET
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+    # Source archives let the source-build fallback resolve an approved tree.
+    # The exact-commit entry alone satisfies validated_checksums_for_bundle.
+    if args.source_archive and args.source_archive.is_file():
+        checksum_artifacts[f"llama.cpp-source-{args.upstream_tag}.tar.gz"] = {
+            "sha256": sha256_file(args.source_archive),
+            "repo": args.source_repo,
+            "kind": "upstream-source",
+        }
+    if args.exact_source_archive and args.exact_source_archive.is_file():
+        checksum_artifacts[f"llama.cpp-source-commit-{commit}.tar.gz"] = {
+            "sha256": sha256_file(args.exact_source_archive),
+            "repo": args.source_repo,
+            "kind": "exact-source",
+        }
+
+    # The manifest's own sha is cross-checked by validated_checksums_for_bundle,
+    # so hash it after it is written and add it to the checksum asset.
+    checksum_artifacts[MANIFEST_ASSET] = {
+        "sha256": sha256_file(manifest_path),
+        "repo": "unslothai/llama.cpp",
+        "kind": "published-manifest",
+    }
+
+    checksums = {
+        "schema_version": 1,
+        "component": "llama.cpp",
+        "release_tag": args.release_tag,
+        "upstream_tag": args.upstream_tag,
+        **source_fields,
+        "artifacts": checksum_artifacts,
+    }
+    (out / SHA256_ASSET).write_text(
+        json.dumps(checksums, indent=2) + "\n", encoding="utf-8"
+    )
+
+    print(f"wrote {manifest_path}")
+    print(f"wrote {out / SHA256_ASSET}")
+    print(f"artifacts: {', '.join(sorted(checksum_artifacts))}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Add a daily workflow that builds our own macOS llama.cpp prebuilts and publishes them as a macOS-only release on this fork, which Unsloth Studio installs from.

## Why

Upstream `ggml-org/llama.cpp` moved its arm64 release runner to `macos-26` without pinning a deployment target, so every arm64 release from `b9428` onward is stamped `minos=26` and fails to dyld-load on macOS < 26. Studio's host-version-aware selection already walks back to the last loadable upstream prebuilt, but that leaves macOS < 26 users on a steadily aging binary. Owning the build removes the dependency on upstream's runner config.

The only change over upstream's own `macos-cpu` build is pinning `-DCMAKE_OSX_DEPLOYMENT_TARGET=13.3` (the same flag upstream already sets on its x64 slice), so the binaries declare a minimum macOS of 13.3 and load on every current Mac. The x64 slice is built for resilience as Apple winds down Intel.

## How it works

- `resolve` job resolves the latest upstream `ggml-org/llama.cpp` release tag and skips if we already published it.
- `build` matrix compiles from the upstream source at that tag: arm64 (Metal) on `macos-14`, x64 (CPU) on `macos-15-intel`. A load gate (`scripts/unsloth/assert_macho_minos.sh`) fails the build unless every shipped Mach-O has `minos <= 13.3`, carries the expected arch slice, and launches.
- `publish` job generates `llama-prebuilt-manifest.json` and `llama-prebuilt-sha256.json` (`scripts/unsloth/gen_manifest.py`, in the exact schema the installer parses) and creates a `llama-prebuilt-macos-<tag>` release with both slices plus source archives.
- Runs daily at 22:13 UTC. The macOS-only release tag keeps it separate from the existing Linux bundles.

## Files

- `.github/workflows/unsloth-macos-prebuilt.yml`
- `scripts/unsloth/gen_manifest.py`
- `scripts/unsloth/assert_macho_minos.sh`

## Consumer side

The Studio installer already understands `macos-arm64` / `macos-x64` published artifacts; the matching `setup.sh` change to route macOS at this fork is in a separate unslothai/unsloth PR.
