### PR TITLE
More readable release notes description for automated builds

### DIFF
--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -499,16 +499,19 @@ jobs:
           REPO="$GITHUB_REPOSITORY"
           PRS='${{ needs.resolve.outputs.prs }}'
           BASE='${{ needs.resolve.outputs.base }}'
-          # Link the base to the upstream release tag (always resolves). The PR
-          # links use each pin's own commit-in-PR URL, so they point at the exact
-          # SHA that was merged. We deliberately do not link the merged commit:
-          # in mix mode it is a throwaway merge made on the runner and never
-          # pushed anywhere, so any repo@sha URL for it 404s.
+          # Link the base to the upstream release tag (always resolves). Each PR
+          # is a bare ggml-org/llama.cpp#<n> reference, which GitHub renders as a
+          # link to the upstream PR (shown inline as ggml-org#<n>, title/state on
+          # hover) that resolves to upstream no matter which repo hosts the
+          # release; the short SHA links to that pin's commit-in-PR URL. We
+          # deliberately do not link the merged commit: in mix mode it is a
+          # throwaway merge made on the runner and never pushed anywhere, so any
+          # repo@sha URL for it 404s.
           NOTES="Automated Unsloth llama.cpp CUDA (Linux + Windows) + ROCm + macOS prebuild for upstream [${BASE}](https://github.com/ggml-org/llama.cpp/releases/tag/${BASE})"
           if [ "$(jq length <<<"$PRS")" = 0 ]; then
             NOTES="${NOTES}."
           else
-            PR_LIST="$(jq -r 'map("- [PR #\(.number) @ \(.sha[0:7])](\(.url))") | join("\n")' <<<"$PRS")"
+            PR_LIST="$(jq -r 'map("- ggml-org/llama.cpp#\(.number) @ [\(.sha[0:7])](\(.url))") | join("\n")' <<<"$PRS")"
             NOTES="$(printf '%s, merged with:\n\n%s' "$NOTES" "$PR_LIST")"
           fi
 

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -498,8 +498,19 @@ jobs:
           TAG='${{ needs.resolve.outputs.tag }}'
           REPO="$GITHUB_REPOSITORY"
           PRS='${{ needs.resolve.outputs.prs }}'
-          SRC="upstream ${{ needs.resolve.outputs.base }}"
-          [ "$(jq length <<<"$PRS")" = 0 ] || SRC="$SRC + $(jq -r 'map("PR #\(.number) @ \(.sha[0:7])") | join(", ")' <<<"$PRS")"
+          BASE='${{ needs.resolve.outputs.base }}'
+          # Link the base to the upstream release tag (always resolves). The PR
+          # links use each pin's own commit-in-PR URL, so they point at the exact
+          # SHA that was merged. We deliberately do not link the merged commit:
+          # in mix mode it is a throwaway merge made on the runner and never
+          # pushed anywhere, so any repo@sha URL for it 404s.
+          NOTES="Automated Unsloth llama.cpp CUDA (Linux + Windows) + ROCm + macOS prebuild for upstream [${BASE}](https://github.com/ggml-org/llama.cpp/releases/tag/${BASE})"
+          if [ "$(jq length <<<"$PRS")" = 0 ]; then
+            NOTES="${NOTES}."
+          else
+            PR_LIST="$(jq -r 'map("- [PR #\(.number) @ \(.sha[0:7])](\(.url))") | join("\n")' <<<"$PRS")"
+            NOTES="$(printf '%s, merged with:\n\n%s' "$NOTES" "$PR_LIST")"
+          fi
 
           # Atomic publish: upload as draft (hidden from the anon GitHub API
           # the installer uses), then flip draft=false only once every asset
@@ -510,6 +521,6 @@ jobs:
           fi
           gh release create "$TAG" --repo "$REPO" --draft \
             --title "llama.cpp prebuilt $TAG" \
-            --notes "Automated Unsloth llama.cpp CUDA (Linux + Windows) + ROCm + macOS prebuild for $SRC (${{ needs.resolve.outputs.repo }}@${{ needs.resolve.outputs.commit }})." \
+            --notes "$NOTES" \
             dist/*
           gh release edit "$TAG" --repo "$REPO" --draft=false


### PR DESCRIPTION
Reformats the release notes the nightly prebuild publishes, so they read better when there are merged PRs.

#### Before:

Automated Unsloth llama.cpp CUDA (Linux + Windows) + ROCm + macOS prebuild for upstream b9611 + PR #24423 @ 1153c4a, PR #24523 @ 2846a38, PR #24260 @ d932047 (unslothai/llama.cpp@b8672a063da7b46874b119f5b6e4e1fac47e9004).

#### After:

Automated Unsloth llama.cpp CUDA (Linux + Windows) + ROCm + macOS prebuild for upstream [b9611](https://github.com/ggml-org/llama.cpp/releases/tag/b9611), merged with:

- ggml-org/llama.cpp#24423 @ [1153c4a](https://github.com/ggml-org/llama.cpp/pull/24423/commits/1153c4ac6d959486a0837593683c7ce846b78a83)
- ggml-org/llama.cpp#24523 @ [2846a38](https://github.com/ggml-org/llama.cpp/pull/24523/commits/2846a387c2bf90a39194b818557ce86e19b99c07)
- ggml-org/llama.cpp#24260 @ [d932047](https://github.com/ggml-org/llama.cpp/pull/24260/commits/d9320477de5549e53a9452296f468d32a1d81d26)

Each `ggml-org/llama.cpp#<n>` is a bare cross-repo reference, so GitHub expands it into a rich PR link (icon + title) that resolves to the upstream PR no matter which repo hosts the release, and the short SHA links to the exact pinned commit. A plain upstream build with no PRs collapses to the single sentence ending in a period.

The links got fixed in passing too: before, the trailing `(repo@commit)` linked to the runner-only merge commit, which is never pushed, so it always 404'd. Now the base points at its upstream release tag and each PR at its pin.
