### PR TITLE
ci: age upstream release (6h) and pin per-slice macOS deployment targets (arm64 14.0, x64 13.3)

### DIFF
--- a/.github/workflows/unsloth-macos-prebuilt.yml
+++ b/.github/workflows/unsloth-macos-prebuilt.yml
@@ -1,8 +1,9 @@
 # Build and publish Unsloth Studio's own macOS llama.cpp prebuilts once per day.
-# Source is ggml-org/llama.cpp (latest release tag); the only change over their
-# macos-cpu build is -DCMAKE_OSX_DEPLOYMENT_TARGET=13.3, so the binaries load on
-# macOS 13.3+ instead of inheriting the runner OS as their minimum. Publishes a
-# macOS-only release on this fork that Unsloth Studio installs from.
+# Source is ggml-org/llama.cpp at the newest release that has been public for at
+# least UNSLOTH_LLAMA_MIN_RELEASE_AGE_HOURS (supply-chain delay); the only change
+# over their macos-cpu build is -DCMAKE_OSX_DEPLOYMENT_TARGET=13.3, so the
+# binaries load on macOS 13.3+ instead of inheriting the runner OS as their
+# minimum. Publishes a macOS-only release on this fork that Studio installs from.
 
 name: Unsloth macOS llama.cpp prebuilt
 
@@ -12,7 +13,11 @@ on:
   workflow_dispatch:
     inputs:
       upstream_tag:
-        description: "ggml-org/llama.cpp release tag to build (blank = latest)"
+        description: "ggml-org/llama.cpp release tag to build (blank = newest aged release)"
+        required: false
+        default: ""
+      min_age_hours:
+        description: "Only build a release public for at least this many hours (blank = default)"
         required: false
         default: ""
 
@@ -22,6 +27,12 @@ concurrency:
 
 permissions:
   contents: write
+
+env:
+  # Supply-chain aging: build only upstream releases that have been public for
+  # at least this many hours, so a malicious or broken release has time to be
+  # caught and yanked before we compile and ship it. Per-run override above.
+  UNSLOTH_LLAMA_MIN_RELEASE_AGE_HOURS: "6"
 
 jobs:
   resolve:
@@ -39,10 +50,20 @@ jobs:
         run: |
           set -euo pipefail
           REQ="${{ github.event.inputs.upstream_tag }}"
+          AGE_H="${{ github.event.inputs.min_age_hours }}"
+          [ -n "$AGE_H" ] || AGE_H="${UNSLOTH_LLAMA_MIN_RELEASE_AGE_HOURS:-6}"
           if [ -n "$REQ" ]; then
-            TAG="$REQ"
+            TAG="$REQ"   # explicit override skips the aging filter
           else
-            TAG="$(gh api repos/ggml-org/llama.cpp/releases/latest --jq .tag_name)"
+            # Newest published release that has been public for >= AGE_H hours.
+            CUTOFF="$(date -u -d "-${AGE_H} hours" +%s)"
+            TAG="$(gh api 'repos/ggml-org/llama.cpp/releases?per_page=100' \
+              --jq "[.[] | select(.draft==false and .prerelease==false) | select((.published_at|fromdateiso8601) <= ${CUTOFF})] | first | .tag_name")"
+            if [ -z "$TAG" ] || [ "$TAG" = "null" ]; then
+              echo "::error::no ggml-org release older than ${AGE_H}h found in the last 100 releases"
+              exit 1
+            fi
+            echo "selected $TAG (aged >= ${AGE_H}h)"
           fi
           SHA="$(gh api "repos/ggml-org/llama.cpp/commits/$TAG" --jq .sha)"
           RTAG="llama-prebuilt-macos-$TAG"

--- a/.github/workflows/unsloth-macos-prebuilt.yml
+++ b/.github/workflows/unsloth-macos-prebuilt.yml
@@ -1,9 +1,12 @@
 # Build and publish Unsloth Studio's own macOS llama.cpp prebuilts once per day.
 # Source is ggml-org/llama.cpp at the newest release that has been public for at
 # least UNSLOTH_LLAMA_MIN_RELEASE_AGE_HOURS (supply-chain delay); the only change
-# over their macos-cpu build is -DCMAKE_OSX_DEPLOYMENT_TARGET=13.3, so the
-# binaries load on macOS 13.3+ instead of inheriting the runner OS as their
-# minimum. Publishes a macOS-only release on this fork that Studio installs from.
+# over their macos-cpu build is an explicit -DCMAKE_OSX_DEPLOYMENT_TARGET per
+# slice, so the binaries declare their load floor instead of inheriting the
+# runner OS: arm64 pins 14.0 (the floor of upstream's pre-macos-26 arm64
+# release), x64 pins 13.3 (matching upstream's own Intel leg, which still
+# covers 2017 Intel Macs capped at Ventura). Publishes a macOS-only release on
+# this fork that Studio installs from.
 
 name: Unsloth macOS llama.cpp prebuilt
 
@@ -90,10 +93,12 @@ jobs:
             runner: macos-14
             defines: "-DGGML_METAL_USE_BF16=ON -DGGML_METAL_EMBED_LIBRARY=ON"
             expect_arch: arm64
+            deploy_target: "14.0"   # no Apple Silicon Mac is capped below 14
           - build: x64
             runner: macos-15-intel
             defines: "-DGGML_METAL=OFF"
             expect_arch: x86_64
+            deploy_target: "13.3"   # matches upstream; covers 2017 Intel (Ventura)
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v6
@@ -105,13 +110,13 @@ jobs:
           git clone --depth 1 --branch "${{ needs.resolve.outputs.upstream_tag }}" \
             https://github.com/ggml-org/llama.cpp src
 
-      - name: Build (deployment target 13.3)
+      - name: Build (deployment target ${{ matrix.deploy_target }})
         working-directory: src
         run: |
           set -euo pipefail
           cmake -B build \
             ${{ matrix.defines }} \
-            -DCMAKE_OSX_DEPLOYMENT_TARGET=13.3 \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET=${{ matrix.deploy_target }} \
             -DCMAKE_INSTALL_RPATH='@loader_path' \
             -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
             -DLLAMA_FATAL_WARNINGS=ON \
@@ -120,8 +125,8 @@ jobs:
             -DLLAMA_BUILD_SERVER=ON -DGGML_RPC=ON
           cmake --build build --config Release -j "$(sysctl -n hw.logicalcpu)"
 
-      - name: Load gate (minos <= 13.3, arch, launch)
-        run: bash scripts/unsloth/assert_macho_minos.sh src/build/bin "${{ matrix.expect_arch }}" 13.3
+      - name: Load gate (minos <= ${{ matrix.deploy_target }}, arch, launch)
+        run: bash scripts/unsloth/assert_macho_minos.sh src/build/bin "${{ matrix.expect_arch }}" "${{ matrix.deploy_target }}"
 
       - name: Package
         working-directory: src

--- a/scripts/unsloth/assert_macho_minos.sh
+++ b/scripts/unsloth/assert_macho_minos.sh
@@ -1,20 +1,20 @@
 #!/usr/bin/env bash
 # Pre-publish gate for the Unsloth macOS llama.cpp prebuilt. Fails the build
 # unless every shipped Mach-O declares a minimum macOS <= the pinned deployment
-# target (so it dyld-loads on macOS 13.3+), carries the expected arch slice, and
+# target (so it dyld-loads on that floor or newer), carries the expected arch slice, and
 # actually launches. This is what keeps a runner/SDK bump from silently shipping
 # a minos=26 binary that fails on older Macs.
 #
 # Usage: assert_macho_minos.sh <bin_dir> <expect_arch> [max_minos]
-#   expect_arch: arm64 | x86_64        max_minos: default 13.3
+#   expect_arch: arm64 | x86_64        max_minos: default 14.0
 set -uo pipefail
 
 BIN_DIR="${1:?bin dir required}"
 EXPECT_ARCH="${2:?expected arch required}"
-MAX_MINOS="${3:-13.3}"
+MAX_MINOS="${3:-14.0}"
 
 fail() { echo "::error::$*"; exit 1; }
-# Compare dotted major.minor as major*100+minor (13.3 -> 1303).
+# Compare dotted major.minor as major*100+minor (14.0 -> 1400).
 ver_key() { local v="${1%%-*}"; awk -F. '{printf "%d", $1*100 + ($2==""?0:$2)}' <<<"$v"; }
 MAX_KEY="$(ver_key "$MAX_MINOS")"
 


### PR DESCRIPTION
Two pre-go-live refinements to the daily macOS prebuilt producer.

## 1. Age upstream releases before building (supply-chain delay)

Build only the newest `ggml-org/llama.cpp` release that has been public for at least `UNSLOTH_LLAMA_MIN_RELEASE_AGE_HOURS` (default 6h), instead of the absolute latest release.

A deliberate aging window is a supply-chain defense: if upstream publishes a compromised or broken release, the delay gives the community time to detect and yank it before we compile from that source and ship binaries to Studio users. We already build from upstream source (not their binaries) and pin our own deployment target, so this only changes which commit we pick, not how we build.

The `resolve` job selects the newest non-draft, non-prerelease release whose `published_at` is at least the window old:

```
CUTOFF=$(date -u -d "-${AGE_H} hours" +%s)
gh api 'repos/ggml-org/llama.cpp/releases?per_page=100' \
  --jq "[.[] | select(.draft==false and .prerelease==false) | select((.published_at|fromdateiso8601) <= ${CUTOFF})] | first | .tag_name"
```

- Default window: 6h (`UNSLOTH_LLAMA_MIN_RELEASE_AGE_HOURS`, set at the workflow level).
- Per-run override: the `min_age_hours` dispatch input.
- An explicit `upstream_tag` dispatch input still bypasses the filter for manual rebuilds.

## 2. Pin the macOS deployment target explicitly, per slice

Declare an explicit `-DCMAKE_OSX_DEPLOYMENT_TARGET` for each slice instead of inheriting the runner OS. The missing pin is exactly what let upstream's arm64 floor silently drift to `minos=26` when their runner moved `macos-14` to `macos-26` (#23878), breaking every arm64 release on macOS < 26.

The floors match upstream's own pre-#23878 per-slice values:

| Slice | Runner | Deployment target | Why |
|---|---|---|---|
| arm64 | `macos-14` | **14.0** | Floor of upstream's last good arm64 release (`b9415` = `minos 14.0.0`). No Apple Silicon Mac (M1, late 2020) is capped below 14, so this costs zero users and is the oldest Apple-security-supported macOS. |
| x64 | `macos-15-intel` | **13.3** | Identical to upstream's own Intel leg. macOS 14 dropped the 2017 Kaby Lake Intel Macs, for which Ventura 13 is the last supported OS; 13.3 keeps them covered at no cost (a 13.3 binary still runs on 14/15/26). |

Net effect: our binaries are floor-identical to pre-#23878 upstream on both slices, with the one hardening that arm64's 14 is now declared rather than inherited. The load gate (`assert_macho_minos.sh`, called with each slice's target) fails any Mach-O whose `minos` exceeds its floor, so a future runner or SDK bump is caught before publish instead of shipping a broken binary.

## Validation

- Aging: against live releases (checked 2026-05-31 11:47Z) the 6h window selects `b9437` (published 2026-05-30 20:56Z), versus the absolute latest `b9442` (2026-05-31 11:07Z).
- Floors: measured real upstream binaries -- `b9415` arm64 = `minos 14.0.0`, x64 = `minos 13.3.0`; the broken `b9442` arm64 = `minos 26.0.0`. Our targets reproduce the two good floors exactly.
- Gate: `ver_key` cap comparison re-checked per slice. cap=14.0 passes 13.3/14.0 and rejects 15.0/26.0; cap=13.3 passes 13.3 and rejects 14.0/15.0/26.0. YAML and bash syntax verified.
