### PR TITLE
Add CPU-only and Vulkan prebuilt workflows (Linux + Windows, x64 + arm64 CPU)

### DIFF
--- a/.github/workflows/unsloth-prebuilt-cpu.yml
+++ b/.github/workflows/unsloth-prebuilt-cpu.yml
@@ -1,0 +1,308 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+name: "Unsloth prebuilt: CPU"
+
+# Reusable child of unsloth-prebuilt.yml. Builds the CPU-only bundles for
+# Linux + Windows, each on x64 and arm64 (one matrix entry per arch). Every
+# matrix entry uploads a single app-*.{tar.gz|zip} artifact for the parent's
+# assemble step to pick up.
+#
+# The Linux build mirrors oobabooga/llama-cpp-binaries' build-wheels-cpu.yml
+# (GGML_BACKEND_DL + GGML_CPU_ALL_VARIANTS + GGML_RPC, no GPU backend). The
+# Windows build instead matches ggml-org/llama.cpp release.yml's windows-cpu
+# job (clang/LLVM toolchain file + "Ninja Multi-Config" + OpenMP + BoringSSL,
+# arm64 cross-compiled from x64) -- clang is upstream's proven CPU path, so we
+# follow it rather than llama-cpp-binaries' MSVC recipe; MSVC stays only where
+# it is mandatory (CUDA/nvcc). Adapted to this repo's conventions:
+# app-<tag>-<platform>-<arch>-cpu archives packaged straight from build/bin like
+# the ROCm/macOS children (no embedded UNSLOTH_PREBUILT_INFO.json --
+# assemble_metadata.py derives the manifest entry from the filename), $ORIGIN
+# RPATH on Linux. arm64 extends llama-cpp-binaries (x64-only) so the release
+# covers the arm64 CPU hosts that previously fell back to ggml-org upstream.
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Upstream llama.cpp release tag (b####), resolved by parent'
+        required: true
+        type: string
+      ref:
+        description: 'Git ref to build (refs/tags/<tag>); defaults to tag'
+        required: false
+        default: ''
+        type: string
+      repo:
+        description: 'GitHub repository (owner/name) holding the ref: upstream, or the publish repo for merged mix tags'
+        required: false
+        default: 'ggml-org/llama.cpp'
+        type: string
+      source_artifact:
+        description: 'Workflow artifact holding the merged source tarball (mix builds); empty = clone repo at ref'
+        required: false
+        default: ''
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  build-linux:
+    name: linux/${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { arch: x64,   runner: ubuntu-22.04 }
+          - { arch: arm64, runner: ubuntu-24.04-arm }
+    steps:
+      - name: Checkout upstream source @ ${{ inputs.tag }}
+        if: inputs.source_artifact == ''
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ inputs.repo }}
+          ref: ${{ inputs.ref || inputs.tag }}
+          path: src
+          # Full history: cmake/build-info.cmake runs `git rev-list --count HEAD`
+          # to bake LLAMA_BUILD_NUMBER into llama-server --version as b<N>.
+          # A shallow clone would bake in "b1" instead.
+          fetch-depth: 0
+
+      # Mix builds: the parent's resolve job merged the PR set and uploaded the
+      # tree (with build number/commit pre-baked into cmake/build-info.cmake,
+      # since there is no .git here) as an artifact.
+      - name: Download merged source @ ${{ inputs.tag }}
+        if: inputs.source_artifact != ''
+        uses: actions/download-artifact@v6
+        with:
+          name: ${{ inputs.source_artifact }}
+          path: srcpkg
+      - name: Extract merged source
+        if: inputs.source_artifact != ''
+        shell: bash
+        run: |
+          set -eux
+          mkdir -p src
+          tar -xzf "srcpkg/llama.cpp-source-${{ inputs.tag }}.tar.gz" -C src --strip-components=1
+
+      - name: Install build dependencies
+        run: |
+          set -eux
+          sudo apt-get update
+          sudo apt-get install -y build-essential libssl-dev ninja-build
+
+      # ggml-org's release.yml applies this GCC-14 workaround on every
+      # ubuntu-24.04 leg (our arm64 runner); the default toolchain there
+      # miscompiles ggml. Matches the gcc-14 step in our CUDA arm64 child.
+      - name: Toolchain workaround (GCC 14 on arm64)
+        if: matrix.arch == 'arm64'
+        run: |
+          set -eux
+          sudo apt-get install -y gcc-14 g++-14
+          {
+            echo "CC=gcc-14"
+            echo "CXX=g++-14"
+          } >> "$GITHUB_ENV"
+
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2.20
+        with:
+          key: cpu-linux-${{ matrix.arch }}
+          variant: ccache
+          evict-old-files: 14d
+
+      - name: Configure
+        working-directory: src
+        run: |
+          set -eux
+          # Build recipe mirrors llama-cpp-binaries' CPU wheel (backend-DL +
+          # all CPU variants + RPC, no GPU backend). RPATH=$ORIGIN so the
+          # bundle's sibling .so files resolve from the binary's own directory.
+          cmake -S . -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DGGML_NATIVE=OFF \
+            -DGGML_BACKEND_DL=ON \
+            -DGGML_CPU_ALL_VARIANTS=ON \
+            -DGGML_RPC=ON \
+            -DLLAMA_BUILD_TESTS=OFF \
+            -DLLAMA_BUILD_EXAMPLES=OFF \
+            -DCMAKE_INSTALL_RPATH='$ORIGIN' \
+            -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
+            -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=OFF \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+      - name: Build
+        working-directory: src
+        run: |
+          set -eux
+          # Backend modules (CPU variants, RPC) build as ggml dependencies, so
+          # the server/quantize targets pull them in.
+          cmake --build build --config Release -j "$(nproc)" \
+            --target llama-server llama-quantize
+          strip build/bin/llama-server build/bin/llama-quantize || true
+
+      # DiffusionGemma binaries (example targets present only in #24423 mix
+      # builds): best-effort, never fail the job. See the CUDA child for the
+      # rationale. The bundle tars all of build/bin, so anything produced here
+      # is shipped automatically.
+      - name: Build DiffusionGemma binaries (best-effort; mix builds only)
+        working-directory: src
+        run: |
+          set -u
+          if [ ! -d examples/diffusion-gemma-server ]; then
+            echo "no DiffusionGemma sources in this tree; skipping"
+            exit 0
+          fi
+          cmake -S . -B build -DLLAMA_BUILD_EXAMPLES=ON \
+            || { echo "reconfigure for examples failed; skipping DiffusionGemma binaries"; exit 0; }
+          if cmake --build build --config Release -j "$(nproc)" \
+              --target llama-diffusion-gemma-visual-server llama-diffusion-cli; then
+            strip build/bin/llama-diffusion-gemma-visual-server build/bin/llama-diffusion-cli || true
+            echo "built DiffusionGemma binaries"
+          else
+            echo "warning: DiffusionGemma binaries failed to build; bundle will omit them"
+          fi
+          exit 0
+
+      - name: Package bundle (tar.gz)
+        run: |
+          set -eux
+          ASSET="app-${{ inputs.tag }}-linux-${{ matrix.arch }}-cpu.tar.gz"
+          cp src/LICENSE src/build/bin/
+          mkdir -p dist
+          (cd src/build/bin && tar -czf "${GITHUB_WORKSPACE}/dist/${ASSET}" .)
+          ls -la dist
+
+      - name: Upload bundle artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: app-${{ inputs.tag }}-linux-${{ matrix.arch }}-cpu
+          path: dist/app-${{ inputs.tag }}-linux-${{ matrix.arch }}-cpu.tar.gz
+          if-no-files-found: error
+
+  build-windows:
+    name: windows/${{ matrix.arch }}
+    # Single x64 runner for both arches: arm64 is cross-compiled with the clang
+    # toolchain (vcvars amd64_arm64), exactly like ggml-org's release.yml
+    # windows-cpu job. CUDA stays on MSVC (mandatory for nvcc on Windows), but
+    # the CPU build uses clang/LLVM to match upstream's proven CPU recipe.
+    runs-on: windows-2025-vs2026
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { arch: x64,   vcvars: x64,         omp_arch: x86_64,  cpu_variants: 'ON' }
+          - { arch: arm64, vcvars: amd64_arm64, omp_arch: aarch64, cpu_variants: 'OFF' }
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - name: Checkout upstream source @ ${{ inputs.tag }}
+        if: inputs.source_artifact == ''
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ inputs.repo }}
+          ref: ${{ inputs.ref || inputs.tag }}
+          path: src
+          # Full history: cmake/build-info.cmake runs `git rev-list --count HEAD`
+          # to bake LLAMA_BUILD_NUMBER into llama-server --version as b<N>.
+          fetch-depth: 0
+
+      # Mix builds: the parent's resolve job merged the PR set and uploaded the
+      # tree (with build number/commit pre-baked into cmake/build-info.cmake,
+      # since there is no .git here) as an artifact.
+      - name: Download merged source @ ${{ inputs.tag }}
+        if: inputs.source_artifact != ''
+        uses: actions/download-artifact@v6
+        with:
+          name: ${{ inputs.source_artifact }}
+          path: srcpkg
+      - name: Extract merged source
+        if: inputs.source_artifact != ''
+        shell: bash
+        run: |
+          set -eux
+          mkdir -p src
+          tar -xzf "srcpkg/llama.cpp-source-${{ inputs.tag }}.tar.gz" -C src --strip-components=1
+
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2.20
+        with:
+          key: cpu-windows-${{ matrix.arch }}
+          variant: ccache
+          evict-old-files: 14d
+
+      - name: Install Ninja
+        run: choco install ninja --no-progress
+
+      # Build recipe copied from ggml-org/llama.cpp release.yml (windows-cpu):
+      # clang via the per-arch LLVM toolchain file, "Ninja Multi-Config", OpenMP,
+      # BoringSSL, and GGML_CPU_ALL_VARIANTS only on x64 (it is an x86 microarch
+      # fan-out). vcvarsall sets the env (incl. the amd64_arm64 cross toolchain),
+      # so this runs in cmd. CMAKE_ARGS mirrors upstream's env.CMAKE_ARGS; we
+      # only narrow `--target` to the binaries we ship.
+      - name: Build
+        working-directory: src
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ matrix.vcvars }}
+          cmake -S . -B build -G "Ninja Multi-Config" ^
+            -D CMAKE_TOOLCHAIN_FILE=cmake/${{ matrix.arch }}-windows-llvm.cmake ^
+            -DLLAMA_BUILD_BORINGSSL=ON ^
+            -DGGML_NATIVE=OFF ^
+            -DGGML_BACKEND_DL=ON ^
+            -DGGML_CPU_ALL_VARIANTS=${{ matrix.cpu_variants }} ^
+            -DGGML_OPENMP=ON ^
+            -DGGML_RPC=ON ^
+            -DLLAMA_BUILD_TESTS=OFF ^
+            -DLLAMA_BUILD_EXAMPLES=OFF ^
+            -DLLAMA_BUILD_TOOLS=ON ^
+            -DLLAMA_BUILD_SERVER=ON ^
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache ^
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          if errorlevel 1 exit /b 1
+          cmake --build build --config Release --target llama-server llama-quantize
+          if errorlevel 1 exit /b 1
+
+      # DiffusionGemma binaries (#24423 mix builds only): best-effort, never fail
+      # the job (trailing `exit /b 0`). vcvarsall is re-called -- step env does
+      # not persist -- and the reconfigure reuses the cached clang toolchain.
+      - name: Build DiffusionGemma binaries (best-effort; mix builds only)
+        working-directory: src
+        shell: cmd
+        run: |
+          if not exist examples\diffusion-gemma-server (
+            echo no DiffusionGemma sources in this tree; skipping
+            exit /b 0
+          )
+          call "C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ matrix.vcvars }}
+          cmake -S . -B build -DLLAMA_BUILD_EXAMPLES=ON
+          cmake --build build --config Release --target llama-diffusion-gemma-visual-server llama-diffusion-cli
+          exit /b 0
+
+      # Ninja Multi-Config emits to build/bin/Release. Ship the OpenMP runtime
+      # (GGML_OPENMP=ON) from the VS LLVM redist -- exactly as upstream does --
+      # globbing the MSVC version dir so an image bump does not break the path.
+      - name: Package bundle (zip)
+        run: |
+          $rel = "src/build/bin/Release"
+          Copy-Item src/LICENSE $rel/
+          $omp = Get-ChildItem "C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Redist\MSVC\*\debug_nonredist\${{ matrix.arch }}\Microsoft.VC*.OpenMP.LLVM\libomp140.${{ matrix.omp_arch }}.dll" -ErrorAction SilentlyContinue | Select-Object -First 1
+          if (-not $omp) { Write-Error "libomp140.${{ matrix.omp_arch }}.dll not found in the VS LLVM redist"; exit 1 }
+          Copy-Item $omp.FullName $rel/
+          New-Item -ItemType Directory -Force -Path dist | Out-Null
+          $asset = "app-${{ inputs.tag }}-windows-${{ matrix.arch }}-cpu.zip"
+          Push-Location $rel
+          7z a -tzip "$env:GITHUB_WORKSPACE/dist/$asset" .
+          Pop-Location
+          Get-ChildItem dist
+
+      - name: Upload bundle artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: app-${{ inputs.tag }}-windows-${{ matrix.arch }}-cpu
+          path: dist/app-${{ inputs.tag }}-windows-${{ matrix.arch }}-cpu.zip
+          if-no-files-found: error

--- a/.github/workflows/unsloth-prebuilt-vulkan.yml
+++ b/.github/workflows/unsloth-prebuilt-vulkan.yml
@@ -1,0 +1,298 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+name: "Unsloth prebuilt: Vulkan"
+
+# Reusable child of unsloth-prebuilt.yml. Builds the Vulkan bundles for
+# Linux x64 + Windows x64. Each job uploads a single app-*.{tar.gz|zip}
+# artifact for the parent's assemble step to pick up.
+#
+# Mirrors oobabooga/llama-cpp-binaries' build-wheels-vulkan.yml build recipe
+# (the CPU recipe plus GGML_VULKAN=ON and a Vulkan SDK install), adapted to
+# this repo's conventions: app-<tag>-<platform>-x64-vulkan archives packaged
+# straight from build/bin like the ROCm/macOS children (no embedded
+# UNSLOTH_PREBUILT_INFO.json -- assemble_metadata.py derives the manifest entry
+# from the filename), MSVC + BoringSSL on Windows, $ORIGIN RPATH on Linux.
+#
+# The Vulkan loader (libvulkan.so.1 / vulkan-1.dll) is a system/driver library
+# resolved by the OS at runtime, so -- like llama-cpp-binaries -- it is not
+# bundled; only ggml's own libggml-vulkan backend module ships in the archive.
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Upstream llama.cpp release tag (b####), resolved by parent'
+        required: true
+        type: string
+      ref:
+        description: 'Git ref to build (refs/tags/<tag>); defaults to tag'
+        required: false
+        default: ''
+        type: string
+      repo:
+        description: 'GitHub repository (owner/name) holding the ref: upstream, or the publish repo for merged mix tags'
+        required: false
+        default: 'ggml-org/llama.cpp'
+        type: string
+      source_artifact:
+        description: 'Workflow artifact holding the merged source tarball (mix builds); empty = clone repo at ref'
+        required: false
+        default: ''
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  # LunarG SDK version, matching llama-cpp-binaries' build-wheels-vulkan.yml.
+  VULKAN_VERSION: 1.4.313.2
+
+jobs:
+  build-linux:
+    name: linux/x64
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout upstream source @ ${{ inputs.tag }}
+        if: inputs.source_artifact == ''
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ inputs.repo }}
+          ref: ${{ inputs.ref || inputs.tag }}
+          path: src
+          # Full history: cmake/build-info.cmake runs `git rev-list --count HEAD`
+          # to bake LLAMA_BUILD_NUMBER into llama-server --version as b<N>.
+          # A shallow clone would bake in "b1" instead.
+          fetch-depth: 0
+
+      # Mix builds: the parent's resolve job merged the PR set and uploaded the
+      # tree (with build number/commit pre-baked into cmake/build-info.cmake,
+      # since there is no .git here) as an artifact.
+      - name: Download merged source @ ${{ inputs.tag }}
+        if: inputs.source_artifact != ''
+        uses: actions/download-artifact@v6
+        with:
+          name: ${{ inputs.source_artifact }}
+          path: srcpkg
+      - name: Extract merged source
+        if: inputs.source_artifact != ''
+        shell: bash
+        run: |
+          set -eux
+          mkdir -p src
+          tar -xzf "srcpkg/llama.cpp-source-${{ inputs.tag }}.tar.gz" -C src --strip-components=1
+
+      - name: Install Vulkan SDK + build dependencies
+        run: |
+          set -eux
+          wget -qO - https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo apt-key add -
+          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-jammy.list https://packages.lunarg.com/vulkan/lunarg-vulkan-jammy.list
+          sudo apt-get update -y
+          sudo apt-get install -y build-essential mesa-vulkan-drivers vulkan-sdk libssl-dev ninja-build
+
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2.20
+        with:
+          key: vulkan-linux-x64
+          variant: ccache
+          evict-old-files: 14d
+
+      - name: Configure
+        working-directory: src
+        run: |
+          set -eux
+          # Build recipe mirrors llama-cpp-binaries' Vulkan wheel: the CPU recipe
+          # (backend-DL + all CPU variants + RPC) plus GGML_VULKAN. RPATH=$ORIGIN
+          # so the bundle's sibling .so files resolve from the binary's own dir.
+          cmake -S . -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DGGML_NATIVE=OFF \
+            -DGGML_BACKEND_DL=ON \
+            -DGGML_CPU_ALL_VARIANTS=ON \
+            -DGGML_RPC=ON \
+            -DGGML_VULKAN=ON \
+            -DLLAMA_BUILD_TESTS=OFF \
+            -DLLAMA_BUILD_EXAMPLES=OFF \
+            -DCMAKE_INSTALL_RPATH='$ORIGIN' \
+            -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
+            -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=OFF \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+      - name: Build
+        working-directory: src
+        run: |
+          set -eux
+          # Backend modules (CPU variants, Vulkan, RPC) build as ggml
+          # dependencies, so the server/quantize targets pull them in.
+          cmake --build build --config Release -j "$(nproc)" \
+            --target llama-server llama-quantize
+          strip build/bin/llama-server build/bin/llama-quantize || true
+
+      # DiffusionGemma binaries (example targets present only in #24423 mix
+      # builds): best-effort, never fail the job. See the CUDA child for the
+      # rationale. The bundle tars all of build/bin, so anything produced here
+      # is shipped automatically.
+      - name: Build DiffusionGemma binaries (best-effort; mix builds only)
+        working-directory: src
+        run: |
+          set -u
+          if [ ! -d examples/diffusion-gemma-server ]; then
+            echo "no DiffusionGemma sources in this tree; skipping"
+            exit 0
+          fi
+          cmake -S . -B build -DLLAMA_BUILD_EXAMPLES=ON \
+            || { echo "reconfigure for examples failed; skipping DiffusionGemma binaries"; exit 0; }
+          if cmake --build build --config Release -j "$(nproc)" \
+              --target llama-diffusion-gemma-visual-server llama-diffusion-cli; then
+            strip build/bin/llama-diffusion-gemma-visual-server build/bin/llama-diffusion-cli || true
+            echo "built DiffusionGemma binaries"
+          else
+            echo "warning: DiffusionGemma binaries failed to build; bundle will omit them"
+          fi
+          exit 0
+
+      - name: Package bundle (tar.gz)
+        run: |
+          set -eux
+          ASSET="app-${{ inputs.tag }}-linux-x64-vulkan.tar.gz"
+          cp src/LICENSE src/build/bin/
+          mkdir -p dist
+          (cd src/build/bin && tar -czf "${GITHUB_WORKSPACE}/dist/${ASSET}" .)
+          ls -la dist
+
+      - name: Upload bundle artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: app-${{ inputs.tag }}-linux-x64-vulkan
+          path: dist/app-${{ inputs.tag }}-linux-x64-vulkan.tar.gz
+          if-no-files-found: error
+
+  build-windows:
+    name: windows/x64
+    runs-on: windows-2022
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - name: Checkout upstream source @ ${{ inputs.tag }}
+        if: inputs.source_artifact == ''
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ inputs.repo }}
+          ref: ${{ inputs.ref || inputs.tag }}
+          path: src
+          # Full history: cmake/build-info.cmake runs `git rev-list --count HEAD`
+          # to bake LLAMA_BUILD_NUMBER into llama-server --version as b<N>.
+          fetch-depth: 0
+
+      # Mix builds: the parent's resolve job merged the PR set and uploaded the
+      # tree (with build number/commit pre-baked into cmake/build-info.cmake,
+      # since there is no .git here) as an artifact.
+      - name: Download merged source @ ${{ inputs.tag }}
+        if: inputs.source_artifact != ''
+        uses: actions/download-artifact@v6
+        with:
+          name: ${{ inputs.source_artifact }}
+          path: srcpkg
+      - name: Extract merged source
+        if: inputs.source_artifact != ''
+        shell: bash
+        run: |
+          set -eux
+          mkdir -p src
+          tar -xzf "srcpkg/llama.cpp-source-${{ inputs.tag }}.tar.gz" -C src --strip-components=1
+
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2.20
+        with:
+          key: vulkan-windows-x64
+          variant: ccache
+          evict-old-files: 14d
+
+      - name: Install Ninja
+        run: choco install ninja --no-progress
+
+      - name: Setup MSVC
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Install Vulkan SDK
+        run: |
+          curl.exe -o $env:RUNNER_TEMP/VulkanSDK-Installer.exe -L "https://sdk.lunarg.com/sdk/download/${env:VULKAN_VERSION}/windows/vulkansdk-windows-X64-${env:VULKAN_VERSION}.exe"
+          & "$env:RUNNER_TEMP\VulkanSDK-Installer.exe" --accept-licenses --default-answer --confirm-command install
+          Add-Content $env:GITHUB_ENV "VULKAN_SDK=C:\VulkanSDK\${env:VULKAN_VERSION}"
+          Add-Content $env:GITHUB_PATH "C:\VulkanSDK\${env:VULKAN_VERSION}\bin"
+
+      - name: Configure
+        working-directory: src
+        run: |
+          # Same recipe as Linux plus BoringSSL (statically linked, no system
+          # OpenSSL on the runner). No RPATH -- Windows loads sibling DLLs from
+          # the binary's directory. CMAKE_PREFIX_PATH points at the Vulkan SDK
+          # so CMake finds its SPIRV-Headers config (set via env, not -D, so the
+          # backslashes survive); mirrors llama-cpp-binaries' Vulkan wheel.
+          # GGML_OPENMP=OFF keeps this MSVC bundle self-contained: a default-ON
+          # MSVC build would link vcomp140.dll (not shipped). Upstream sidesteps
+          # this by building its Windows Vulkan artifact with GGML_CPU=OFF (no
+          # OpenMP at all); we ship a full bundle, so we disable OpenMP instead
+          # (the CPU backend is a GPU-offload fallback and uses ggml's threadpool).
+          $env:CMAKE_PREFIX_PATH = $env:VULKAN_SDK
+          cmake -S . -B build -G Ninja `
+            -DCMAKE_BUILD_TYPE=Release `
+            -DGGML_NATIVE=OFF `
+            -DGGML_BACKEND_DL=ON `
+            -DGGML_CPU_ALL_VARIANTS=ON `
+            -DGGML_OPENMP=OFF `
+            -DGGML_RPC=ON `
+            -DGGML_VULKAN=ON `
+            -DLLAMA_BUILD_TESTS=OFF `
+            -DLLAMA_BUILD_EXAMPLES=OFF `
+            -DLLAMA_BUILD_BORINGSSL=ON `
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache `
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+      - name: Build
+        working-directory: src
+        run: |
+          cmake --build build --config Release -j 3 `
+            --target llama-server llama-quantize
+
+      # DiffusionGemma binaries (#24423 mix builds only): best-effort, never
+      # fail the job. See the CUDA child for the rationale.
+      - name: Build DiffusionGemma binaries (best-effort; mix builds only)
+        working-directory: src
+        run: |
+          if (-not (Test-Path "examples/diffusion-gemma-server")) {
+            Write-Host "no DiffusionGemma sources in this tree; skipping"
+            exit 0
+          }
+          cmake -S . -B build -DLLAMA_BUILD_EXAMPLES=ON
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "reconfigure for examples failed; skipping DiffusionGemma binaries"
+            exit 0
+          }
+          cmake --build build --config Release -j 3 `
+            --target llama-diffusion-gemma-visual-server llama-diffusion-cli
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "warning: DiffusionGemma binaries failed to build; bundle will omit them"
+          } else {
+            Write-Host "built DiffusionGemma binaries"
+          }
+          exit 0
+
+      - name: Package bundle (zip)
+        shell: bash
+        run: |
+          set -eux
+          ASSET="app-${{ inputs.tag }}-windows-x64-vulkan.zip"
+          cp src/LICENSE src/build/bin/
+          mkdir -p dist
+          (cd src/build/bin && 7z a -tzip "${GITHUB_WORKSPACE}/dist/${ASSET}" .)
+          ls -la dist
+
+      - name: Upload bundle artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: app-${{ inputs.tag }}-windows-x64-vulkan
+          path: dist/app-${{ inputs.tag }}-windows-x64-vulkan.zip
+          if-no-files-found: error

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -553,7 +553,7 @@ jobs:
           # commit-in-PR URL. We deliberately do not link the merged commit: in
           # mix mode it is a throwaway merge made on the runner and never pushed
           # anywhere, so any repo@sha URL for it 404s.
-          NOTES="Automated Unsloth llama.cpp CUDA (Linux + Windows) + ROCm + macOS + CPU (Linux + Windows) + Vulkan (Linux + Windows) prebuild for upstream [${BASE}](https://github.com/ggml-org/llama.cpp/releases/tag/${BASE})"
+          NOTES="Automated Unsloth llama.cpp CUDA + ROCm + Vulkan + macOS + CPU prebuild for upstream [${BASE}](https://github.com/ggml-org/llama.cpp/releases/tag/${BASE})"
           if [ "$(jq length <<<"$PRS")" = 0 ]; then
             NOTES="${NOTES}."
           else

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -4,12 +4,14 @@
 name: Unsloth prebuilt (full release)
 
 # Atomic daily build for unslothai/llama.cpp. One cron, one workflow run, one
-# release per upstream b#### tag. Splits the heavy build work into four reusable
+# release per upstream b#### tag. Splits the heavy build work into six reusable
 # children:
 #   unsloth-prebuilt-cuda.yml          -- Linux CUDA bundles (x64 + arm64, matrix profiles)
 #   unsloth-prebuilt-cuda-windows.yml  -- CUDA Windows bundles (x64, matrix profiles)
 #   unsloth-prebuilt-rocm.yml          -- ROCm bundles (Windows + Ubuntu, per gfx target)
 #   unsloth-prebuilt-macos.yml         -- macOS bundles (arm64 Metal + x64 CPU)
+#   unsloth-prebuilt-cpu.yml           -- CPU-only bundles (Linux + Windows, x64 + arm64)
+#   unsloth-prebuilt-vulkan.yml        -- Vulkan bundles (Linux + Windows, x64)
 #
 # Atomicity: the `assemble` job depends on all children. GitHub's default
 # `needs` semantics require all needs to succeed -- if any matrix entry in
@@ -371,9 +373,31 @@ jobs:
       source_artifact: ${{ needs.resolve.outputs.source_artifact }}
       matrix: ${{ needs.resolve.outputs.macos_matrix }}
 
+  build-cpu:
+    name: CPU
+    needs: resolve
+    if: ${{ needs.resolve.outputs.exists != 'true' || github.event_name == 'workflow_dispatch' }}
+    uses: ./.github/workflows/unsloth-prebuilt-cpu.yml
+    with:
+      tag: ${{ needs.resolve.outputs.tag }}
+      ref: ${{ needs.resolve.outputs.ref }}
+      repo: ${{ needs.resolve.outputs.repo }}
+      source_artifact: ${{ needs.resolve.outputs.source_artifact }}
+
+  build-vulkan:
+    name: Vulkan
+    needs: resolve
+    if: ${{ needs.resolve.outputs.exists != 'true' || github.event_name == 'workflow_dispatch' }}
+    uses: ./.github/workflows/unsloth-prebuilt-vulkan.yml
+    with:
+      tag: ${{ needs.resolve.outputs.tag }}
+      ref: ${{ needs.resolve.outputs.ref }}
+      repo: ${{ needs.resolve.outputs.repo }}
+      source_artifact: ${{ needs.resolve.outputs.source_artifact }}
+
   assemble:
     name: Assemble metadata + publish
-    needs: [resolve, build-cuda, build-windows-cuda, build-rocm, build-macos]
+    needs: [resolve, build-cuda, build-windows-cuda, build-rocm, build-macos, build-cpu, build-vulkan]
     # No `if: always()`. Atomicity: if any matrix entry in any child
     # workflow failed, the corresponding `build-*` job reports failure, the
     # default `needs` success check skips this assemble job, and nothing is
@@ -480,7 +504,13 @@ jobs:
           for f in \
             "llama-${TAG}-bin-macos-arm64.tar.gz" \
             "llama-${TAG}-bin-macos-x64.tar.gz" \
-            "app-${TAG}-linux-arm64-cuda13-portable.tar.gz"; do
+            "app-${TAG}-linux-arm64-cuda13-portable.tar.gz" \
+            "app-${TAG}-linux-x64-cpu.tar.gz" \
+            "app-${TAG}-windows-x64-cpu.zip" \
+            "app-${TAG}-linux-arm64-cpu.tar.gz" \
+            "app-${TAG}-windows-arm64-cpu.zip" \
+            "app-${TAG}-linux-x64-vulkan.tar.gz" \
+            "app-${TAG}-windows-x64-vulkan.zip"; do
             [ -s "dist/$f" ] || { echo "ERROR: missing $f in dist/" >&2; fail=1; }
           done
           # Default ROCm set (mirrors the gfx_target input default): both OSes
@@ -510,6 +540,6 @@ jobs:
           fi
           gh release create "$TAG" --repo "$REPO" --draft \
             --title "llama.cpp prebuilt $TAG" \
-            --notes "Automated Unsloth llama.cpp CUDA (Linux + Windows) + ROCm + macOS prebuild for $SRC (${{ needs.resolve.outputs.repo }}@${{ needs.resolve.outputs.commit }})." \
+            --notes "Automated Unsloth llama.cpp CUDA (Linux + Windows) + ROCm + macOS + CPU (Linux + Windows) + Vulkan (Linux + Windows) prebuild for $SRC (${{ needs.resolve.outputs.repo }}@${{ needs.resolve.outputs.commit }})." \
             dist/*
           gh release edit "$TAG" --repo "$REPO" --draft=false

--- a/scripts/unsloth/assemble_metadata.py
+++ b/scripts/unsloth/assemble_metadata.py
@@ -3,11 +3,12 @@
 
 Produces, matching the schema consumed by unslothai/unsloth's installer:
   - llama-prebuilt-manifest.json : describes every locally-built bundle in this
-    release (CUDA x64/arm64 profiles + ROCm Linux/Windows per gfx target),
+    release (CUDA x64/arm64 profiles + ROCm Linux/Windows per gfx target +
+    macOS arm64/x64 + CPU Linux/Windows x64+arm64 + Vulkan Linux/Windows x64),
     with the dispatch metadata the installer needs to pick the right one.
   - llama-prebuilt-sha256.json   : a cross-OS integrity index covering both the
-    locally-built bundles AND the upstream ggml-org assets the installer pulls
-    for Windows/macOS/Linux-CPU + the source tarballs.
+    locally-built bundles AND the upstream ggml-org assets the installer still
+    pulls (arm64 CPU + the Windows CUDA cudart/runtime) + the source tarballs.
 
 Run after the build matrix has dropped the app-*.{tar.gz,zip} bundles into --dist.
 """
@@ -38,6 +39,19 @@ ROCM_BUNDLE_RE = re.compile(
     r"^app-(?P<tag>[^/]+)-(?P<platform>linux|windows)-x64-rocm-(?P<gfx>gfx[0-9a-zA-Z]+)\.(?P<ext>tar\.gz|zip)$"
 )
 
+# CPU-only and Vulkan bundles, built locally by unsloth-prebuilt-cpu.yml /
+# unsloth-prebuilt-vulkan.yml. Like ROCm/macOS they are raw build/bin archives
+# with no embedded UNSLOTH_PREBUILT_INFO.json, so everything in the manifest
+# entry is derived from the filename. CPU covers x64 + arm64 (the arm64 slices
+# supersede the upstream ggml-org CPU passthroughs); Vulkan is x64-only.
+CPU_BUNDLE_RE = re.compile(
+    r"^app-(?P<tag>[^/]+)-(?P<platform>linux|windows)-(?P<arch>x64|arm64)-cpu\.(?P<ext>tar\.gz|zip)$"
+)
+
+VULKAN_BUNDLE_RE = re.compile(
+    r"^app-(?P<tag>[^/]+)-(?P<platform>linux|windows)-x64-vulkan\.(?P<ext>tar\.gz|zip)$"
+)
+
 # macOS slices are built by unsloth-prebuilt-macos.yml and land in dist/ under
 # upstream's own naming (the installer expects that name). They carry no
 # embedded UNSLOTH_PREBUILT_INFO.json, so -- like ROCm -- everything is derived
@@ -59,6 +73,24 @@ KIND_BY_CUDA = {
 KIND_BY_ROCM_PLATFORM = {
     "linux":   {"manifest": "linux-rocm",   "sha": "linux-rocm-app"},
     "windows": {"manifest": "windows-rocm", "sha": "windows-rocm-app"},
+}
+
+# CPU + Vulkan slices. These supersede the upstream ggml-org CPU/Vulkan
+# passthroughs (we now build them ourselves). The manifest kinds match what the
+# installer selects per (platform, arch): x64 keeps the historical
+# linux-cpu/windows-cpu, arm64 uses linux-arm64/windows-arm64 (the same kinds
+# the installer's upstream-fallback path used). The "-app" sha kinds mark them
+# as locally-built bundles.
+KIND_BY_CPU = {
+    ("linux",   "x64"):   {"manifest": "linux-cpu",     "sha": "linux-cpu-app"},
+    ("linux",   "arm64"): {"manifest": "linux-arm64",   "sha": "linux-arm64-app"},
+    ("windows", "x64"):   {"manifest": "windows-cpu",   "sha": "windows-cpu-app"},
+    ("windows", "arm64"): {"manifest": "windows-arm64", "sha": "windows-arm64-app"},
+}
+
+KIND_BY_VULKAN_PLATFORM = {
+    "linux":   {"manifest": "linux-vulkan",   "sha": "linux-vulkan-app"},
+    "windows": {"manifest": "windows-vulkan", "sha": "windows-vulkan-app"},
 }
 
 # macOS slices: install_kind / sha-index kind / manifest bundle_profile per arch.
@@ -174,15 +206,20 @@ def build_artifacts(
     cuda_bundles: list[tuple[str, str, str, dict]],
     rocm_bundles: list[tuple[str, str, str]],
     macos_bundles: list[tuple[str, str]],
+    cpu_bundles: list[tuple[str, str, str]],
+    vulkan_bundles: list[tuple[str, str]],
 ) -> list[dict]:
     """cuda_bundles: list of (asset_name, platform, arch, embedded UNSLOTH_PREBUILT_INFO).
     rocm_bundles:    list of (asset_name, platform, gfx_target).
     macos_bundles:   list of (asset_name, arch).
+    cpu_bundles:     list of (asset_name, platform, arch).
+    vulkan_bundles:  list of (asset_name, platform).
 
     CUDA fields come from each bundle's own embedded metadata, so the manifest
-    can never disagree with what was actually compiled. ROCm and macOS bundles
-    are raw archives (no embedded info), so their manifest entries are derived
-    from the filename + the ROCM_TARGET_MAP / MACOS_SLICE tables.
+    can never disagree with what was actually compiled. ROCm, macOS, CPU and
+    Vulkan bundles are raw archives (no embedded info), so their manifest
+    entries are derived from the filename + the ROCM_TARGET_MAP / MACOS_SLICE
+    tables.
     """
     artifacts = []
     for asset_name, platform, arch, info in cuda_bundles:
@@ -216,6 +253,28 @@ def build_artifacts(
             "runtime_line": None,
             "coverage_class": None,
             "rank": 50,
+        })
+    # CPU + Vulkan: no CUDA/ROCm runtime to match, so runtime_line/coverage_class
+    # are explicit null (stable key set). A single slice per (backend, platform,
+    # arch), so a fixed rank; CPU ranks last (1000) as the universal fallback,
+    # matching the installer's own direct-scan rank for a CPU bundle.
+    for asset_name, platform, arch in cpu_bundles:
+        artifacts.append({
+            "asset_name": asset_name,
+            "install_kind": KIND_BY_CPU[(platform, arch)]["manifest"],
+            "bundle_profile": f"{platform}-cpu-{arch}",
+            "runtime_line": None,
+            "coverage_class": None,
+            "rank": 1000,
+        })
+    for asset_name, platform in vulkan_bundles:
+        artifacts.append({
+            "asset_name": asset_name,
+            "install_kind": KIND_BY_VULKAN_PLATFORM[platform]["manifest"],
+            "bundle_profile": f"{platform}-vulkan-x64",
+            "runtime_line": None,
+            "coverage_class": None,
+            "rank": 60,
         })
     return artifacts
 
@@ -319,9 +378,40 @@ def main() -> int:
         # assembles. The daily schedule always builds both slices.
         print("WARNING: no llama-*-bin-macos-*.tar.gz bundles found", file=sys.stderr)
 
+    # 1d) locally-built CPU + Vulkan bundles (Linux .tar.gz + Windows .zip).
+    # No embedded metadata; everything is derived from the filename. These
+    # replace the upstream ggml-org CPU/Vulkan passthroughs that section 2 used
+    # to record -- the release now ships our own builds for these slices.
+    def scan_bundles(regex) -> list[tuple[str, "re.Match[str]"]]:
+        out: list[tuple[str, "re.Match[str]"]] = []
+        for p in sorted(list(args.dist.glob("app-*.tar.gz")) + list(args.dist.glob("app-*.zip"))):
+            m = regex.match(p.name)
+            if m:
+                out.append((p.name, m))
+        return out
+
+    cpu_found = [(name, m.group("platform"), m.group("arch")) for name, m in scan_bundles(CPU_BUNDLE_RE)]
+    if cpu_found:
+        with ThreadPoolExecutor(max_workers=4) as pool:
+            cpu_digests = list(pool.map(lambda b: sha256_file(args.dist / b[0]), cpu_found))
+        for (name, platform, arch), digest in zip(cpu_found, cpu_digests):
+            sha_artifacts[name] = base_entry(KIND_BY_CPU[(platform, arch)]["sha"], args.publish_repo, digest)
+    else:
+        print("WARNING: no app-*-cpu.{tar.gz,zip} bundles found", file=sys.stderr)
+
+    vulkan_found = [(name, m.group("platform")) for name, m in scan_bundles(VULKAN_BUNDLE_RE)]
+    if vulkan_found:
+        with ThreadPoolExecutor(max_workers=4) as pool:
+            vulkan_digests = list(pool.map(lambda b: sha256_file(args.dist / b[0]), vulkan_found))
+        for (name, platform), digest in zip(vulkan_found, vulkan_digests):
+            sha_artifacts[name] = base_entry(KIND_BY_VULKAN_PLATFORM[platform]["sha"], args.publish_repo, digest)
+    else:
+        print("WARNING: no app-*-vulkan.{tar.gz,zip} bundles found", file=sys.stderr)
+
     # 2) upstream per-OS bundles: read GitHub's published asset.digest from the
     #    API response; fall back to a streaming hash if a digest is missing.
-    #    macOS is absent here on purpose -- we build our own slices in 1c.
+    #    macOS + x64 CPU/Vulkan are absent here on purpose -- we build those
+    #    ourselves (1c/1d).
     #    A mix build has no upstream release for its tag, so the whole section
     #    is skipped; its uncovered hosts fall back to a source build of the
     #    merged tree instead of a vanilla upstream binary missing the PRs.
@@ -343,11 +433,13 @@ def main() -> int:
                 rf"llama-{re.escape(tag)}-bin-win-cuda-\d+\.\d+-x64\.zip", name
             ):
                 wanted.append((name, "windows-cuda-upstream"))
+        # x64 CPU + Vulkan are no longer passthroughs -- we build them ourselves
+        # (sections 1d above). arm64 CPU is now built too (1d emits the
+        # locally-built linux-arm64/windows-arm64 bundles), but the installer
+        # still selects the upstream arm64 asset until it is switched over to
+        # those bundles; keep these passthrough checksums until that installer
+        # flip lands, then drop them.
         for name, kind in (
-            (f"llama-{tag}-bin-ubuntu-x64.tar.gz",        "linux-cpu-upstream"),
-            (f"llama-{tag}-bin-win-cpu-x64.zip",          "windows-cpu-upstream"),
-            (f"llama-{tag}-bin-ubuntu-vulkan-x64.tar.gz", "linux-vulkan-upstream"),
-            (f"llama-{tag}-bin-win-vulkan-x64.zip",       "windows-vulkan-upstream"),
             (f"llama-{tag}-bin-ubuntu-arm64.tar.gz",      "linux-arm64-upstream"),
             (f"llama-{tag}-bin-win-cpu-arm64.zip",        "windows-arm64-upstream"),
         ):
@@ -399,7 +491,7 @@ def main() -> int:
     manifest = {
         **common,
         "generated_at_utc": _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "artifacts": build_artifacts(found, rocm_found, macos_found),
+        "artifacts": build_artifacts(found, rocm_found, macos_found, cpu_found, vulkan_found),
     }
     manifest_path = args.out / "llama-prebuilt-manifest.json"
     manifest_path.write_text(json.dumps(manifest, indent=2))


### PR DESCRIPTION
Adds two new workflow files:

- `unsloth-prebuilt-cpu.yml`: compiles llama.cpp artifacts for CPU on Windows or Linux, x86_64 or arm64 (4 artifacts)
- `unsloth-prebuilt-vulkan.yml`: same for Vulkan on Windows or Linux, x86_64 only (2 artifacts)

Both initially adapted from the functional workflows at [oobabooga/llama-cpp-binaries](https://github.com/oobabooga/llama-cpp-binaries), and then audited against the current upstream workflows at [ggml-org/llama.cpp](https://github.com/ggml-org/llama.cpp): the compilation matches upstream's flags and toolchain (e.g. Windows CPU uses upstream's clang/LLVM toolchain; Vulkan pins the same LunarG SDK), with a few deliberate deviations:

- full self-contained bundles rather than upstream's backend-DLL overlays
- the build narrowed to `llama-server` + `llama-quantize`
- flat `app-*` packaging like the ROCm/macOS children

## Wiring into the full release

- `unsloth-prebuilt.yml` gains `build-cpu`/`build-vulkan` jobs, with the same assemble atomicity + coverage checks as the other children.
- `assemble_metadata.py` records the 6 bundles in the manifest + sha256 index and drops the now-redundant x86_64 CPU/Vulkan ggml-org passthroughs (arm64 CPU passthroughs stay until the installer is switched over).

I'm doing a test run at https://github.com/oobabooga/llama.cpp/actions/runs/27461979407
