### PR TITLE
Prebuilds: merge a set of upstream PRs into the GitHub Actions builds via `pr-set.json`

### DIFF
--- a/.github/workflows/unsloth-pr-set-lint.yml
+++ b/.github/workflows/unsloth-pr-set-lint.yml
@@ -1,0 +1,63 @@
+name: "Unsloth: lint pr-set.json"
+
+# Tripwire for edits to the mix-build PR set: validates the file the moment a
+# commit touching it is pushed (the team edits it by pushing to master, so
+# there is no PR gate to hook). A bad entry can never build -- the nightly's
+# resolve job re-runs the same structural checks -- but this surfaces the
+# mistake on the commit within seconds instead of failing the 3 AM build, and
+# adds the one check resolve skips: that each pinned commit actually belongs
+# to the PR it is listed under (a wrong paste would otherwise merge unreviewed
+# code while the manifest blames the named PR).
+
+on:
+  push:
+    paths:
+      - scripts/unsloth/pr-set.json
+  pull_request:
+    paths:
+      - scripts/unsloth/pr-set.json
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Validate pr-set.json
+    runs-on: ubuntu-22.04
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v6
+      - run: |
+          set -euo pipefail
+          FILE=scripts/unsloth/pr-set.json
+          jq -e '.prs | type == "array" and all(.[]; type == "string")' "$FILE" >/dev/null \
+            || { echo "::error file=$FILE::.prs must be an array of PR url strings" >&2; exit 1; }
+          URL_RE='^https://github\.com/ggml-org/llama\.cpp/pull/([0-9]+)/commits/([0-9a-f]{40})/?$'
+          fail=0
+          for url in $(jq -r '.prs[]' "$FILE"); do
+            if ! [[ "$url" =~ $URL_RE ]]; then
+              echo "::error file=$FILE::malformed entry '$url' (expected https://github.com/ggml-org/llama.cpp/pull/<n>/commits/<40-hex-sha>)"
+              fail=1
+              continue
+            fi
+            NUM="${BASH_REMATCH[1]}"; PIN="${BASH_REMATCH[2]}"
+            PR_JSON="$(gh api "repos/ggml-org/llama.cpp/pulls/${NUM}" --jq '{state: .state, commits: .commits, head: .head.sha}')"
+            STATE="$(jq -r .state <<<"$PR_JSON")"
+            COMMITS="$(jq -r .commits <<<"$PR_JSON")"
+            HEAD="$(jq -r .head <<<"$PR_JSON")"
+            [ "$STATE" = "open" ] || echo "::warning file=$FILE::PR #${NUM} is ${STATE}; the nightly will skip this entry"
+            # The commits listing is capped at 250 by the API; past that the
+            # membership check cannot be trusted, so skip it rather than
+            # false-fail a legitimate giant PR.
+            if [ "$COMMITS" -gt 250 ]; then
+              echo "::notice::PR #${NUM} has ${COMMITS} commits (over the API listing cap); skipping pin membership check"
+            elif ! gh api "repos/ggml-org/llama.cpp/pulls/${NUM}/commits" --paginate --jq '.[].sha' | grep -qx "$PIN"; then
+              echo "::error file=$FILE::pinned commit ${PIN} is not a commit of PR #${NUM}"
+              fail=1
+              continue
+            fi
+            [ "$PIN" = "$HEAD" ] || echo "::notice::PR #${NUM} pin ${PIN} is behind its head ${HEAD}"
+            echo "OK: PR #${NUM} @ ${PIN} (${STATE})"
+          done
+          exit "$fail"

--- a/.github/workflows/unsloth-pr-set-lint.yml
+++ b/.github/workflows/unsloth-pr-set-lint.yml
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
 name: "Unsloth: lint pr-set.json"
 
 # Tripwire for edits to the mix-build PR set: validates the file the moment a

--- a/.github/workflows/unsloth-prebuilt-cuda-windows.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda-windows.yml
@@ -30,6 +30,11 @@ on:
         required: false
         default: 'ggml-org/llama.cpp'
         type: string
+      source_artifact:
+        description: 'Workflow artifact holding the merged source tarball (mix builds); empty = clone repo at ref'
+        required: false
+        default: ''
+        type: string
       matrix:
         description: 'Matrix JSON {include:[...]} produced by the parent resolve job'
         required: true
@@ -55,6 +60,7 @@ jobs:
           path: tooling
 
       - name: Checkout upstream source @ ${{ inputs.tag }}
+        if: inputs.source_artifact == ''
         uses: actions/checkout@v6
         with:
           repository: ${{ inputs.repo }}
@@ -64,6 +70,23 @@ jobs:
           # to bake LLAMA_BUILD_NUMBER into llama-server --version as b<N>.
           # A shallow clone would bake in "b1" instead.
           fetch-depth: 0
+
+      # Mix builds: the parent's resolve job merged the PR set and uploaded the
+      # tree (with build number/commit pre-baked into cmake/build-info.cmake,
+      # since there is no .git here) as an artifact.
+      - name: Download merged source @ ${{ inputs.tag }}
+        if: inputs.source_artifact != ''
+        uses: actions/download-artifact@v6
+        with:
+          name: ${{ inputs.source_artifact }}
+          path: srcpkg
+      - name: Extract merged source
+        if: inputs.source_artifact != ''
+        shell: bash
+        run: |
+          set -eux
+          mkdir -p src
+          tar -xzf "srcpkg/llama.cpp-source-${{ inputs.tag }}.tar.gz" -C src --strip-components=1
 
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.20

--- a/.github/workflows/unsloth-prebuilt-cuda-windows.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda-windows.yml
@@ -21,9 +21,14 @@ on:
         required: true
         type: string
       ref:
-        description: 'Git ref to build (refs/tags/<tag> or refs/pull/<n>/head); defaults to tag'
+        description: 'Git ref to build (refs/tags/<tag>); defaults to tag'
         required: false
         default: ''
+        type: string
+      repo:
+        description: 'GitHub repository (owner/name) holding the ref: upstream, or the publish repo for merged mix tags'
+        required: false
+        default: 'ggml-org/llama.cpp'
         type: string
       matrix:
         description: 'Matrix JSON {include:[...]} produced by the parent resolve job'
@@ -52,7 +57,7 @@ jobs:
       - name: Checkout upstream source @ ${{ inputs.tag }}
         uses: actions/checkout@v6
         with:
-          repository: ggml-org/llama.cpp
+          repository: ${{ inputs.repo }}
           ref: ${{ inputs.ref || inputs.tag }}
           path: src
           # Full history: cmake/build-info.cmake runs `git rev-list --count HEAD`

--- a/.github/workflows/unsloth-prebuilt-cuda-windows.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda-windows.yml
@@ -198,6 +198,7 @@ jobs:
           TAG: ${{ inputs.tag }}
           SOURCE_COMMIT: ${{ inputs.commit }}
           SOURCE_REPO: ${{ inputs.repo }}
+          SOURCE_REF_KIND: ${{ inputs.source_artifact != '' && 'mix' || 'tag' }}
           PROFILE: ${{ matrix.profile }}
           LINE: ${{ matrix.line }}
           KLASS: ${{ matrix.klass }}

--- a/.github/workflows/unsloth-prebuilt-cuda-windows.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda-windows.yml
@@ -174,6 +174,7 @@ jobs:
           OUT_DIR: ${{ github.workspace }}/dist
           TAG: ${{ inputs.tag }}
           SOURCE_COMMIT: ${{ inputs.commit }}
+          SOURCE_REPO: ${{ inputs.repo }}
           PROFILE: ${{ matrix.profile }}
           LINE: ${{ matrix.line }}
           KLASS: ${{ matrix.klass }}

--- a/.github/workflows/unsloth-prebuilt-cuda.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda.yml
@@ -198,6 +198,7 @@ jobs:
           OUT_DIR: ${{ github.workspace }}/dist
           TAG: ${{ inputs.tag }}
           SOURCE_COMMIT: ${{ inputs.commit }}
+          SOURCE_REPO: ${{ inputs.repo }}
           PROFILE: ${{ matrix.profile }}
           LINE: ${{ matrix.line }}
           KLASS: ${{ matrix.klass }}

--- a/.github/workflows/unsloth-prebuilt-cuda.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda.yml
@@ -222,6 +222,7 @@ jobs:
           TAG: ${{ inputs.tag }}
           SOURCE_COMMIT: ${{ inputs.commit }}
           SOURCE_REPO: ${{ inputs.repo }}
+          SOURCE_REF_KIND: ${{ inputs.source_artifact != '' && 'mix' || 'tag' }}
           PROFILE: ${{ matrix.profile }}
           LINE: ${{ matrix.line }}
           KLASS: ${{ matrix.klass }}

--- a/.github/workflows/unsloth-prebuilt-cuda.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda.yml
@@ -25,6 +25,11 @@ on:
         required: false
         default: 'ggml-org/llama.cpp'
         type: string
+      source_artifact:
+        description: 'Workflow artifact holding the merged source tarball (mix builds); empty = clone repo at ref'
+        required: false
+        default: ''
+        type: string
       matrix:
         description: 'Matrix JSON {include:[...]} produced by the parent resolve job'
         required: true
@@ -57,6 +62,7 @@ jobs:
           path: tooling
 
       - name: Checkout upstream source @ ${{ inputs.tag }}
+        if: inputs.source_artifact == ''
         uses: actions/checkout@v6
         with:
           repository: ${{ inputs.repo }}
@@ -67,6 +73,23 @@ jobs:
           # which gets baked into llama-server --version as b<N>.
           # Shallow clone (default depth=1) would bake in "b1" instead.
           fetch-depth: 0
+
+      # Mix builds: the parent's resolve job merged the PR set and uploaded the
+      # tree (with build number/commit pre-baked into cmake/build-info.cmake,
+      # since there is no .git here) as an artifact.
+      - name: Download merged source @ ${{ inputs.tag }}
+        if: inputs.source_artifact != ''
+        uses: actions/download-artifact@v6
+        with:
+          name: ${{ inputs.source_artifact }}
+          path: srcpkg
+      - name: Extract merged source
+        if: inputs.source_artifact != ''
+        shell: bash
+        run: |
+          set -eux
+          mkdir -p src
+          tar -xzf "srcpkg/llama.cpp-source-${{ inputs.tag }}.tar.gz" -C src --strip-components=1
 
       - name: Install build dependencies
         run: |

--- a/.github/workflows/unsloth-prebuilt-cuda.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda.yml
@@ -16,9 +16,14 @@ on:
         required: true
         type: string
       ref:
-        description: 'Git ref to build (refs/tags/<tag> or refs/pull/<n>/head); defaults to tag'
+        description: 'Git ref to build (refs/tags/<tag>); defaults to tag'
         required: false
         default: ''
+        type: string
+      repo:
+        description: 'GitHub repository (owner/name) holding the ref: upstream, or the publish repo for merged mix tags'
+        required: false
+        default: 'ggml-org/llama.cpp'
         type: string
       matrix:
         description: 'Matrix JSON {include:[...]} produced by the parent resolve job'
@@ -54,7 +59,7 @@ jobs:
       - name: Checkout upstream source @ ${{ inputs.tag }}
         uses: actions/checkout@v6
         with:
-          repository: ggml-org/llama.cpp
+          repository: ${{ inputs.repo }}
           ref: ${{ inputs.ref || inputs.tag }}
           path: src
           # Full history is required: cmake/build-info.cmake runs

--- a/.github/workflows/unsloth-prebuilt-macos.yml
+++ b/.github/workflows/unsloth-prebuilt-macos.yml
@@ -27,6 +27,11 @@ on:
         required: false
         default: 'ggml-org/llama.cpp'
         type: string
+      source_artifact:
+        description: 'Workflow artifact holding the merged source tarball (mix builds); empty = clone repo at ref'
+        required: false
+        default: ''
+        type: string
       matrix:
         description: 'Matrix JSON {include:[...]} produced by the parent resolve job'
         required: true
@@ -50,6 +55,7 @@ jobs:
           persist-credentials: false
 
       - name: Checkout upstream source @ ${{ inputs.tag }}
+        if: inputs.source_artifact == ''
         uses: actions/checkout@v6
         with:
           repository: ${{ inputs.repo }}
@@ -59,6 +65,23 @@ jobs:
           # to bake LLAMA_BUILD_NUMBER into llama-server --version as b<N>.
           # A shallow clone would bake in "b1" instead.
           fetch-depth: 0
+
+      # Mix builds: the parent's resolve job merged the PR set and uploaded the
+      # tree (with build number/commit pre-baked into cmake/build-info.cmake,
+      # since there is no .git here) as an artifact.
+      - name: Download merged source @ ${{ inputs.tag }}
+        if: inputs.source_artifact != ''
+        uses: actions/download-artifact@v6
+        with:
+          name: ${{ inputs.source_artifact }}
+          path: srcpkg
+      - name: Extract merged source
+        if: inputs.source_artifact != ''
+        shell: bash
+        run: |
+          set -eux
+          mkdir -p src
+          tar -xzf "srcpkg/llama.cpp-source-${{ inputs.tag }}.tar.gz" -C src --strip-components=1
 
       - name: Build (deployment target ${{ matrix.deploy_target }})
         working-directory: src

--- a/.github/workflows/unsloth-prebuilt-macos.yml
+++ b/.github/workflows/unsloth-prebuilt-macos.yml
@@ -18,9 +18,14 @@ on:
         required: true
         type: string
       ref:
-        description: 'Git ref to build (refs/tags/<tag> or refs/pull/<n>/head); defaults to tag'
+        description: 'Git ref to build (refs/tags/<tag>); defaults to tag'
         required: false
         default: ''
+        type: string
+      repo:
+        description: 'GitHub repository (owner/name) holding the ref: upstream, or the publish repo for merged mix tags'
+        required: false
+        default: 'ggml-org/llama.cpp'
         type: string
       matrix:
         description: 'Matrix JSON {include:[...]} produced by the parent resolve job'
@@ -47,7 +52,7 @@ jobs:
       - name: Checkout upstream source @ ${{ inputs.tag }}
         uses: actions/checkout@v6
         with:
-          repository: ggml-org/llama.cpp
+          repository: ${{ inputs.repo }}
           ref: ${{ inputs.ref || inputs.tag }}
           path: src
           # Full history: cmake/build-info.cmake runs `git rev-list --count HEAD`

--- a/.github/workflows/unsloth-prebuilt-rocm.yml
+++ b/.github/workflows/unsloth-prebuilt-rocm.yml
@@ -36,6 +36,11 @@ on:
         required: false
         default: 'ggml-org/llama.cpp'
         type: string
+      source_artifact:
+        description: 'Workflow artifact holding the merged source tarball (mix builds); empty = clone repo at ref'
+        required: false
+        default: ''
+        type: string
       matrix:
         description: 'gfx_target matrix JSON ({"gfx_target":[...]}), built by parent'
         required: true
@@ -204,6 +209,7 @@ jobs:
         tar -xzf rocm.tar.gz -C C:\opt\rocm --strip-components=1
 
     - name: Clone llama.cpp @ ${{ inputs.ref || inputs.tag }}
+      if: inputs.source_artifact == ''
       run: |
         $ref = "${{ inputs.ref || inputs.tag }}"
         Write-Host "Cloning llama.cpp at ${ref} (full history so LLAMA_BUILD_NUMBER is correct)"
@@ -217,6 +223,23 @@ jobs:
         # Show current commit info
         Write-Host "Current llama.cpp commit:"
         git log --oneline -1
+
+    # Mix builds: the parent's resolve job merged the PR set and uploaded the
+    # tree (with build number/commit pre-baked into cmake/build-info.cmake,
+    # since there is no .git here) as an artifact.
+    - name: Download merged source @ ${{ inputs.tag }}
+      if: inputs.source_artifact != ''
+      uses: actions/download-artifact@v6
+      with:
+        name: ${{ inputs.source_artifact }}
+        path: srcpkg
+    - name: Extract merged source
+      if: inputs.source_artifact != ''
+      shell: bash
+      run: |
+        set -eux
+        mkdir -p llama.cpp
+        tar -xzf "srcpkg/llama.cpp-source-${{ inputs.tag }}.tar.gz" -C llama.cpp --strip-components=1
 
     - name: Build Llama.cpp + ROCm
       shell: cmd
@@ -548,6 +571,7 @@ jobs:
         echo "ROCm environment variables set successfully"
 
     - name: Clone llama.cpp @ ${{ inputs.ref || inputs.tag }}
+      if: inputs.source_artifact == ''
       run: |
         ref="${{ inputs.ref || inputs.tag }}"
         echo "Cloning llama.cpp at $ref (full history so LLAMA_BUILD_NUMBER is correct)"
@@ -559,6 +583,23 @@ jobs:
         # Show current commit info
         echo "Current llama.cpp commit:"
         git log --oneline -1
+
+    # Mix builds: the parent's resolve job merged the PR set and uploaded the
+    # tree (with build number/commit pre-baked into cmake/build-info.cmake,
+    # since there is no .git here) as an artifact.
+    - name: Download merged source @ ${{ inputs.tag }}
+      if: inputs.source_artifact != ''
+      uses: actions/download-artifact@v6
+      with:
+        name: ${{ inputs.source_artifact }}
+        path: srcpkg
+    - name: Extract merged source
+      if: inputs.source_artifact != ''
+      shell: bash
+      run: |
+        set -eux
+        mkdir -p llama.cpp
+        tar -xzf "srcpkg/llama.cpp-source-${{ inputs.tag }}.tar.gz" -C llama.cpp --strip-components=1
 
     - name: Build Llama.cpp + ROCm
       run: |

--- a/.github/workflows/unsloth-prebuilt-rocm.yml
+++ b/.github/workflows/unsloth-prebuilt-rocm.yml
@@ -27,9 +27,14 @@ on:
         required: true
         type: string
       ref:
-        description: 'Git ref to build (refs/tags/<tag> or refs/pull/<n>/head); defaults to tag'
+        description: 'Git ref to build (refs/tags/<tag>); defaults to tag'
         required: false
         default: ''
+        type: string
+      repo:
+        description: 'GitHub repository (owner/name) holding the ref: upstream, or the publish repo for merged mix tags'
+        required: false
+        default: 'ggml-org/llama.cpp'
         type: string
       matrix:
         description: 'gfx_target matrix JSON ({"gfx_target":[...]}), built by parent'
@@ -202,9 +207,7 @@ jobs:
       run: |
         $ref = "${{ inputs.ref || inputs.tag }}"
         Write-Host "Cloning llama.cpp at ${ref} (full history so LLAMA_BUILD_NUMBER is correct)"
-        # fetch + detached checkout instead of clone --branch so pull refs
-        # (refs/pull/<n>/head) work too; those are not clonable as branches.
-        git clone --single-branch --no-checkout https://github.com/ggerganov/llama.cpp.git
+        git clone --single-branch --no-checkout https://github.com/${{ inputs.repo }}.git llama.cpp
         cd llama.cpp
         git fetch origin $ref
         if ($LASTEXITCODE -ne 0) { exit 1 }
@@ -548,9 +551,7 @@ jobs:
       run: |
         ref="${{ inputs.ref || inputs.tag }}"
         echo "Cloning llama.cpp at $ref (full history so LLAMA_BUILD_NUMBER is correct)"
-        # fetch + detached checkout instead of clone --branch so pull refs
-        # (refs/pull/<n>/head) work too; those are not clonable as branches.
-        git clone --single-branch --no-checkout https://github.com/ggerganov/llama.cpp.git
+        git clone --single-branch --no-checkout https://github.com/${{ inputs.repo }}.git llama.cpp
         cd llama.cpp
         git fetch origin "$ref"
         git checkout --detach FETCH_HEAD

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -151,8 +151,9 @@ jobs:
           # is ever built, so a PR author pushing more commits cannot change
           # what the nightly ships. Non-open PRs are skipped, so merged or
           # abandoned entries rot away harmlessly instead of breaking the
-          # nightly. unsloth-pr-set-lint.yml runs these same checks (plus pin
-          # membership) on every push that edits the file.
+          # nightly. unsloth-pr-set-lint.yml runs the same checks on every
+          # push that edits the file, but that is only a tripwire -- a red
+          # lint does not stop the schedule, so the gate must live here.
           jq -e '.prs | type == "array" and all(.[]; type == "string")' scripts/unsloth/pr-set.json >/dev/null \
             || { echo "scripts/unsloth/pr-set.json: .prs must be an array of PR url strings" >&2; exit 1; }
           PRS='[]'
@@ -162,11 +163,21 @@ jobs:
             NUM="${BASH_REMATCH[1]}"; SHA="${BASH_REMATCH[2]}"
             # plain assignment first so a gh failure aborts the run (set -e)
             # instead of being swallowed by read and silently skipping the PR
-            STATE_HEAD="$(gh api "repos/ggml-org/llama.cpp/pulls/${NUM}" --jq '.state + " " + .head.sha')"
-            read -r STATE HEAD <<<"$STATE_HEAD"
+            STATE_HEAD="$(gh api "repos/ggml-org/llama.cpp/pulls/${NUM}" --jq '.state + " " + .head.sha + " " + (.commits|tostring)')"
+            read -r STATE HEAD N_COMMITS <<<"$STATE_HEAD"
             if [ "$STATE" != "open" ]; then
               echo "skipping PR #${NUM} (${STATE}): $url"
               continue
+            fi
+            # A pin pasted from the wrong PR would build arbitrary upstream
+            # code while the manifest blames PR #<num>; require the pinned
+            # commit to be a commit of that PR. The commits listing is capped
+            # at 250 by the API; past that, skip rather than false-fail.
+            if [ "$N_COMMITS" -gt 250 ]; then
+              echo "note: PR #${NUM} has ${N_COMMITS} commits (over the API listing cap); skipping pin membership check"
+            elif ! gh api "repos/ggml-org/llama.cpp/pulls/${NUM}/commits" --paginate --jq '.[].sha' | grep -qx "$SHA"; then
+              echo "refusing PR #${NUM}: pinned commit ${SHA} is not a commit of that PR (wrong paste, or force-pushed away); fix the pin in scripts/unsloth/pr-set.json" >&2
+              exit 1
             fi
             [ "$SHA" = "$HEAD" ] || echo "note: PR #${NUM} is pinned to ${SHA} but its head has moved to ${HEAD}"
             echo "including PR #${NUM} @ ${SHA}"

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -13,6 +13,11 @@ name: Unsloth prebuilt (full release)
 # any child fails, `assemble` skips and no release is published. The
 # installer needs the full bundle set at the same tag or it'll dispatch to
 # something that isn't there.
+#
+# Mix builds: scripts/unsloth/pr-set.json can list upstream PR urls to merge
+# into the build. `resolve` merges the open ones onto the base tag, pushes the
+# merged commit to this repo as tag b####-mix-<hash>, and the children build
+# that tag instead of the upstream one. Empty list = vanilla upstream build.
 
 on:
   schedule:
@@ -20,7 +25,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'ggml-org tag (b####, "latest", or pr/<number> to build an upstream PR head)'
+        description: 'ggml-org tag (b#### or "latest")'
         default: 'latest'
         required: true
         type: string
@@ -77,6 +82,9 @@ jobs:
     outputs:
       tag: ${{ steps.r.outputs.tag }}
       ref: ${{ steps.r.outputs.ref }}
+      repo: ${{ steps.r.outputs.repo }}
+      base: ${{ steps.r.outputs.base }}
+      prs: ${{ steps.r.outputs.prs }}
       commit: ${{ steps.r.outputs.commit }}
       exists: ${{ steps.r.outputs.exists }}
       cuda_matrix: ${{ steps.r.outputs.cuda_matrix }}
@@ -86,6 +94,11 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
+      # Shallow by default (only pr-set.json is needed); a mix build unshallows
+      # in-place to merge PRs and pushes the result back here, reusing this
+      # checkout's credentials.
+      - name: Checkout (pr-set.json + mix tag push access)
+        uses: actions/checkout@v6
       - id: r
         run: |
           set -euo pipefail
@@ -110,38 +123,88 @@ jobs:
             esac
           fi
           [ -n "$AGE_H" ] || AGE_H="${UNSLOTH_LLAMA_MIN_RELEASE_AGE_HOURS:-6}"
-          if [ "${REQ#pr/}" != "$REQ" ]; then
-            # pr/<number>: build the head of an upstream PR. The synthetic tag
-            # embeds the short head SHA so every pushed head gets its own
-            # release. Published PR builds become "latest" like any other
-            # release. Children fetch the pull ref, so a PR force-pushed
-            # mid-run builds the newer head.
-            PR="${REQ#pr/}"
-            printf '%s' "$PR" | grep -qE '^[0-9]+$' || { echo "refusing malformed PR request '$REQ' (expected pr/<number>)" >&2; exit 1; }
-            COMMIT="$(gh api repos/ggml-org/llama.cpp/pulls/"$PR" --jq .head.sha)"
-            TAG="pr${PR}-$(printf '%.7s' "$COMMIT")"
-            REF="refs/pull/${PR}/head"
-            echo "selected PR #${PR} head ${COMMIT}"
-          else
-            if [ "$REQ" = "latest" ]; then
-              # Newest published (non-draft, non-prerelease) release that has been
-              # public for >= AGE_H hours -- the supply-chain aging window. GitHub
-              # does not guarantee the list order, so pick the max by published_at
-              # explicitly rather than trusting `first`.
-              CUTOFF="$(date -u -d "-${AGE_H} hours" +%s)"
-              TAG="$(gh api 'repos/ggml-org/llama.cpp/releases?per_page=100' \
-                --jq "[.[] | select(.draft==false and .prerelease==false) | select((.published_at|fromdateiso8601) <= ${CUTOFF})] | max_by(.published_at|fromdateiso8601) | .tag_name")"
-              if [ -z "$TAG" ] || [ "$TAG" = "null" ]; then
-                echo "refusing: no ggml-org release older than ${AGE_H}h in the last 100 releases" >&2
-                exit 1
-              fi
-              echo "selected $TAG (aged >= ${AGE_H}h)"
-            else
-              TAG="$REQ"   # explicit b#### override skips the aging filter
+          if [ "$REQ" = "latest" ]; then
+            # Newest published (non-draft, non-prerelease) release that has been
+            # public for >= AGE_H hours -- the supply-chain aging window. GitHub
+            # does not guarantee the list order, so pick the max by published_at
+            # explicitly rather than trusting `first`.
+            CUTOFF="$(date -u -d "-${AGE_H} hours" +%s)"
+            BASE="$(gh api 'repos/ggml-org/llama.cpp/releases?per_page=100' \
+              --jq "[.[] | select(.draft==false and .prerelease==false) | select((.published_at|fromdateiso8601) <= ${CUTOFF})] | max_by(.published_at|fromdateiso8601) | .tag_name")"
+            if [ -z "$BASE" ] || [ "$BASE" = "null" ]; then
+              echo "refusing: no ggml-org release older than ${AGE_H}h in the last 100 releases" >&2
+              exit 1
             fi
-            printf '%s' "$TAG" | grep -qE '^b[0-9]+$' || { echo "refusing non-release tag '$TAG'" >&2; exit 1; }
+            echo "selected $BASE (aged >= ${AGE_H}h)"
+          else
+            BASE="$REQ"   # explicit b#### override skips the aging filter
+          fi
+          printf '%s' "$BASE" | grep -qE '^b[0-9]+$' || { echo "refusing non-release tag '$BASE'" >&2; exit 1; }
+
+          # Resolve the PR mix set (scripts/unsloth/pr-set.json): upstream PR
+          # urls, optionally pinned to a commit via a .../pull/<n>/commits/<sha>
+          # url. Non-open PRs are skipped, so merged or abandoned entries rot
+          # away harmlessly instead of breaking the nightly.
+          jq -e '.prs | type == "array"' scripts/unsloth/pr-set.json >/dev/null \
+            || { echo "scripts/unsloth/pr-set.json: .prs must be an array of PR urls" >&2; exit 1; }
+          PRS='[]'
+          URL_RE='^https://github\.com/ggml-org/llama\.cpp/pull/([0-9]+)(/commits/([0-9a-f]{40}))?/?$'
+          for url in $(jq -r '.prs[]' scripts/unsloth/pr-set.json); do
+            [[ "$url" =~ $URL_RE ]] || { echo "refusing malformed PR url '$url' (expected https://github.com/ggml-org/llama.cpp/pull/<n> or .../pull/<n>/commits/<40-hex-sha>)" >&2; exit 1; }
+            NUM="${BASH_REMATCH[1]}"; PIN="${BASH_REMATCH[3]}"
+            # plain assignment first so a gh failure aborts the run (set -e)
+            # instead of being swallowed by read and silently skipping the PR
+            STATE_HEAD="$(gh api "repos/ggml-org/llama.cpp/pulls/${NUM}" --jq '.state + " " + .head.sha')"
+            read -r STATE HEAD <<<"$STATE_HEAD"
+            if [ "$STATE" != "open" ]; then
+              echo "skipping PR #${NUM} (${STATE}): $url"
+              continue
+            fi
+            SHA="${PIN:-$HEAD}"
+            [ -z "$PIN" ] || [ "$PIN" = "$HEAD" ] || echo "note: PR #${NUM} is pinned to ${PIN} but its head has moved to ${HEAD}"
+            echo "including PR #${NUM} @ ${SHA}${PIN:+ (pinned)}"
+            PRS="$(jq -c --arg n "$NUM" --arg s "$SHA" --arg u "$url" '. + [{number: ($n|tonumber), sha: $s, url: $u}]' <<<"$PRS")"
+          done
+
+          if [ "$(jq length <<<"$PRS")" = 0 ]; then
+            TAG="$BASE"
+            REPO='ggml-org/llama.cpp'
             REF="refs/tags/${TAG}"
-            COMMIT="$(gh api repos/ggml-org/llama.cpp/commits/"$TAG" --jq .sha)"
+            COMMIT="$(gh api repos/ggml-org/llama.cpp/commits/"$BASE" --jq .sha)"
+          else
+            # Merge the set onto the base once, here, and push the result to
+            # this repo as a tag every build child fetches: one merge,
+            # identical trees everywhere, full history for LLAMA_BUILD_NUMBER,
+            # and codeload serves the real merged source for the release's
+            # source-tarball assets. The tag embeds a hash of the PR head SHAs,
+            # so a PR that diverges (force-push) yields a new tag and build,
+            # and an unchanged set reuses the already-pushed tag.
+            SETHASH="$(jq -r 'map("\(.number):\(.sha)") | sort | join("\n")' <<<"$PRS" | sha256sum | cut -c1-7)"
+            TAG="${BASE}-mix-${SETHASH}"
+            REPO="$GITHUB_REPOSITORY"
+            REF="refs/tags/${TAG}"
+            COMMIT="$(git ls-remote origin "$REF" | cut -f1)"
+            if [ -n "$COMMIT" ]; then
+              echo "reusing existing ${TAG} (${COMMIT})"
+            else
+              if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+                git fetch -q --unshallow --no-tags origin
+              fi
+              git remote add upstream https://github.com/ggml-org/llama.cpp.git
+              git fetch -q --no-tags upstream "refs/tags/${BASE}:refs/tags/${BASE}"
+              git checkout -q --detach "refs/tags/${BASE}"
+              for pair in $(jq -r '.[] | "\(.number):\(.sha)"' <<<"$PRS"); do
+                NUM="${pair%%:*}"; SHA="${pair##*:}"
+                git fetch -q --no-tags upstream "$SHA"
+                git -c user.name='github-actions[bot]' -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+                  merge --no-ff --no-edit -m "Merge ggml-org/llama.cpp#${NUM} @ ${SHA}" "$SHA" \
+                  || { echo "PR #${NUM} (${SHA}) does not merge cleanly onto ${BASE} + the PRs listed before it; reorder or drop it in scripts/unsloth/pr-set.json" >&2; exit 1; }
+              done
+              COMMIT="$(git rev-parse HEAD)"
+              git tag "$TAG"
+              git push -q origin "$REF"
+              echo "pushed ${TAG} (${COMMIT})"
+            fi
           fi
 
           # Only PUBLISHED releases count as "exists"; a leftover draft (from
@@ -192,6 +255,9 @@ jobs:
           {
             echo "tag=$TAG"
             echo "ref=$REF"
+            echo "repo=$REPO"
+            echo "base=$BASE"
+            echo "prs=$PRS"
             echo "commit=$COMMIT"
             echo "exists=$EXISTS"
             echo "cuda_matrix={\"include\":$CUDA_INCLUDE}"
@@ -199,7 +265,7 @@ jobs:
             echo "rocm_matrix=$ROCM_MATRIX"
             echo "macos_matrix={\"include\":$MACOS_INCLUDE}"
           } >> "$GITHUB_OUTPUT"
-          echo "Resolved $REQ -> $TAG at $REF ($COMMIT); release exists=$EXISTS; only=$ONLY; gfx=$GFX"
+          echo "Resolved $REQ -> $TAG at ${REPO}@${REF} ($COMMIT); prs=$PRS; release exists=$EXISTS; only=$ONLY; gfx=$GFX"
 
   build-cuda:
     name: CUDA
@@ -209,6 +275,7 @@ jobs:
     with:
       tag: ${{ needs.resolve.outputs.tag }}
       ref: ${{ needs.resolve.outputs.ref }}
+      repo: ${{ needs.resolve.outputs.repo }}
       commit: ${{ needs.resolve.outputs.commit }}
       matrix: ${{ needs.resolve.outputs.cuda_matrix }}
 
@@ -220,6 +287,7 @@ jobs:
     with:
       tag: ${{ needs.resolve.outputs.tag }}
       ref: ${{ needs.resolve.outputs.ref }}
+      repo: ${{ needs.resolve.outputs.repo }}
       commit: ${{ needs.resolve.outputs.commit }}
       matrix: ${{ needs.resolve.outputs.win_cuda_matrix }}
 
@@ -231,6 +299,7 @@ jobs:
     with:
       tag: ${{ needs.resolve.outputs.tag }}
       ref: ${{ needs.resolve.outputs.ref }}
+      repo: ${{ needs.resolve.outputs.repo }}
       matrix: ${{ needs.resolve.outputs.rocm_matrix }}
       operating_systems: ${{ github.event.inputs.operating_systems || 'windows,ubuntu' }}
       rocm_version: ${{ github.event.inputs.rocm_version || 'latest' }}
@@ -243,6 +312,7 @@ jobs:
     with:
       tag: ${{ needs.resolve.outputs.tag }}
       ref: ${{ needs.resolve.outputs.ref }}
+      repo: ${{ needs.resolve.outputs.repo }}
       matrix: ${{ needs.resolve.outputs.macos_matrix }}
 
   assemble:
@@ -282,21 +352,23 @@ jobs:
           pattern: app-*
           merge-multiple: true
 
-      # Ship the upstream source tarballs as release assets so the installer's
-      # source-build fallback has a tree to fetch. Downloaded into dist/ (not
-      # self-tarred) so the published bytes match the sha256 index, which
-      # assemble_metadata records by hashing these exact local files.
-      - name: Fetch upstream source archives
+      # Ship the source tarballs (upstream tag, or this repo's merged mix tag)
+      # as release assets so the installer's source-build fallback has a tree
+      # to fetch. Downloaded into dist/ (not self-tarred) so the published
+      # bytes match the sha256 index, which assemble_metadata records by
+      # hashing these exact local files.
+      - name: Fetch source archives
         run: |
           set -eux
           TAG='${{ needs.resolve.outputs.tag }}'
           REF='${{ needs.resolve.outputs.ref }}'
+          REPO='${{ needs.resolve.outputs.repo }}'
           SHA='${{ needs.resolve.outputs.commit }}'
           mkdir -p dist
           curl -fL --retry 3 -o "dist/llama.cpp-source-${TAG}.tar.gz" \
-            "https://codeload.github.com/ggml-org/llama.cpp/tar.gz/${REF}"
+            "https://codeload.github.com/${REPO}/tar.gz/${REF}"
           curl -fL --retry 3 -o "dist/llama.cpp-source-commit-${SHA}.tar.gz" \
-            "https://codeload.github.com/ggml-org/llama.cpp/tar.gz/${SHA}"
+            "https://codeload.github.com/${REPO}/tar.gz/${SHA}"
 
       - name: Generate manifest + sha256 index
         run: |
@@ -304,6 +376,9 @@ jobs:
           python3 tooling/scripts/unsloth/assemble_metadata.py \
             --tag '${{ needs.resolve.outputs.tag }}' \
             --ref '${{ needs.resolve.outputs.ref }}' \
+            --source-repo '${{ needs.resolve.outputs.repo }}' \
+            --base-tag '${{ needs.resolve.outputs.base }}' \
+            --pr-set '${{ needs.resolve.outputs.prs }}' \
             --commit '${{ needs.resolve.outputs.commit }}' \
             --dist dist --out dist \
             --publish-repo "$GITHUB_REPOSITORY"
@@ -359,10 +434,10 @@ jobs:
         run: |
           set -eux
           TAG='${{ needs.resolve.outputs.tag }}'
-          REF='${{ needs.resolve.outputs.ref }}'
           REPO="$GITHUB_REPOSITORY"
-          SRC="upstream $TAG"
-          case "$REF" in refs/pull/*) N="${REF#refs/pull/}"; SRC="upstream PR #${N%/head}" ;; esac
+          PRS='${{ needs.resolve.outputs.prs }}'
+          SRC="upstream ${{ needs.resolve.outputs.base }}"
+          [ "$(jq length <<<"$PRS")" = 0 ] || SRC="$SRC + $(jq -r 'map("PR #\(.number) @ \(.sha[0:7])") | join(", ")' <<<"$PRS")"
 
           # Atomic publish: upload as draft (hidden from the anon GitHub API
           # the installer uses), then flip draft=false only once every asset
@@ -373,6 +448,6 @@ jobs:
           fi
           gh release create "$TAG" --repo "$REPO" --draft \
             --title "llama.cpp prebuilt $TAG" \
-            --notes "Automated Unsloth llama.cpp CUDA (Linux + Windows) + ROCm + macOS prebuild for $SRC (ggml-org/llama.cpp@${{ needs.resolve.outputs.commit }})." \
+            --notes "Automated Unsloth llama.cpp CUDA (Linux + Windows) + ROCm + macOS prebuild for $SRC (${{ needs.resolve.outputs.repo }}@${{ needs.resolve.outputs.commit }})." \
             dist/*
           gh release edit "$TAG" --repo "$REPO" --draft=false

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -204,7 +204,8 @@ jobs:
             git checkout -q --detach "refs/tags/${BASE}"
             for pair in $(jq -r '.[] | "\(.number):\(.sha)"' <<<"$PRS"); do
               NUM="${pair%%:*}"; SHA="${pair##*:}"
-              git fetch -q --no-tags upstream "$SHA"
+              git fetch -q --no-tags upstream "$SHA" \
+                || { echo "could not fetch commit ${SHA} for PR #${NUM}; it may have been pruned after a force-push -- update or remove the pin in scripts/unsloth/pr-set.json" >&2; exit 1; }
               git -c user.name='github-actions[bot]' -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
                 merge --no-ff --no-edit -m "Merge ggml-org/llama.cpp#${NUM} @ ${SHA}" "$SHA" \
                 || { echo "PR #${NUM} (${SHA}) does not merge cleanly onto ${BASE} + the PRs listed before it; reorder or drop it in scripts/unsloth/pr-set.json" >&2; exit 1; }

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -14,11 +14,11 @@ name: Unsloth prebuilt (full release)
 # installer needs the full bundle set at the same tag or it'll dispatch to
 # something that isn't there.
 #
-# Mix builds: scripts/unsloth/pr-set.json can list upstream PR urls to merge
-# into the build. `resolve` merges the open ones onto the base tag and uploads
-# the merged tree as a workflow artifact that the children extract instead of
-# cloning; the release is tagged b####-mix-<hash>. Empty list = vanilla
-# upstream build.
+# Mix builds: scripts/unsloth/pr-set.json can list upstream PRs (each pinned
+# to an exact commit) to merge into the build. `resolve` merges the open ones
+# onto the base tag and uploads the merged tree as a workflow artifact that
+# the children extract instead of cloning; the release is tagged
+# b####-mix-<hash>. Empty list = vanilla upstream build.
 
 on:
   schedule:
@@ -147,16 +147,19 @@ jobs:
           printf '%s' "$BASE" | grep -qE '^b[0-9]+$' || { echo "refusing non-release tag '$BASE'" >&2; exit 1; }
 
           # Resolve the PR mix set (scripts/unsloth/pr-set.json): upstream PR
-          # urls, optionally pinned to a commit via a .../pull/<n>/commits/<sha>
-          # url. Non-open PRs are skipped, so merged or abandoned entries rot
-          # away harmlessly instead of breaking the nightly.
+          # commit urls. Pins are mandatory -- only an exact, reviewed commit
+          # is ever built, so a PR author pushing more commits cannot change
+          # what the nightly ships. Non-open PRs are skipped, so merged or
+          # abandoned entries rot away harmlessly instead of breaking the
+          # nightly. unsloth-pr-set-lint.yml runs these same checks (plus pin
+          # membership) on every push that edits the file.
           jq -e '.prs | type == "array" and all(.[]; type == "string")' scripts/unsloth/pr-set.json >/dev/null \
             || { echo "scripts/unsloth/pr-set.json: .prs must be an array of PR url strings" >&2; exit 1; }
           PRS='[]'
-          URL_RE='^https://github\.com/ggml-org/llama\.cpp/pull/([0-9]+)(/commits/([0-9a-f]{40}))?/?$'
+          URL_RE='^https://github\.com/ggml-org/llama\.cpp/pull/([0-9]+)/commits/([0-9a-f]{40})/?$'
           for url in $(jq -r '.prs[]' scripts/unsloth/pr-set.json); do
-            [[ "$url" =~ $URL_RE ]] || { echo "refusing malformed PR url '$url' (expected https://github.com/ggml-org/llama.cpp/pull/<n> or .../pull/<n>/commits/<40-hex-sha>)" >&2; exit 1; }
-            NUM="${BASH_REMATCH[1]}"; PIN="${BASH_REMATCH[3]}"
+            [[ "$url" =~ $URL_RE ]] || { echo "refusing malformed PR url '$url' (expected https://github.com/ggml-org/llama.cpp/pull/<n>/commits/<40-hex-sha>)" >&2; exit 1; }
+            NUM="${BASH_REMATCH[1]}"; SHA="${BASH_REMATCH[2]}"
             # plain assignment first so a gh failure aborts the run (set -e)
             # instead of being swallowed by read and silently skipping the PR
             STATE_HEAD="$(gh api "repos/ggml-org/llama.cpp/pulls/${NUM}" --jq '.state + " " + .head.sha')"
@@ -165,9 +168,8 @@ jobs:
               echo "skipping PR #${NUM} (${STATE}): $url"
               continue
             fi
-            SHA="${PIN:-$HEAD}"
-            [ -z "$PIN" ] || [ "$PIN" = "$HEAD" ] || echo "note: PR #${NUM} is pinned to ${PIN} but its head has moved to ${HEAD}"
-            echo "including PR #${NUM} @ ${SHA}${PIN:+ (pinned)}"
+            [ "$SHA" = "$HEAD" ] || echo "note: PR #${NUM} is pinned to ${SHA} but its head has moved to ${HEAD}"
+            echo "including PR #${NUM} @ ${SHA}"
             PRS="$(jq -c --arg n "$NUM" --arg s "$SHA" --arg u "$url" '. + [{number: ($n|tonumber), sha: $s, url: $u}]' <<<"$PRS")"
           done
 
@@ -183,9 +185,9 @@ jobs:
             # trees everywhere, nothing pushed to the repo (GITHUB_TOKEN may
             # never push commits touching .github/workflows, which upstream
             # history routinely does). The synthetic tag embeds a hash of the
-            # PR head SHAs in listed order (merge order can matter for
-            # conflicts), so a force-pushed PR or a reorder yields a new tag
-            # and build, while the release "exists" check below still skips
+            # pinned SHAs in listed order (merge order can matter for
+            # conflicts), so a pin update or a reorder yields a new tag and
+            # build, while the release "exists" check below still skips
             # rebuilding an already-published set.
             SETHASH="$(jq -r 'map("\(.number):\(.sha)") | join("\n")' <<<"$PRS" | sha256sum | cut -c1-7)"
             TAG="${BASE}-mix-${SETHASH}"

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -15,9 +15,10 @@ name: Unsloth prebuilt (full release)
 # something that isn't there.
 #
 # Mix builds: scripts/unsloth/pr-set.json can list upstream PR urls to merge
-# into the build. `resolve` merges the open ones onto the base tag, pushes the
-# merged commit to this repo as tag b####-mix-<hash>, and the children build
-# that tag instead of the upstream one. Empty list = vanilla upstream build.
+# into the build. `resolve` merges the open ones onto the base tag and uploads
+# the merged tree as a workflow artifact that the children extract instead of
+# cloning; the release is tagged b####-mix-<hash>. Empty list = vanilla
+# upstream build.
 
 on:
   schedule:
@@ -79,12 +80,17 @@ jobs:
   resolve:
     name: Resolve tag
     runs-on: ubuntu-22.04
+    # Read-only: resolve merges third-party PR content but pushes nothing;
+    # only assemble needs the workflow-level contents:write (publish).
+    permissions:
+      contents: read
     outputs:
       tag: ${{ steps.r.outputs.tag }}
       ref: ${{ steps.r.outputs.ref }}
       repo: ${{ steps.r.outputs.repo }}
       base: ${{ steps.r.outputs.base }}
       prs: ${{ steps.r.outputs.prs }}
+      source_artifact: ${{ steps.r.outputs.source_artifact }}
       commit: ${{ steps.r.outputs.commit }}
       exists: ${{ steps.r.outputs.exists }}
       cuda_matrix: ${{ steps.r.outputs.cuda_matrix }}
@@ -95,9 +101,8 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       # Shallow by default (only pr-set.json is needed); a mix build unshallows
-      # in-place to merge PRs and pushes the result back here, reusing this
-      # checkout's credentials.
-      - name: Checkout (pr-set.json + mix tag push access)
+      # in-place to merge the PRs.
+      - name: Checkout (pr-set.json + mix merge workspace)
         uses: actions/checkout@v6
       - id: r
         run: |
@@ -166,46 +171,58 @@ jobs:
             PRS="$(jq -c --arg n "$NUM" --arg s "$SHA" --arg u "$url" '. + [{number: ($n|tonumber), sha: $s, url: $u}]' <<<"$PRS")"
           done
 
+          SRC_ARTIFACT=""
           if [ "$(jq length <<<"$PRS")" = 0 ]; then
             TAG="$BASE"
             REPO='ggml-org/llama.cpp'
             REF="refs/tags/${TAG}"
             COMMIT="$(gh api repos/ggml-org/llama.cpp/commits/"$BASE" --jq .sha)"
           else
-            # Merge the set onto the base once, here, and push the result to
-            # this repo as a tag every build child fetches: one merge,
-            # identical trees everywhere, full history for LLAMA_BUILD_NUMBER,
-            # and codeload serves the real merged source for the release's
-            # source-tarball assets. The tag embeds a hash of the PR head SHAs
-            # in listed order (merge order can matter for conflicts), so a
-            # force-pushed PR or a reorder yields a new tag and build, and an
-            # unchanged set reuses the already-pushed tag.
+            # Merge the set onto the base once, here, and ship the merged tree
+            # to the build children as a workflow artifact: one merge, identical
+            # trees everywhere, nothing pushed to the repo (GITHUB_TOKEN may
+            # never push commits touching .github/workflows, which upstream
+            # history routinely does). The synthetic tag embeds a hash of the
+            # PR head SHAs in listed order (merge order can matter for
+            # conflicts), so a force-pushed PR or a reorder yields a new tag
+            # and build, while the release "exists" check below still skips
+            # rebuilding an already-published set.
             SETHASH="$(jq -r 'map("\(.number):\(.sha)") | join("\n")' <<<"$PRS" | sha256sum | cut -c1-7)"
             TAG="${BASE}-mix-${SETHASH}"
-            REPO="$GITHUB_REPOSITORY"
-            REF="refs/tags/${TAG}"
-            COMMIT="$(git ls-remote origin "$REF" | cut -f1)"
-            if [ -n "$COMMIT" ]; then
-              echo "reusing existing ${TAG} (${COMMIT})"
-            else
-              if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
-                git fetch -q --unshallow --no-tags origin
-              fi
-              git remote add upstream https://github.com/ggml-org/llama.cpp.git
-              git fetch -q --no-tags upstream "refs/tags/${BASE}:refs/tags/${BASE}"
-              git checkout -q --detach "refs/tags/${BASE}"
-              for pair in $(jq -r '.[] | "\(.number):\(.sha)"' <<<"$PRS"); do
-                NUM="${pair%%:*}"; SHA="${pair##*:}"
-                git fetch -q --no-tags upstream "$SHA"
-                git -c user.name='github-actions[bot]' -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
-                  merge --no-ff --no-edit -m "Merge ggml-org/llama.cpp#${NUM} @ ${SHA}" "$SHA" \
-                  || { echo "PR #${NUM} (${SHA}) does not merge cleanly onto ${BASE} + the PRs listed before it; reorder or drop it in scripts/unsloth/pr-set.json" >&2; exit 1; }
-              done
-              COMMIT="$(git rev-parse HEAD)"
-              git tag "$TAG"
-              git push -q origin "$REF"
-              echo "pushed ${TAG} (${COMMIT})"
+            REPO='ggml-org/llama.cpp'
+            REF=""
+            SRC_ARTIFACT="app-source-${TAG}"
+            if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+              git fetch -q --unshallow --no-tags origin
             fi
+            git remote add upstream https://github.com/ggml-org/llama.cpp.git
+            git fetch -q --no-tags upstream "refs/tags/${BASE}:refs/tags/${BASE}"
+            git checkout -q --detach "refs/tags/${BASE}"
+            for pair in $(jq -r '.[] | "\(.number):\(.sha)"' <<<"$PRS"); do
+              NUM="${pair%%:*}"; SHA="${pair##*:}"
+              git fetch -q --no-tags upstream "$SHA"
+              git -c user.name='github-actions[bot]' -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+                merge --no-ff --no-edit -m "Merge ggml-org/llama.cpp#${NUM} @ ${SHA}" "$SHA" \
+                || { echo "PR #${NUM} (${SHA}) does not merge cleanly onto ${BASE} + the PRs listed before it; reorder or drop it in scripts/unsloth/pr-set.json" >&2; exit 1; }
+            done
+            COMMIT="$(git rev-parse HEAD)"
+
+            # The tarball ships without .git, where cmake/build-info.cmake falls
+            # back to its defaults; bake real values into those defaults so
+            # llama-server --version doesn't report b0 (unknown). The build
+            # number stays the BASE's b#### number (not the merged commit
+            # count), so anything comparing versions against upstream releases
+            # keeps working; BUILD_COMMIT identifies the merged head.
+            COUNT="${BASE#b}"
+            SHORT="$(git rev-parse --short HEAD)"
+            sed -i "s/^set(BUILD_NUMBER 0)$/set(BUILD_NUMBER ${COUNT})/" cmake/build-info.cmake
+            sed -i "s/^set(BUILD_COMMIT \"unknown\")$/set(BUILD_COMMIT \"${SHORT}\")/" cmake/build-info.cmake
+            grep -q "set(BUILD_NUMBER ${COUNT})" cmake/build-info.cmake \
+              && grep -q "set(BUILD_COMMIT \"${SHORT}\")" cmake/build-info.cmake \
+              || { echo "cmake/build-info.cmake no longer has the expected fallback lines; cannot bake the build number into the source artifact" >&2; exit 1; }
+
+            tar -czf "${RUNNER_TEMP}/llama.cpp-source-${TAG}.tar.gz" --exclude-vcs --transform "s,^\.,llama.cpp-${TAG}," .
+            echo "merged ${TAG} (${COMMIT}, build ${COUNT})"
           fi
 
           # Only PUBLISHED releases count as "exists"; a leftover draft (from
@@ -259,6 +276,7 @@ jobs:
             echo "repo=$REPO"
             echo "base=$BASE"
             echo "prs=$PRS"
+            echo "source_artifact=$SRC_ARTIFACT"
             echo "commit=$COMMIT"
             echo "exists=$EXISTS"
             echo "cuda_matrix={\"include\":$CUDA_INCLUDE}"
@@ -266,7 +284,19 @@ jobs:
             echo "rocm_matrix=$ROCM_MATRIX"
             echo "macos_matrix={\"include\":$MACOS_INCLUDE}"
           } >> "$GITHUB_OUTPUT"
-          echo "Resolved $REQ -> $TAG at ${REPO}@${REF} ($COMMIT); prs=$PRS; release exists=$EXISTS; only=$ONLY; gfx=$GFX"
+          echo "Resolved $REQ -> $TAG ($COMMIT); prs=$PRS; source_artifact=${SRC_ARTIFACT:-none}; release exists=$EXISTS; only=$ONLY; gfx=$GFX"
+
+      # The merged source for mix builds: every build child extracts this
+      # instead of cloning, and assemble ships it as the release's
+      # source-tarball asset (the merged commit exists in no repo).
+      - name: Upload merged source artifact
+        if: steps.r.outputs.source_artifact != ''
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ steps.r.outputs.source_artifact }}
+          path: ${{ runner.temp }}/llama.cpp-source-${{ steps.r.outputs.tag }}.tar.gz
+          if-no-files-found: error
+          retention-days: 7
 
   build-cuda:
     name: CUDA
@@ -277,6 +307,7 @@ jobs:
       tag: ${{ needs.resolve.outputs.tag }}
       ref: ${{ needs.resolve.outputs.ref }}
       repo: ${{ needs.resolve.outputs.repo }}
+      source_artifact: ${{ needs.resolve.outputs.source_artifact }}
       commit: ${{ needs.resolve.outputs.commit }}
       matrix: ${{ needs.resolve.outputs.cuda_matrix }}
 
@@ -289,6 +320,7 @@ jobs:
       tag: ${{ needs.resolve.outputs.tag }}
       ref: ${{ needs.resolve.outputs.ref }}
       repo: ${{ needs.resolve.outputs.repo }}
+      source_artifact: ${{ needs.resolve.outputs.source_artifact }}
       commit: ${{ needs.resolve.outputs.commit }}
       matrix: ${{ needs.resolve.outputs.win_cuda_matrix }}
 
@@ -301,6 +333,7 @@ jobs:
       tag: ${{ needs.resolve.outputs.tag }}
       ref: ${{ needs.resolve.outputs.ref }}
       repo: ${{ needs.resolve.outputs.repo }}
+      source_artifact: ${{ needs.resolve.outputs.source_artifact }}
       matrix: ${{ needs.resolve.outputs.rocm_matrix }}
       operating_systems: ${{ github.event.inputs.operating_systems || 'windows,ubuntu' }}
       rocm_version: ${{ github.event.inputs.rocm_version || 'latest' }}
@@ -314,6 +347,7 @@ jobs:
       tag: ${{ needs.resolve.outputs.tag }}
       ref: ${{ needs.resolve.outputs.ref }}
       repo: ${{ needs.resolve.outputs.repo }}
+      source_artifact: ${{ needs.resolve.outputs.source_artifact }}
       matrix: ${{ needs.resolve.outputs.macos_matrix }}
 
   assemble:
@@ -353,11 +387,13 @@ jobs:
           pattern: app-*
           merge-multiple: true
 
-      # Ship the source tarballs (upstream tag, or this repo's merged mix tag)
-      # as release assets so the installer's source-build fallback has a tree
-      # to fetch. Downloaded into dist/ (not self-tarred) so the published
-      # bytes match the sha256 index, which assemble_metadata records by
-      # hashing these exact local files.
+      # Ship the source tarballs as release assets so the installer's
+      # source-build fallback has a tree to fetch. Downloaded into dist/ (not
+      # self-tarred) so the published bytes match the sha256 index, which
+      # assemble_metadata records by hashing these exact local files. For mix
+      # builds the tag-named tarball arrives in dist/ via the resolve job's
+      # app-source-* artifact (the merged tree is in no repo); the exact-source
+      # asset is the same bytes under the commit name.
       - name: Fetch source archives
         run: |
           set -eux
@@ -366,10 +402,14 @@ jobs:
           REPO='${{ needs.resolve.outputs.repo }}'
           SHA='${{ needs.resolve.outputs.commit }}'
           mkdir -p dist
-          curl -fL --retry 3 -o "dist/llama.cpp-source-${TAG}.tar.gz" \
-            "https://codeload.github.com/${REPO}/tar.gz/${REF}"
-          curl -fL --retry 3 -o "dist/llama.cpp-source-commit-${SHA}.tar.gz" \
-            "https://codeload.github.com/${REPO}/tar.gz/${SHA}"
+          if [ -n '${{ needs.resolve.outputs.source_artifact }}' ]; then
+            cp "dist/llama.cpp-source-${TAG}.tar.gz" "dist/llama.cpp-source-commit-${SHA}.tar.gz"
+          else
+            curl -fL --retry 3 -o "dist/llama.cpp-source-${TAG}.tar.gz" \
+              "https://codeload.github.com/${REPO}/tar.gz/${REF}"
+            curl -fL --retry 3 -o "dist/llama.cpp-source-commit-${SHA}.tar.gz" \
+              "https://codeload.github.com/${REPO}/tar.gz/${SHA}"
+          fi
 
       - name: Generate manifest + sha256 index
         run: |

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -493,6 +493,6 @@ jobs:
           fi
           gh release create "$TAG" --repo "$REPO" --draft \
             --title "llama.cpp prebuilt $TAG" \
-            --notes "Automated Unsloth llama.cpp CUDA (Linux + Windows) + ROCm + macOS prebuild for $SRC (${{ needs.resolve.outputs.repo }}@${{ needs.resolve.outputs.commit }})." \
+            --notes "Automated Unsloth llama.cpp CUDA (Linux + Windows) + ROCm + macOS prebuild for $SRC." \
             dist/*
           gh release edit "$TAG" --repo "$REPO" --draft=false

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -494,6 +494,6 @@ jobs:
           fi
           gh release create "$TAG" --repo "$REPO" --draft \
             --title "llama.cpp prebuilt $TAG" \
-            --notes "Automated Unsloth llama.cpp CUDA (Linux + Windows) + ROCm + macOS prebuild for $SRC." \
+            --notes "Automated Unsloth llama.cpp CUDA (Linux + Windows) + ROCm + macOS prebuild for $SRC (${{ needs.resolve.outputs.repo }}@${{ needs.resolve.outputs.commit }})." \
             dist/*
           gh release edit "$TAG" --repo "$REPO" --draft=false

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -176,10 +176,11 @@ jobs:
             # this repo as a tag every build child fetches: one merge,
             # identical trees everywhere, full history for LLAMA_BUILD_NUMBER,
             # and codeload serves the real merged source for the release's
-            # source-tarball assets. The tag embeds a hash of the PR head SHAs,
-            # so a PR that diverges (force-push) yields a new tag and build,
-            # and an unchanged set reuses the already-pushed tag.
-            SETHASH="$(jq -r 'map("\(.number):\(.sha)") | sort | join("\n")' <<<"$PRS" | sha256sum | cut -c1-7)"
+            # source-tarball assets. The tag embeds a hash of the PR head SHAs
+            # in listed order (merge order can matter for conflicts), so a
+            # force-pushed PR or a reorder yields a new tag and build, and an
+            # unchanged set reuses the already-pushed tag.
+            SETHASH="$(jq -r 'map("\(.number):\(.sha)") | join("\n")' <<<"$PRS" | sha256sum | cut -c1-7)"
             TAG="${BASE}-mix-${SETHASH}"
             REPO="$GITHUB_REPOSITORY"
             REF="refs/tags/${TAG}"

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -150,8 +150,8 @@ jobs:
           # urls, optionally pinned to a commit via a .../pull/<n>/commits/<sha>
           # url. Non-open PRs are skipped, so merged or abandoned entries rot
           # away harmlessly instead of breaking the nightly.
-          jq -e '.prs | type == "array"' scripts/unsloth/pr-set.json >/dev/null \
-            || { echo "scripts/unsloth/pr-set.json: .prs must be an array of PR urls" >&2; exit 1; }
+          jq -e '.prs | type == "array" and all(.[]; type == "string")' scripts/unsloth/pr-set.json >/dev/null \
+            || { echo "scripts/unsloth/pr-set.json: .prs must be an array of PR url strings" >&2; exit 1; }
           PRS='[]'
           URL_RE='^https://github\.com/ggml-org/llama\.cpp/pull/([0-9]+)(/commits/([0-9a-f]{40}))?/?$'
           for url in $(jq -r '.prs[]' scripts/unsloth/pr-set.json); do

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -189,7 +189,11 @@ jobs:
             # rebuilding an already-published set.
             SETHASH="$(jq -r 'map("\(.number):\(.sha)") | join("\n")' <<<"$PRS" | sha256sum | cut -c1-7)"
             TAG="${BASE}-mix-${SETHASH}"
-            REPO='ggml-org/llama.cpp'
+            # REPO names where this source is published, for provenance
+            # metadata: the merged tree exists only as this repo's release
+            # assets, never upstream. Children ignore repo in mix mode (they
+            # extract the artifact instead of cloning).
+            REPO="$GITHUB_REPOSITORY"
             REF=""
             SRC_ARTIFACT="app-source-${TAG}"
             if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then

--- a/scripts/unsloth/assemble_metadata.py
+++ b/scripts/unsloth/assemble_metadata.py
@@ -245,8 +245,8 @@ def main() -> int:
     base_tag = args.base_tag or tag
     pr_set = json.loads(args.pr_set)
     # Upstream release assets exist only for a vanilla build of an upstream tag
-    # (a mix tag lives in the publish repo and has no upstream release).
-    is_upstream_release = source_repo == UPSTREAM_REPO and ref == f"refs/tags/{tag}"
+    # (a mix build's merged tree exists in no repo, only in its release assets).
+    is_upstream_release = source_repo == UPSTREAM_REPO and ref == f"refs/tags/{tag}" and not pr_set
     ref_kind = "tag" if is_upstream_release else "mix" if pr_set else "ref"
     source_ref = tag if ref == f"refs/tags/{tag}" else ref
     args.out.mkdir(parents=True, exist_ok=True)

--- a/scripts/unsloth/assemble_metadata.py
+++ b/scripts/unsloth/assemble_metadata.py
@@ -29,7 +29,6 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 UPSTREAM_REPO = "ggml-org/llama.cpp"
-UPSTREAM_URL = f"https://github.com/{UPSTREAM_REPO}"
 
 BUNDLE_RE = re.compile(
     r"^app-(?P<tag>[^/]+)-(?P<platform>linux|windows)-(?P<arch>x64|arm64)-(?P<profile>cuda1[23]-(?:older|newer|portable))\.(?P<ext>tar\.gz|zip)$"
@@ -171,15 +170,11 @@ def asset_digest_or_hash(asset: dict, token: str | None) -> str:
     return sha256_url(asset["url"], token)
 
 
-def build_manifest(
-    tag: str,
-    commit: str,
+def build_artifacts(
     cuda_bundles: list[tuple[str, str, str, dict]],
     rocm_bundles: list[tuple[str, str, str]],
     macos_bundles: list[tuple[str, str]],
-    ref_kind: str,
-    source_ref: str,
-) -> dict:
+) -> list[dict]:
     """cuda_bundles: list of (asset_name, platform, arch, embedded UNSLOTH_PREBUILT_INFO).
     rocm_bundles:    list of (asset_name, platform, gfx_target).
     macos_bundles:   list of (asset_name, arch).
@@ -222,30 +217,20 @@ def build_manifest(
             "coverage_class": None,
             "rank": 50,
         })
-    return {
-        "schema_version": 1,
-        "component": "llama.cpp",
-        "source_repo": UPSTREAM_REPO,
-        "source_repo_url": UPSTREAM_URL,
-        "source_ref_kind": ref_kind,
-        "requested_source_ref": source_ref,
-        "resolved_source_ref": source_ref,
-        "source_commit": commit,
-        "source_commit_short": commit[:7],
-        "upstream_repo": UPSTREAM_REPO,
-        "upstream_tag": tag,
-        "generated_at_utc": _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "artifacts": artifacts,
-    }
+    return artifacts
 
 
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--tag", required=True)
     ap.add_argument("--ref", default=None,
-                    help="git ref the source was built from (refs/tags/<tag> or refs/pull/<n>/head); "
-                         "defaults to refs/tags/<tag>. A non-tag ref has no upstream release, so the "
-                         "upstream asset index entries are skipped.")
+                    help="git ref the source was built from; defaults to refs/tags/<tag>")
+    ap.add_argument("--source-repo", default=UPSTREAM_REPO,
+                    help="repo holding the source ref: upstream, or the publish repo for merged mix tags")
+    ap.add_argument("--base-tag", default=None,
+                    help="upstream release tag the build is based on; defaults to --tag (differs for mix builds)")
+    ap.add_argument("--pr-set", default="[]",
+                    help='JSON array of merged upstream PRs: [{"number":..,"sha":..,"url":..},..]')
     ap.add_argument("--commit", required=True)
     ap.add_argument("--dist", required=True, type=Path, help="dir holding the built app-*.tar.gz bundles")
     ap.add_argument("--out", required=True, type=Path, help="dir to write the two JSON sidecars into")
@@ -256,9 +241,14 @@ def main() -> int:
     token = args.token or os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
     tag, commit, short = args.tag, args.commit, args.commit[:7]
     ref = args.ref or f"refs/tags/{tag}"
-    is_release_tag = ref == f"refs/tags/{tag}"
-    ref_kind = "tag" if is_release_tag else "pr" if ref.startswith("refs/pull/") else "ref"
-    source_ref = tag if is_release_tag else ref
+    source_repo = args.source_repo
+    base_tag = args.base_tag or tag
+    pr_set = json.loads(args.pr_set)
+    # Upstream release assets exist only for a vanilla build of an upstream tag
+    # (a mix tag lives in the publish repo and has no upstream release).
+    is_upstream_release = source_repo == UPSTREAM_REPO and ref == f"refs/tags/{tag}"
+    ref_kind = "tag" if is_upstream_release else "mix" if pr_set else "ref"
+    source_ref = tag if ref == f"refs/tags/{tag}" else ref
     args.out.mkdir(parents=True, exist_ok=True)
 
     def base_entry(kind: str, repo: str, digest: str) -> dict:
@@ -268,7 +258,7 @@ def main() -> int:
             "sha256": digest,
             "source_commit": commit,
             "source_commit_short": short,
-            "upstream_tag": tag,
+            "upstream_tag": base_tag,
         }
 
     sha_artifacts: dict[str, dict] = {}
@@ -332,10 +322,11 @@ def main() -> int:
     # 2) upstream per-OS bundles: read GitHub's published asset.digest from the
     #    API response; fall back to a streaming hash if a digest is missing.
     #    macOS is absent here on purpose -- we build our own slices in 1c.
-    #    A non-tag ref (PR test build) has no upstream release to index, so the
-    #    whole section is skipped; such runs are never published anyway.
-    if not is_release_tag:
-        print(f"WARNING: source ref {ref} is not an upstream release tag; "
+    #    A mix build has no upstream release for its tag, so the whole section
+    #    is skipped; its uncovered hosts fall back to a source build of the
+    #    merged tree instead of a vanilla upstream binary missing the PRs.
+    if not is_upstream_release:
+        print(f"WARNING: {source_repo}@{ref} is not an upstream release tag; "
               "skipping upstream asset index entries", file=sys.stderr)
     else:
         assets = upstream_assets(tag, token)
@@ -374,9 +365,9 @@ def main() -> int:
     #    doesn't expose pre-computed digests, so we always hash the content.
     source_jobs = [
         (f"llama.cpp-source-{tag}.tar.gz", "upstream-source",
-         f"https://codeload.github.com/{UPSTREAM_REPO}/tar.gz/{ref}"),
+         f"https://codeload.github.com/{source_repo}/tar.gz/{ref}"),
         (f"llama.cpp-source-commit-{commit}.tar.gz", "exact-source",
-         f"https://codeload.github.com/{UPSTREAM_REPO}/tar.gz/{commit}"),
+         f"https://codeload.github.com/{source_repo}/tar.gz/{commit}"),
     ]
 
     def source_digest(name: str, url: str) -> str:
@@ -386,10 +377,30 @@ def main() -> int:
     with ThreadPoolExecutor(max_workers=2) as pool:
         source_digests = list(pool.map(lambda j: source_digest(j[0], j[2]), source_jobs))
     for (name, kind, _url), digest in zip(source_jobs, source_digests):
-        sha_artifacts[name] = base_entry(kind, UPSTREAM_REPO, digest)
+        sha_artifacts[name] = base_entry(kind, source_repo, digest)
 
-    # 4) manifest, then hash it into the index
-    manifest = build_manifest(tag, commit, found, rocm_found, macos_found, ref_kind, source_ref)
+    # 4) manifest, then hash it into the index. Both sidecars share the same
+    #    source-description header; merged_prs records the exact PR head SHAs
+    #    a mix build compiled (empty for vanilla builds).
+    common = {
+        "schema_version": 1,
+        "component": "llama.cpp",
+        "source_repo": source_repo,
+        "source_repo_url": f"https://github.com/{source_repo}",
+        "source_ref_kind": ref_kind,
+        "requested_source_ref": source_ref,
+        "resolved_source_ref": source_ref,
+        "source_commit": commit,
+        "source_commit_short": short,
+        "upstream_repo": UPSTREAM_REPO,
+        "upstream_tag": base_tag,
+        "merged_prs": pr_set,
+    }
+    manifest = {
+        **common,
+        "generated_at_utc": _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "artifacts": build_artifacts(found, rocm_found, macos_found),
+    }
     manifest_path = args.out / "llama-prebuilt-manifest.json"
     manifest_path.write_text(json.dumps(manifest, indent=2))
     sha_artifacts["llama-prebuilt-manifest.json"] = base_entry(
@@ -397,18 +408,9 @@ def main() -> int:
     )
 
     sha256_doc = {
-        "artifacts": sha_artifacts,
-        "component": "llama.cpp",
+        **common,
         "release_tag": tag,
-        "requested_source_ref": source_ref,
-        "resolved_source_ref": source_ref,
-        "schema_version": 1,
-        "source_commit": commit,
-        "source_commit_short": short,
-        "source_ref_kind": ref_kind,
-        "source_repo": UPSTREAM_REPO,
-        "source_repo_url": UPSTREAM_URL,
-        "upstream_tag": tag,
+        "artifacts": sha_artifacts,
     }
     (args.out / "llama-prebuilt-sha256.json").write_text(json.dumps(sha256_doc, indent=2))
 

--- a/scripts/unsloth/package_bundle.py
+++ b/scripts/unsloth/package_bundle.py
@@ -227,7 +227,7 @@ def write_metadata(stage: Path, strategy: PlatformStrategy, cfg: dict, archs: li
         "upstream_tag": cfg["tag"],
         "source_repo": cfg["source_repo"],
         "source_repo_url": f"https://github.com/{cfg['source_repo']}",
-        "source_ref_kind": "tag",
+        "source_ref_kind": cfg["source_ref_kind"],
         "requested_source_ref": cfg["tag"],
         "resolved_source_ref": cfg["tag"],
         "source_commit": cfg["commit"],
@@ -309,6 +309,7 @@ def read_config() -> dict:
         "arch": os.environ.get("ARCH", "x64"),
         "docker_image": os.environ.get("DOCKER_IMAGE", ""),
         "source_repo": os.environ.get("SOURCE_REPO", "ggml-org/llama.cpp"),
+        "source_ref_kind": os.environ.get("SOURCE_REF_KIND", "tag"),
     }
 
 

--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -9,5 +9,6 @@
     "Closed or merged PRs are skipped automatically, and an empty list is a plain upstream build."
   ],
   "prs": [
+    "https://github.com/ggml-org/llama.cpp/pull/24423"
   ]
 }

--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -1,11 +1,9 @@
 {
   "_doc": [
-    "ggml-org/llama.cpp PRs to merge into the nightly prebuilds. Add their urls to the prs list below.",
-    "Both of these forms work:",
-    "  https://github.com/ggml-org/llama.cpp/pull/16334",
+    "ggml-org/llama.cpp PRs to merge into the nightly prebuilds. Each entry pins an exact",
+    "commit -- copy the url of the commit you reviewed from the PR's commits tab:",
     "  https://github.com/ggml-org/llama.cpp/pull/15926/commits/59a3d0cb8f611aa3110ecea3d0afd16b1b18ee06",
-    "The first builds whatever the PR head is at build time. The second (the url of a commit",
-    "inside the PR) stays on that exact commit even if the author keeps pushing.",
+    "Only that commit is built, even if the author keeps pushing; update the pin to take newer code.",
     "Closed or merged PRs are skipped automatically, and an empty list is a plain upstream build."
   ],
   "prs": [

--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -1,0 +1,11 @@
+{
+  "_doc": [
+    "Upstream llama.cpp PRs to merge into the prebuilds (mix 'n match).",
+    "List ggml-org/llama.cpp PR urls. Only OPEN PRs are used; closed or merged ones are skipped automatically.",
+    "Track the PR head:   https://github.com/ggml-org/llama.cpp/pull/12345",
+    "Pin an exact commit: https://github.com/ggml-org/llama.cpp/pull/12345/commits/<full-40-char-sha>",
+    "PRs are merged onto the nightly base tag in the order listed; the build fails fast on a merge conflict.",
+    "Empty list = vanilla upstream build (tag b####); non-empty = tag b####-mix-<hash-of-pr-shas>."
+  ],
+  "prs": []
+}

--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -9,6 +9,5 @@
     "Closed or merged PRs are skipped automatically, and an empty list is a plain upstream build."
   ],
   "prs": [
-    "https://github.com/ggml-org/llama.cpp/pull/24423"
   ]
 }

--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -1,11 +1,13 @@
 {
   "_doc": [
-    "Upstream llama.cpp PRs to merge into the prebuilds (mix 'n match).",
-    "List ggml-org/llama.cpp PR urls. Only OPEN PRs are used; closed or merged ones are skipped automatically.",
-    "Track the PR head:   https://github.com/ggml-org/llama.cpp/pull/12345",
-    "Pin an exact commit: https://github.com/ggml-org/llama.cpp/pull/12345/commits/<full-40-char-sha>",
-    "PRs are merged onto the nightly base tag in the order listed; the build fails fast on a merge conflict.",
-    "Empty list = vanilla upstream build (tag b####); non-empty = tag b####-mix-<hash-of-pr-shas>."
+    "ggml-org/llama.cpp PRs to merge into the nightly prebuilds. Add their urls to the prs list below.",
+    "Both of these forms work:",
+    "  https://github.com/ggml-org/llama.cpp/pull/16334",
+    "  https://github.com/ggml-org/llama.cpp/pull/15926/commits/59a3d0cb8f611aa3110ecea3d0afd16b1b18ee06",
+    "The first builds whatever the PR head is at build time. The second (the url of a commit",
+    "inside the PR) stays on that exact commit even if the author keeps pushing.",
+    "Closed or merged PRs are skipped automatically, and an empty list is a plain upstream build."
   ],
-  "prs": []
+  "prs": [
+  ]
 }


### PR DESCRIPTION
This PR adds support for building the nightly prebuilds with upstream PRs merged in, so we can ship things like new model archs before ggml-org merges them. The set of PRs lives in `scripts/unsloth/pr-set.json` and is edited with a normal commit. This replaces the `tag=pr/<number>` dispatch mode.

## How it works

- List PR urls in the file. A plain url tracks the PR head; a commit url (`.../pull/N/commits/<sha>`) pins it. Closed PRs are skipped, so entries rot away harmlessly once a PR lands upstream.
- `resolve` merges the open PRs onto the base tag once and pushes the result to this repo as tag `b####-mix-<hash>`. All children build that one tag: identical trees, correct `LLAMA_BUILD_NUMBER`, and the release's source tarballs are the real merged tree.
- The hash comes from the PR head SHAs, so a force-pushed PR triggers a new build and an unchanged set reuses the existing tag. The exact commits are recorded in the manifest (`merged_prs`) and release notes.
- A merge conflict fails in `resolve` within ~2 minutes, naming the PR.
- An empty list is a vanilla nightly, byte-identical metadata included.