### PR TITLE
Add AGPLv3 SPDX headers to the Unsloth prebuild workflows

### DIFF
--- a/.github/workflows/unsloth-prebuilt-cuda-windows.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda-windows.yml
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
 name: "Unsloth prebuilt: CUDA Windows"
 
 # Reusable child of unsloth-prebuilt.yml. Builds the per-profile CUDA Windows

--- a/.github/workflows/unsloth-prebuilt-cuda.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda.yml
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
 name: "Unsloth prebuilt: CUDA"
 
 # Reusable child of unsloth-prebuilt.yml. Builds the per-profile CUDA bundles

--- a/.github/workflows/unsloth-prebuilt-macos.yml
+++ b/.github/workflows/unsloth-prebuilt-macos.yml
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
 name: "Unsloth prebuilt: macOS"
 
 # Reusable child of unsloth-prebuilt.yml. Builds the macOS slices (arm64 Metal +

--- a/.github/workflows/unsloth-prebuilt-rocm.yml
+++ b/.github/workflows/unsloth-prebuilt-rocm.yml
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
 name: "Unsloth prebuilt: ROCm"
 
 # Reusable child of unsloth-prebuilt.yml. Per-gfx-target ROCm bundles on

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
 name: Unsloth prebuilt (full release)
 
 # Atomic daily build for unslothai/llama.cpp. One cron, one workflow run, one


### PR DESCRIPTION
Adds the standard Unsloth AGPLv3 SPDX header to the Unsloth-authored prebuild workflows, matching how the headers are applied in unslothai/unsloth:

```
# SPDX-License-Identifier: AGPL-3.0-only
# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
```

Files updated:

- `unsloth-prebuilt.yml`
- `unsloth-prebuilt-cuda.yml`
- `unsloth-prebuilt-cuda-windows.yml`
- `unsloth-prebuilt-rocm.yml`
- `unsloth-prebuilt-macos.yml`

Header-only change (leading comment lines), no behavior change. `bench.yml.disabled` is left untouched since it is an upstream-derived file, not Unsloth-authored. All five files still parse as valid YAML.
