### PR TITLE
Install Strawberry Perl via Chocolatey in the Windows ROCm prebuilt workflow

### DIFF
--- a/.github/workflows/unsloth-prebuilt-rocm.yml
+++ b/.github/workflows/unsloth-prebuilt-rocm.yml
@@ -153,15 +153,15 @@ jobs:
         Invoke-DownloadWithRetry -Uri $ninjaUrl -OutFile $ninjaPath
         Expand-Archive -Path $ninjaPath -DestinationPath $ninjaDir -Force
 
-        # Install Strawberry Perl
-        Write-Host "Installing Strawberry Perl..."
-        $perlUrl = "http://strawberryperl.com/download/5.32.1.1/strawberry-perl-5.32.1.1-64bit.msi"
-        $perlPath = "$env:TEMP\strawberry-perl-5.32.1.1-64bit.msi"
-        Invoke-DownloadWithRetry -Uri $perlUrl -OutFile $perlPath
-        Start-Process msiexec.exe -ArgumentList "/i $perlPath /quiet /norestart" -Wait
+        # Install Strawberry Perl via Chocolatey (already on the runner) instead
+        # of downloading the MSI from the frequently-unreachable strawberryperl.com
+        # host that was timing out and failing these builds. It ships preinstalled
+        # on the windows-latest image, so this is normally a fast no-op.
+        Write-Host "Installing Strawberry Perl via Chocolatey..."
+        choco install strawberryperl -y --no-progress
 
         # Verify installations
-        $env:PATH = "C:\ninja;C:\Strawberry\perl\bin;$env:PATH"
+        $env:PATH = "C:\ninja;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;$env:PATH"
         Write-Host "Verifying installations..."
         ninja --version
         perl --version


### PR DESCRIPTION
## Summary

The scheduled "Unsloth prebuilt (full release)" nightly failed three runs in a row (2026-06-15, 06-16, 06-17). Every failure is the same: one of the seven ROCm/Windows matrix jobs dies in "Install build dependencies" while downloading the Strawberry Perl MSI from `http://strawberryperl.com`:

```
Installing Strawberry Perl...
Invoke-WebRequest -Uri $perlUrl -OutFile $perlPath
A connection attempt failed because the connected party did not properly respond
after a period of time, or established connection failed because connected host
has failed to respond.
##[error]Process completed with exit code 1.
```

strawberryperl.com is a single, frequently-overloaded host and has been intermittently dropping connections at the TCP level since mid-June. A different gfx target fails each night (gfx1151, then gfx120X, then gfx1150) depending on which request happens to land while the host is unresponsive. Because any single matrix job failing fails the whole workflow, one transient timeout paints the entire nightly run red even though the other ~39 jobs passed.

## Fix

Strawberry Perl already ships preinstalled on the `windows-latest` runner image via Chocolatey (the `strawberryperl` package, currently 5.42.0.1, installed to `C:\Strawberry` and on PATH). So instead of downloading the MSI from the flaky host, install it with Chocolatey, which is already on the runner:

```powershell
choco install strawberryperl -y --no-progress
```

This removes the external network dependency that was breaking the builds. When the package is already present (the normal case) the command is a fast no-op, and it self-heals if a future runner image ever drops it. Also adds `C:\Strawberry\c\bin` to PATH alongside the existing `C:\Strawberry\perl\bin`.

## Notes

- Only `.github/workflows/unsloth-prebuilt-rocm.yml` references Strawberry Perl, so no other workflow needed changing.
- The Ninja download in the same step pulls from GitHub releases (reliable) and is left as-is. Ninja is also preinstalled via choco on the runner, so it could be simplified the same way later if wanted.

## Testing

- YAML and PowerShell syntax validated locally.
- The reusable ROCm workflow is `workflow_call` only, so full validation runs through the parent "Unsloth prebuilt (full release)" workflow. Happy to kick off a manual run to confirm the ROCm/Windows jobs go green before merge.
