### PR TITLE
Add an Unsloth fingerprint to the prebuilt binaries

### DIFF
--- a/.github/workflows/unsloth-prebuilt-cpu.yml
+++ b/.github/workflows/unsloth-prebuilt-cpu.yml
@@ -28,18 +28,13 @@ on:
         description: 'Upstream llama.cpp release tag (b####), resolved by parent'
         required: true
         type: string
-      ref:
-        description: 'Git ref to build (refs/tags/<tag>); defaults to tag'
-        required: false
-        default: ''
-        type: string
       repo:
-        description: 'GitHub repository (owner/name) holding the ref: upstream, or the publish repo for merged mix tags'
+        description: 'Source repo (owner/name): ggml-org/llama.cpp for plain builds, or this repo for mix tags'
         required: false
         default: 'ggml-org/llama.cpp'
         type: string
       source_artifact:
-        description: 'Workflow artifact holding the merged source tarball (mix builds); empty = clone repo at ref'
+        description: 'Workflow artifact (app-source-*) holding the stamped source tree; set by resolve for every build'
         required: false
         default: ''
         type: string
@@ -58,29 +53,16 @@ jobs:
           - { arch: x64,   runner: ubuntu-22.04 }
           - { arch: arm64, runner: ubuntu-24.04-arm }
     steps:
-      - name: Checkout upstream source @ ${{ inputs.tag }}
-        if: inputs.source_artifact == ''
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ inputs.repo }}
-          ref: ${{ inputs.ref || inputs.tag }}
-          path: src
-          # Full history: cmake/build-info.cmake runs `git rev-list --count HEAD`
-          # to bake LLAMA_BUILD_NUMBER into llama-server --version as b<N>.
-          # A shallow clone would bake in "b1" instead.
-          fetch-depth: 0
-
-      # Mix builds: the parent's resolve job merged the PR set and uploaded the
-      # tree (with build number/commit pre-baked into cmake/build-info.cmake,
-      # since there is no .git here) as an artifact.
-      - name: Download merged source @ ${{ inputs.tag }}
-        if: inputs.source_artifact != ''
+      # The parent's resolve job built the source tree (upstream base + any mix
+      # PRs, with the build number/commit and Unsloth fingerprint baked
+      # into cmake/build-info.cmake) and uploaded it as an artifact; extract it
+      # instead of cloning -- no .git needed, the build number is already baked.
+      - name: Download source @ ${{ inputs.tag }}
         uses: actions/download-artifact@v6
         with:
           name: ${{ inputs.source_artifact }}
           path: srcpkg
-      - name: Extract merged source
-        if: inputs.source_artifact != ''
+      - name: Extract source
         shell: bash
         run: |
           set -eux
@@ -200,28 +182,16 @@ jobs:
       run:
         shell: pwsh
     steps:
-      - name: Checkout upstream source @ ${{ inputs.tag }}
-        if: inputs.source_artifact == ''
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ inputs.repo }}
-          ref: ${{ inputs.ref || inputs.tag }}
-          path: src
-          # Full history: cmake/build-info.cmake runs `git rev-list --count HEAD`
-          # to bake LLAMA_BUILD_NUMBER into llama-server --version as b<N>.
-          fetch-depth: 0
-
-      # Mix builds: the parent's resolve job merged the PR set and uploaded the
-      # tree (with build number/commit pre-baked into cmake/build-info.cmake,
-      # since there is no .git here) as an artifact.
-      - name: Download merged source @ ${{ inputs.tag }}
-        if: inputs.source_artifact != ''
+      # The parent's resolve job built the source tree (upstream base + any mix
+      # PRs, with the build number/commit and Unsloth fingerprint baked
+      # into cmake/build-info.cmake) and uploaded it as an artifact; extract it
+      # instead of cloning -- no .git needed, the build number is already baked.
+      - name: Download source @ ${{ inputs.tag }}
         uses: actions/download-artifact@v6
         with:
           name: ${{ inputs.source_artifact }}
           path: srcpkg
-      - name: Extract merged source
-        if: inputs.source_artifact != ''
+      - name: Extract source
         shell: bash
         run: |
           set -eux

--- a/.github/workflows/unsloth-prebuilt-cuda-windows.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda-windows.yml
@@ -23,18 +23,13 @@ on:
         description: 'Upstream commit SHA for that tag, resolved by parent'
         required: true
         type: string
-      ref:
-        description: 'Git ref to build (refs/tags/<tag>); defaults to tag'
-        required: false
-        default: ''
-        type: string
       repo:
-        description: 'GitHub repository (owner/name) holding the ref: upstream, or the publish repo for merged mix tags'
+        description: 'Source repo (owner/name): ggml-org/llama.cpp for plain builds, or this repo for mix tags'
         required: false
         default: 'ggml-org/llama.cpp'
         type: string
       source_artifact:
-        description: 'Workflow artifact holding the merged source tarball (mix builds); empty = clone repo at ref'
+        description: 'Workflow artifact (app-source-*) holding the stamped source tree; set by resolve for every build'
         required: false
         default: ''
         type: string
@@ -62,29 +57,16 @@ jobs:
         with:
           path: tooling
 
-      - name: Checkout upstream source @ ${{ inputs.tag }}
-        if: inputs.source_artifact == ''
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ inputs.repo }}
-          ref: ${{ inputs.ref || inputs.tag }}
-          path: src
-          # Full history: cmake/build-info.cmake runs `git rev-list --count HEAD`
-          # to bake LLAMA_BUILD_NUMBER into llama-server --version as b<N>.
-          # A shallow clone would bake in "b1" instead.
-          fetch-depth: 0
-
-      # Mix builds: the parent's resolve job merged the PR set and uploaded the
-      # tree (with build number/commit pre-baked into cmake/build-info.cmake,
-      # since there is no .git here) as an artifact.
-      - name: Download merged source @ ${{ inputs.tag }}
-        if: inputs.source_artifact != ''
+      # The parent's resolve job built the source tree (upstream base + any mix
+      # PRs, with the build number/commit and Unsloth fingerprint baked
+      # into cmake/build-info.cmake) and uploaded it as an artifact; extract it
+      # instead of cloning -- no .git needed, the build number is already baked.
+      - name: Download source @ ${{ inputs.tag }}
         uses: actions/download-artifact@v6
         with:
           name: ${{ inputs.source_artifact }}
           path: srcpkg
-      - name: Extract merged source
-        if: inputs.source_artifact != ''
+      - name: Extract source
         shell: bash
         run: |
           set -eux
@@ -227,7 +209,7 @@ jobs:
           TAG: ${{ inputs.tag }}
           SOURCE_COMMIT: ${{ inputs.commit }}
           SOURCE_REPO: ${{ inputs.repo }}
-          SOURCE_REF_KIND: ${{ inputs.source_artifact != '' && 'mix' || 'tag' }}
+          SOURCE_REF_KIND: ${{ inputs.repo == 'ggml-org/llama.cpp' && 'tag' || 'mix' }}
           PROFILE: ${{ matrix.profile }}
           LINE: ${{ matrix.line }}
           KLASS: ${{ matrix.klass }}

--- a/.github/workflows/unsloth-prebuilt-cuda.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda.yml
@@ -18,18 +18,13 @@ on:
         description: 'Upstream commit SHA for that tag, resolved by parent'
         required: true
         type: string
-      ref:
-        description: 'Git ref to build (refs/tags/<tag>); defaults to tag'
-        required: false
-        default: ''
-        type: string
       repo:
-        description: 'GitHub repository (owner/name) holding the ref: upstream, or the publish repo for merged mix tags'
+        description: 'Source repo (owner/name): ggml-org/llama.cpp for plain builds, or this repo for mix tags'
         required: false
         default: 'ggml-org/llama.cpp'
         type: string
       source_artifact:
-        description: 'Workflow artifact holding the merged source tarball (mix builds); empty = clone repo at ref'
+        description: 'Workflow artifact (app-source-*) holding the stamped source tree; set by resolve for every build'
         required: false
         default: ''
         type: string
@@ -64,30 +59,16 @@ jobs:
         with:
           path: tooling
 
-      - name: Checkout upstream source @ ${{ inputs.tag }}
-        if: inputs.source_artifact == ''
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ inputs.repo }}
-          ref: ${{ inputs.ref || inputs.tag }}
-          path: src
-          # Full history is required: cmake/build-info.cmake runs
-          # `git rev-list --count HEAD` to compute LLAMA_BUILD_NUMBER,
-          # which gets baked into llama-server --version as b<N>.
-          # Shallow clone (default depth=1) would bake in "b1" instead.
-          fetch-depth: 0
-
-      # Mix builds: the parent's resolve job merged the PR set and uploaded the
-      # tree (with build number/commit pre-baked into cmake/build-info.cmake,
-      # since there is no .git here) as an artifact.
-      - name: Download merged source @ ${{ inputs.tag }}
-        if: inputs.source_artifact != ''
+      # The parent's resolve job built the source tree (upstream base + any mix
+      # PRs, with the build number/commit and Unsloth fingerprint baked
+      # into cmake/build-info.cmake) and uploaded it as an artifact; extract it
+      # instead of cloning -- no .git needed, the build number is already baked.
+      - name: Download source @ ${{ inputs.tag }}
         uses: actions/download-artifact@v6
         with:
           name: ${{ inputs.source_artifact }}
           path: srcpkg
-      - name: Extract merged source
-        if: inputs.source_artifact != ''
+      - name: Extract source
         shell: bash
         run: |
           set -eux
@@ -251,7 +232,7 @@ jobs:
           TAG: ${{ inputs.tag }}
           SOURCE_COMMIT: ${{ inputs.commit }}
           SOURCE_REPO: ${{ inputs.repo }}
-          SOURCE_REF_KIND: ${{ inputs.source_artifact != '' && 'mix' || 'tag' }}
+          SOURCE_REF_KIND: ${{ inputs.repo == 'ggml-org/llama.cpp' && 'tag' || 'mix' }}
           PROFILE: ${{ matrix.profile }}
           LINE: ${{ matrix.line }}
           KLASS: ${{ matrix.klass }}

--- a/.github/workflows/unsloth-prebuilt-macos.yml
+++ b/.github/workflows/unsloth-prebuilt-macos.yml
@@ -20,18 +20,13 @@ on:
         description: 'Upstream llama.cpp release tag (b####), resolved by parent'
         required: true
         type: string
-      ref:
-        description: 'Git ref to build (refs/tags/<tag>); defaults to tag'
-        required: false
-        default: ''
-        type: string
       repo:
-        description: 'GitHub repository (owner/name) holding the ref: upstream, or the publish repo for merged mix tags'
+        description: 'Source repo (owner/name): ggml-org/llama.cpp for plain builds, or this repo for mix tags'
         required: false
         default: 'ggml-org/llama.cpp'
         type: string
       source_artifact:
-        description: 'Workflow artifact holding the merged source tarball (mix builds); empty = clone repo at ref'
+        description: 'Workflow artifact (app-source-*) holding the stamped source tree; set by resolve for every build'
         required: false
         default: ''
         type: string
@@ -57,29 +52,16 @@ jobs:
           path: tooling
           persist-credentials: false
 
-      - name: Checkout upstream source @ ${{ inputs.tag }}
-        if: inputs.source_artifact == ''
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ inputs.repo }}
-          ref: ${{ inputs.ref || inputs.tag }}
-          path: src
-          # Full history: cmake/build-info.cmake runs `git rev-list --count HEAD`
-          # to bake LLAMA_BUILD_NUMBER into llama-server --version as b<N>.
-          # A shallow clone would bake in "b1" instead.
-          fetch-depth: 0
-
-      # Mix builds: the parent's resolve job merged the PR set and uploaded the
-      # tree (with build number/commit pre-baked into cmake/build-info.cmake,
-      # since there is no .git here) as an artifact.
-      - name: Download merged source @ ${{ inputs.tag }}
-        if: inputs.source_artifact != ''
+      # The parent's resolve job built the source tree (upstream base + any mix
+      # PRs, with the build number/commit and Unsloth fingerprint baked
+      # into cmake/build-info.cmake) and uploaded it as an artifact; extract it
+      # instead of cloning -- no .git needed, the build number is already baked.
+      - name: Download source @ ${{ inputs.tag }}
         uses: actions/download-artifact@v6
         with:
           name: ${{ inputs.source_artifact }}
           path: srcpkg
-      - name: Extract merged source
-        if: inputs.source_artifact != ''
+      - name: Extract source
         shell: bash
         run: |
           set -eux

--- a/.github/workflows/unsloth-prebuilt-rocm.yml
+++ b/.github/workflows/unsloth-prebuilt-rocm.yml
@@ -29,18 +29,13 @@ on:
         description: 'Upstream llama.cpp release tag (b####), resolved by parent'
         required: true
         type: string
-      ref:
-        description: 'Git ref to build (refs/tags/<tag>); defaults to tag'
-        required: false
-        default: ''
-        type: string
       repo:
-        description: 'GitHub repository (owner/name) holding the ref: upstream, or the publish repo for merged mix tags'
+        description: 'Source repo (owner/name): ggml-org/llama.cpp for plain builds, or this repo for mix tags'
         required: false
         default: 'ggml-org/llama.cpp'
         type: string
       source_artifact:
-        description: 'Workflow artifact holding the merged source tarball (mix builds); empty = clone repo at ref'
+        description: 'Workflow artifact (app-source-*) holding the stamped source tree; set by resolve for every build'
         required: false
         default: ''
         type: string
@@ -211,33 +206,16 @@ jobs:
         # Extract the tarball
         tar -xzf rocm.tar.gz -C C:\opt\rocm --strip-components=1
 
-    - name: Clone llama.cpp @ ${{ inputs.ref || inputs.tag }}
-      if: inputs.source_artifact == ''
-      run: |
-        $ref = "${{ inputs.ref || inputs.tag }}"
-        Write-Host "Cloning llama.cpp at ${ref} (full history so LLAMA_BUILD_NUMBER is correct)"
-        git clone --single-branch --no-checkout https://github.com/${{ inputs.repo }}.git llama.cpp
-        cd llama.cpp
-        git fetch origin $ref
-        if ($LASTEXITCODE -ne 0) { exit 1 }
-        git checkout --detach FETCH_HEAD
-        if ($LASTEXITCODE -ne 0) { exit 1 }
-
-        # Show current commit info
-        Write-Host "Current llama.cpp commit:"
-        git log --oneline -1
-
-    # Mix builds: the parent's resolve job merged the PR set and uploaded the
-    # tree (with build number/commit pre-baked into cmake/build-info.cmake,
-    # since there is no .git here) as an artifact.
-    - name: Download merged source @ ${{ inputs.tag }}
-      if: inputs.source_artifact != ''
+    # The parent's resolve job built the source tree (upstream base + any mix
+    # PRs, with the build number/commit and Unsloth fingerprint baked
+    # into cmake/build-info.cmake) and uploaded it as an artifact; extract it
+    # instead of cloning -- no .git needed, the build number is already baked.
+    - name: Download source @ ${{ inputs.tag }}
       uses: actions/download-artifact@v6
       with:
         name: ${{ inputs.source_artifact }}
         path: srcpkg
-    - name: Extract merged source
-      if: inputs.source_artifact != ''
+    - name: Extract source
       shell: bash
       run: |
         set -eux
@@ -578,31 +556,16 @@ jobs:
 
         echo "ROCm environment variables set successfully"
 
-    - name: Clone llama.cpp @ ${{ inputs.ref || inputs.tag }}
-      if: inputs.source_artifact == ''
-      run: |
-        ref="${{ inputs.ref || inputs.tag }}"
-        echo "Cloning llama.cpp at $ref (full history so LLAMA_BUILD_NUMBER is correct)"
-        git clone --single-branch --no-checkout https://github.com/${{ inputs.repo }}.git llama.cpp
-        cd llama.cpp
-        git fetch origin "$ref"
-        git checkout --detach FETCH_HEAD
-
-        # Show current commit info
-        echo "Current llama.cpp commit:"
-        git log --oneline -1
-
-    # Mix builds: the parent's resolve job merged the PR set and uploaded the
-    # tree (with build number/commit pre-baked into cmake/build-info.cmake,
-    # since there is no .git here) as an artifact.
-    - name: Download merged source @ ${{ inputs.tag }}
-      if: inputs.source_artifact != ''
+    # The parent's resolve job built the source tree (upstream base + any mix
+    # PRs, with the build number/commit and Unsloth fingerprint baked
+    # into cmake/build-info.cmake) and uploaded it as an artifact; extract it
+    # instead of cloning -- no .git needed, the build number is already baked.
+    - name: Download source @ ${{ inputs.tag }}
       uses: actions/download-artifact@v6
       with:
         name: ${{ inputs.source_artifact }}
         path: srcpkg
-    - name: Extract merged source
-      if: inputs.source_artifact != ''
+    - name: Extract source
       shell: bash
       run: |
         set -eux

--- a/.github/workflows/unsloth-prebuilt-vulkan.yml
+++ b/.github/workflows/unsloth-prebuilt-vulkan.yml
@@ -25,18 +25,13 @@ on:
         description: 'Upstream llama.cpp release tag (b####), resolved by parent'
         required: true
         type: string
-      ref:
-        description: 'Git ref to build (refs/tags/<tag>); defaults to tag'
-        required: false
-        default: ''
-        type: string
       repo:
-        description: 'GitHub repository (owner/name) holding the ref: upstream, or the publish repo for merged mix tags'
+        description: 'Source repo (owner/name): ggml-org/llama.cpp for plain builds, or this repo for mix tags'
         required: false
         default: 'ggml-org/llama.cpp'
         type: string
       source_artifact:
-        description: 'Workflow artifact holding the merged source tarball (mix builds); empty = clone repo at ref'
+        description: 'Workflow artifact (app-source-*) holding the stamped source tree; set by resolve for every build'
         required: false
         default: ''
         type: string
@@ -53,29 +48,16 @@ jobs:
     name: linux/x64
     runs-on: ubuntu-22.04
     steps:
-      - name: Checkout upstream source @ ${{ inputs.tag }}
-        if: inputs.source_artifact == ''
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ inputs.repo }}
-          ref: ${{ inputs.ref || inputs.tag }}
-          path: src
-          # Full history: cmake/build-info.cmake runs `git rev-list --count HEAD`
-          # to bake LLAMA_BUILD_NUMBER into llama-server --version as b<N>.
-          # A shallow clone would bake in "b1" instead.
-          fetch-depth: 0
-
-      # Mix builds: the parent's resolve job merged the PR set and uploaded the
-      # tree (with build number/commit pre-baked into cmake/build-info.cmake,
-      # since there is no .git here) as an artifact.
-      - name: Download merged source @ ${{ inputs.tag }}
-        if: inputs.source_artifact != ''
+      # The parent's resolve job built the source tree (upstream base + any mix
+      # PRs, with the build number/commit and Unsloth fingerprint baked
+      # into cmake/build-info.cmake) and uploaded it as an artifact; extract it
+      # instead of cloning -- no .git needed, the build number is already baked.
+      - name: Download source @ ${{ inputs.tag }}
         uses: actions/download-artifact@v6
         with:
           name: ${{ inputs.source_artifact }}
           path: srcpkg
-      - name: Extract merged source
-        if: inputs.source_artifact != ''
+      - name: Extract source
         shell: bash
         run: |
           set -eux
@@ -175,28 +157,16 @@ jobs:
       run:
         shell: pwsh
     steps:
-      - name: Checkout upstream source @ ${{ inputs.tag }}
-        if: inputs.source_artifact == ''
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ inputs.repo }}
-          ref: ${{ inputs.ref || inputs.tag }}
-          path: src
-          # Full history: cmake/build-info.cmake runs `git rev-list --count HEAD`
-          # to bake LLAMA_BUILD_NUMBER into llama-server --version as b<N>.
-          fetch-depth: 0
-
-      # Mix builds: the parent's resolve job merged the PR set and uploaded the
-      # tree (with build number/commit pre-baked into cmake/build-info.cmake,
-      # since there is no .git here) as an artifact.
-      - name: Download merged source @ ${{ inputs.tag }}
-        if: inputs.source_artifact != ''
+      # The parent's resolve job built the source tree (upstream base + any mix
+      # PRs, with the build number/commit and Unsloth fingerprint baked
+      # into cmake/build-info.cmake) and uploaded it as an artifact; extract it
+      # instead of cloning -- no .git needed, the build number is already baked.
+      - name: Download source @ ${{ inputs.tag }}
         uses: actions/download-artifact@v6
         with:
           name: ${{ inputs.source_artifact }}
           path: srcpkg
-      - name: Extract merged source
-        if: inputs.source_artifact != ''
+      - name: Extract source
         shell: bash
         run: |
           set -eux

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -91,7 +91,6 @@ jobs:
       contents: read
     outputs:
       tag: ${{ steps.r.outputs.tag }}
-      ref: ${{ steps.r.outputs.ref }}
       repo: ${{ steps.r.outputs.repo }}
       base: ${{ steps.r.outputs.base }}
       prs: ${{ steps.r.outputs.prs }}
@@ -194,53 +193,74 @@ jobs:
             PRS="$(jq -c --arg n "$NUM" --arg s "$SHA" --arg u "$url" --arg t "$TITLE" '. + [{number: ($n|tonumber), sha: $s, url: $u, title: $t}]' <<<"$PRS")"
           done
 
-          SRC_ARTIFACT=""
+          # Decide the tag and source repo first; the source tree is built
+          # further down, only if this release isn't already published.
           if [ "$(jq length <<<"$PRS")" = 0 ]; then
+            # Plain build: pristine upstream base, no merge. REPO stays the real
+            # upstream repo even though we ship our own stamped tarball.
             TAG="$BASE"
             REPO='ggml-org/llama.cpp'
-            REF="refs/tags/${TAG}"
-            COMMIT="$(gh api repos/ggml-org/llama.cpp/commits/"$BASE" --jq .sha)"
           else
-            # Merge the set onto the base once, here, and ship the merged tree
-            # to the build children as a workflow artifact: one merge, identical
-            # trees everywhere, nothing pushed to the repo (GITHUB_TOKEN may
-            # never push commits touching .github/workflows, which upstream
-            # history routinely does). The synthetic tag embeds a hash of the
-            # pinned SHAs in listed order (merge order can matter for
-            # conflicts), so a pin update or a reorder yields a new tag and
-            # build, while the release "exists" check below still skips
-            # rebuilding an already-published set.
+            # The synthetic tag embeds a hash of the pinned SHAs in listed order
+            # (merge order can matter for conflicts), so a pin update or a reorder
+            # yields a new tag and build, while the "exists" check below still
+            # skips rebuilding an already-published set. The merged tree exists
+            # only as this repo's release assets, never upstream.
             SETHASH="$(jq -r 'map("\(.number):\(.sha)") | join("\n")' <<<"$PRS" | sha256sum | cut -c1-7)"
             TAG="${BASE}-mix-${SETHASH}"
-            # REPO names where this source is published, for provenance
-            # metadata: the merged tree exists only as this repo's release
-            # assets, never upstream. Children ignore repo in mix mode (they
-            # extract the artifact instead of cloning).
             REPO="$GITHUB_REPOSITORY"
-            REF=""
-            SRC_ARTIFACT="app-source-${TAG}"
-            if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
-              git fetch -q --unshallow --no-tags origin
-            fi
+          fi
+          SRC_ARTIFACT="app-source-${TAG}"
+          COMMIT=""
+
+          # Only PUBLISHED releases count as "exists"; a leftover draft (from
+          # a failed prior publish) should not block today's rebuild.
+          EXISTS=false
+          if [ "$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json isDraft --jq .isDraft 2>/dev/null || true)" = "false" ]; then
+            EXISTS=true
+          fi
+
+          # Build the source tree every child compiles, ONCE, here -- but only
+          # when something will actually be built. On a scheduled no-op (the aged
+          # "latest" was already published) skip the whole checkout/merge/tar +
+          # upload; a manual dispatch always rebuilds. Check out the upstream base,
+          # merge any pinned PRs (mix builds), then bake the build number/commit
+          # and the Unsloth fingerprint into cmake/build-info.cmake. The
+          # result is uploaded as the app-source-* artifact every child extracts --
+          # one identical tree everywhere, no child clones, fingerprint patch in one
+          # place. Nothing is pushed (GITHUB_TOKEN may never push commits touching
+          # .github/workflows, which upstream history routinely does).
+          if [ "$EXISTS" != "true" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             git remote add upstream https://github.com/ggml-org/llama.cpp.git
-            git fetch -q --no-tags upstream "refs/tags/${BASE}:refs/tags/${BASE}"
-            git checkout -q --detach "refs/tags/${BASE}"
-            for pair in $(jq -r '.[] | "\(.number):\(.sha)"' <<<"$PRS"); do
-              NUM="${pair%%:*}"; SHA="${pair##*:}"
-              git fetch -q --no-tags upstream "$SHA" \
-                || { echo "could not fetch commit ${SHA} for PR #${NUM}; it may have been pruned after a force-push -- update or remove the pin in scripts/unsloth/pr-set.json" >&2; exit 1; }
-              git -c user.name='github-actions[bot]' -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
-                merge --no-ff --no-edit -m "Merge ggml-org/llama.cpp#${NUM} @ ${SHA}" "$SHA" \
-                || { echo "PR #${NUM} (${SHA}) does not merge cleanly onto ${BASE} + the PRs listed before it; reorder or drop it in scripts/unsloth/pr-set.json" >&2; exit 1; }
-            done
+            if [ "$(jq length <<<"$PRS")" != 0 ]; then
+              # Merges need a merge-base, so unshallow first.
+              if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+                git fetch -q --unshallow --no-tags origin
+              fi
+              git fetch -q --no-tags upstream "refs/tags/${BASE}:refs/tags/${BASE}"
+              git checkout -q --detach "refs/tags/${BASE}"
+              for pair in $(jq -r '.[] | "\(.number):\(.sha)"' <<<"$PRS"); do
+                NUM="${pair%%:*}"; SHA="${pair##*:}"
+                git fetch -q --no-tags upstream "$SHA" \
+                  || { echo "could not fetch commit ${SHA} for PR #${NUM}; it may have been pruned after a force-push -- update or remove the pin in scripts/unsloth/pr-set.json" >&2; exit 1; }
+                git -c user.name='github-actions[bot]' -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+                  merge --no-ff --no-edit -m "Merge ggml-org/llama.cpp#${NUM} @ ${SHA}" "$SHA" \
+                  || { echo "PR #${NUM} (${SHA}) does not merge cleanly onto ${BASE} + the PRs listed before it; reorder or drop it in scripts/unsloth/pr-set.json" >&2; exit 1; }
+              done
+            else
+              # Plain build: only the base tree is needed. Shallow is fine -- the
+              # build number is baked below, so no git history is needed at build time.
+              git fetch -q --depth 1 --no-tags upstream "refs/tags/${BASE}:refs/tags/${BASE}"
+              git checkout -q --detach "refs/tags/${BASE}"
+            fi
             COMMIT="$(git rev-parse HEAD)"
 
             # The tarball ships without .git, where cmake/build-info.cmake falls
             # back to its defaults; bake real values into those defaults so
-            # llama-server --version doesn't report b0 (unknown). The build
-            # number stays the BASE's b#### number (not the merged commit
-            # count), so anything comparing versions against upstream releases
-            # keeps working; BUILD_COMMIT identifies the merged head.
+            # llama-server --version doesn't report b0 (unknown). The build number
+            # stays the BASE's b#### number (the upstream tag's commit count), so
+            # anything comparing versions against upstream releases keeps working;
+            # BUILD_COMMIT identifies the (possibly merged) head.
             COUNT="${BASE#b}"
             SHORT="$(git rev-parse --short HEAD)"
             sed -i "s/^set(BUILD_NUMBER 0)$/set(BUILD_NUMBER ${COUNT})/" cmake/build-info.cmake
@@ -249,15 +269,22 @@ jobs:
               && grep -q "set(BUILD_COMMIT \"${SHORT}\")" cmake/build-info.cmake \
               || { echo "cmake/build-info.cmake no longer has the expected fallback lines; cannot bake the build number into the source artifact" >&2; exit 1; }
 
-            tar -czf "${RUNNER_TEMP}/llama.cpp-source-${TAG}.tar.gz" --exclude-vcs --transform "s,^\.,llama.cpp-${TAG}," .
-            echo "merged ${TAG} (${COMMIT}, build ${COUNT})"
-          fi
+            # Unsloth fingerprint: fold "Compiled by the Unsloth team"
+            # into BUILD_TARGET, which cmake bakes into LLAMA_BUILD_TARGET, so it
+            # prints on llama-server --version ("built with ... for ...") and shows
+            # up in `strings` on every binary that links common. Append so it wraps
+            # whatever BUILD_TARGET the build computes. Keep this string byte-identical
+            # to MARK in the assemble job's verify gate, which re-checks it landed.
+            grep -q 'set(BUILD_TARGET' cmake/build-info.cmake \
+              || { echo "cmake/build-info.cmake has no BUILD_TARGET line to stamp" >&2; exit 1; }
+            printf '\n# Unsloth fingerprint: shows in --version and strings.\nset(BUILD_TARGET "${BUILD_TARGET} (Compiled by the Unsloth team)")\n' >> cmake/build-info.cmake
+            grep -q 'Compiled by the Unsloth team' cmake/build-info.cmake \
+              || { echo "failed to stamp the Unsloth fingerprint into cmake/build-info.cmake" >&2; exit 1; }
 
-          # Only PUBLISHED releases count as "exists"; a leftover draft (from
-          # a failed prior publish) should not block today's rebuild.
-          EXISTS=false
-          if [ "$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json isDraft --jq .isDraft 2>/dev/null || true)" = "false" ]; then
-            EXISTS=true
+            tar -czf "${RUNNER_TEMP}/llama.cpp-source-${TAG}.tar.gz" --exclude-vcs --transform "s,^\.,llama.cpp-${TAG}," .
+            echo "prepared ${TAG} (${COMMIT}, build ${COUNT})"
+          else
+            echo "release ${TAG} already published; skipping source prep (nothing to build)"
           fi
 
           # ubuntu-22.04 is x64 (glibc 2.35). arm64 only has ubuntu-24.04-arm
@@ -300,7 +327,6 @@ jobs:
 
           {
             echo "tag=$TAG"
-            echo "ref=$REF"
             echo "repo=$REPO"
             echo "base=$BASE"
             echo "prs=$PRS"
@@ -314,11 +340,13 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           echo "Resolved $REQ -> $TAG ($COMMIT); prs=$PRS; source_artifact=${SRC_ARTIFACT:-none}; release exists=$EXISTS; only=$ONLY; gfx=$GFX"
 
-      # The merged source for mix builds: every build child extracts this
-      # instead of cloning, and assemble ships it as the release's
-      # source-tarball asset (the merged commit exists in no repo).
-      - name: Upload merged source artifact
-        if: steps.r.outputs.source_artifact != ''
+      # The stamped source tree (every build): every build child extracts this
+      # instead of cloning, and assemble ships it as the release's source-tarball
+      # asset, so a source build reproduces the same fingerprinted binary. Only
+      # produced when we build, so guard on the same condition as the build jobs
+      # (resolve skips source prep on a scheduled no-op, leaving no tarball).
+      - name: Upload source artifact
+        if: ${{ steps.r.outputs.exists != 'true' || github.event_name == 'workflow_dispatch' }}
         uses: actions/upload-artifact@v6
         with:
           name: ${{ steps.r.outputs.source_artifact }}
@@ -333,7 +361,6 @@ jobs:
     uses: ./.github/workflows/unsloth-prebuilt-cuda.yml
     with:
       tag: ${{ needs.resolve.outputs.tag }}
-      ref: ${{ needs.resolve.outputs.ref }}
       repo: ${{ needs.resolve.outputs.repo }}
       source_artifact: ${{ needs.resolve.outputs.source_artifact }}
       commit: ${{ needs.resolve.outputs.commit }}
@@ -346,7 +373,6 @@ jobs:
     uses: ./.github/workflows/unsloth-prebuilt-cuda-windows.yml
     with:
       tag: ${{ needs.resolve.outputs.tag }}
-      ref: ${{ needs.resolve.outputs.ref }}
       repo: ${{ needs.resolve.outputs.repo }}
       source_artifact: ${{ needs.resolve.outputs.source_artifact }}
       commit: ${{ needs.resolve.outputs.commit }}
@@ -359,7 +385,6 @@ jobs:
     uses: ./.github/workflows/unsloth-prebuilt-rocm.yml
     with:
       tag: ${{ needs.resolve.outputs.tag }}
-      ref: ${{ needs.resolve.outputs.ref }}
       repo: ${{ needs.resolve.outputs.repo }}
       source_artifact: ${{ needs.resolve.outputs.source_artifact }}
       matrix: ${{ needs.resolve.outputs.rocm_matrix }}
@@ -373,7 +398,6 @@ jobs:
     uses: ./.github/workflows/unsloth-prebuilt-macos.yml
     with:
       tag: ${{ needs.resolve.outputs.tag }}
-      ref: ${{ needs.resolve.outputs.ref }}
       repo: ${{ needs.resolve.outputs.repo }}
       source_artifact: ${{ needs.resolve.outputs.source_artifact }}
       matrix: ${{ needs.resolve.outputs.macos_matrix }}
@@ -385,7 +409,6 @@ jobs:
     uses: ./.github/workflows/unsloth-prebuilt-cpu.yml
     with:
       tag: ${{ needs.resolve.outputs.tag }}
-      ref: ${{ needs.resolve.outputs.ref }}
       repo: ${{ needs.resolve.outputs.repo }}
       source_artifact: ${{ needs.resolve.outputs.source_artifact }}
 
@@ -396,7 +419,6 @@ jobs:
     uses: ./.github/workflows/unsloth-prebuilt-vulkan.yml
     with:
       tag: ${{ needs.resolve.outputs.tag }}
-      ref: ${{ needs.resolve.outputs.ref }}
       repo: ${{ needs.resolve.outputs.repo }}
       source_artifact: ${{ needs.resolve.outputs.source_artifact }}
 
@@ -437,29 +459,53 @@ jobs:
           pattern: app-*
           merge-multiple: true
 
-      # Ship the source tarballs as release assets so the installer's
-      # source-build fallback has a tree to fetch. Downloaded into dist/ (not
-      # self-tarred) so the published bytes match the sha256 index, which
-      # assemble_metadata records by hashing these exact local files. For mix
-      # builds the tag-named tarball arrives in dist/ via the resolve job's
-      # app-source-* artifact (the merged tree is in no repo); the exact-source
-      # asset is the same bytes under the commit name.
+      # Fingerprint gate: every bundle must carry the fingerprint the build children
+      # fold into BUILD_TARGET (-> LLAMA_BUILD_TARGET, printed by `--version`). That
+      # string is compiled into common (build-info.cpp); on Linux/macOS it lands in
+      # llama-server's own .rodata, but on a Windows shared build it can live in the
+      # sibling llama-common DLL instead -- so scan every file in the bundle, not
+      # just the exe. Nothing but a compiled binary carries this string (no metadata
+      # file does), so a hit means the brand shipped. Scan bytes rather than running
+      # `--version`: cross-compiled (ROCm) and Windows binaries can't run on this
+      # Linux runner. MARK must stay byte-identical to the resolve job's stamp string.
+      # Refuse to publish if any bundle is unbranded.
+      - name: Verify Unsloth fingerprint in every bundle
+        run: |
+          set -euo pipefail
+          MARK='Compiled by the Unsloth team'
+          shopt -s nullglob
+          tmp="$(mktemp -d)"
+          fail=0
+          checked=0
+          for arc in dist/app-*.tar.gz dist/app-*.zip dist/llama-*-bin-macos-*.tar.gz; do
+            d="$tmp/extract"
+            rm -rf "$d"; mkdir -p "$d"
+            case "$arc" in
+              *.zip)    unzip -qo "$arc" -d "$d" ;;
+              *.tar.gz) tar -xzf "$arc" -C "$d" ;;
+            esac
+            if grep -arq "$MARK" "$d"; then
+              checked=$((checked + 1))
+            else
+              echo "ERROR: $(basename "$arc"): no file carries the Unsloth fingerprint" >&2; fail=1
+            fi
+          done
+          rm -rf "$tmp"
+          [ "$checked" -gt 0 ] || { echo "ERROR: no bundles found to verify (expected app-*/llama-*-bin-macos-* in dist/)" >&2; exit 1; }
+          [ "$fail" = 0 ] || { echo "ERROR: refusing to publish unbranded binaries" >&2; exit 1; }
+          echo "fingerprint verified in $checked bundles"
+
+      # Ship the stamped source tree as release assets so the installer's
+      # source-build fallback reproduces the same fingerprinted binary. The resolve
+      # job's app-source-* artifact lands the tag-named tarball in dist/ (via the
+      # app-* download above); copy it to the commit name too. Both are the exact
+      # local bytes assemble_metadata hashes into the sha256 index.
       - name: Fetch source archives
         run: |
           set -eux
           TAG='${{ needs.resolve.outputs.tag }}'
-          REF='${{ needs.resolve.outputs.ref }}'
-          REPO='${{ needs.resolve.outputs.repo }}'
           SHA='${{ needs.resolve.outputs.commit }}'
-          mkdir -p dist
-          if [ -n '${{ needs.resolve.outputs.source_artifact }}' ]; then
-            cp "dist/llama.cpp-source-${TAG}.tar.gz" "dist/llama.cpp-source-commit-${SHA}.tar.gz"
-          else
-            curl -fL --retry 3 -o "dist/llama.cpp-source-${TAG}.tar.gz" \
-              "https://codeload.github.com/${REPO}/tar.gz/${REF}"
-            curl -fL --retry 3 -o "dist/llama.cpp-source-commit-${SHA}.tar.gz" \
-              "https://codeload.github.com/${REPO}/tar.gz/${SHA}"
-          fi
+          cp "dist/llama.cpp-source-${TAG}.tar.gz" "dist/llama.cpp-source-commit-${SHA}.tar.gz"
 
       - name: Generate manifest + sha256 index
         # prs carries upstream PR titles (arbitrary text), so pass it through env
@@ -471,7 +517,6 @@ jobs:
           set -eux
           python3 tooling/scripts/unsloth/assemble_metadata.py \
             --tag '${{ needs.resolve.outputs.tag }}' \
-            --ref '${{ needs.resolve.outputs.ref }}' \
             --source-repo '${{ needs.resolve.outputs.repo }}' \
             --base-tag '${{ needs.resolve.outputs.base }}' \
             --pr-set "$PRS_JSON" \


### PR DESCRIPTION
This PR stamps `Compiled by the Unsloth team` into every prebuilt binary.

The string is appended to `BUILD_TARGET` in `cmake/build-info.cmake`, which cmake bakes into the `LLAMA_BUILD_TARGET` constant that `--version` prints and that gets compiled into everything linking `common`. So it shows up in `llama-server --version` (the "built with ... for ..." line) and in `strings` on any shipped executable, with no new code and no upstream C++ patch: one appended line in one cmake file, applied at build time.

## What changed

- `resolve` job: appends the fingerprint to `cmake/build-info.cmake` right after it bakes in the build number and commit, and now builds + uploads the stamped source tree for plain builds too (it already did this for mix builds). The stamp is applied in this one place instead of in every build job.
- The six platform workflows (cuda, cuda-windows, macos, rocm, cpu, vulkan): drop the upstream clone and download the `app-source-*` artifact instead. Plain builds used to do a full-history clone in every job, only so `cmake/build-info.cmake`'s `git rev-list --count HEAD` could bake the right `b<N>`. `resolve` bakes that number once, so the jobs no longer need git at all.
- `assemble` job: new gate that scans every shipped bundle for the string and refuses to publish if any is missing it. It greps bytes rather than running `--version` (the ROCm and Windows binaries are cross-compiled and won't run on the Linux runner), and scans every file in the bundle, not just the exe (on a shared build the string can land in the sibling lib instead -- the `llama-common` DLL on Windows, the `libllama-common` dylib on macOS, where the server exe alone doesn't carry it).
- Removed the now-dead `ref` input from the six children and the `resolve` outputs, and dropped the `--ref` arg from the `assemble_metadata.py` call (the script still accepts it, defaulting to `refs/tags/<tag>`, which keeps `source_ref_kind` correct). `SOURCE_REF_KIND` (in the cuda / cuda-windows children) now derives from `repo` instead of from whether `source_artifact` is set, which became always-true and would have mislabeled every plain build as a mix.

## Coverage

The string ends up in the executables and `libllama-common`, not the standalone `ggml` backend libraries (they don't link `common`). Every bundle still ships at least one stamped file and the gate enforces that, so a bundle is always identifiable.

One behavior change: the release's source-tarball asset is now the stamped tree, not a fresh `codeload.github.com` download. A source build from it reproduces the fingerprint, and the asset no longer byte-matches a pristine upstream download.
