### PR TITLE
GPU prebuilts: ship the full bin set (incl llama-cli)

### DIFF
--- a/.github/workflows/unsloth-prebuilt-cuda-windows.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda-windows.yml
@@ -159,6 +159,8 @@ jobs:
             -DGGML_CUDA_CUB_3DOT2=ON `
             -DLLAMA_BUILD_TESTS=OFF `
             -DLLAMA_BUILD_EXAMPLES=OFF `
+            -DLLAMA_BUILD_TOOLS=ON `
+            -DLLAMA_BUILD_SERVER=ON `
             -DLLAMA_BUILD_BORINGSSL=ON `
             -DCMAKE_CUDA_ARCHITECTURES="$archs" `
             -DCMAKE_C_COMPILER_LAUNCHER=ccache `
@@ -172,8 +174,7 @@ jobs:
           # 4 vCPU / 16 GB GitHub-hosted runners (measured over a 1s sampler),
           # so 3 parallel TUs leave ~13 GB free. -j 4 adds no speed (the runner
           # is ~2 physical cores + HT), so 3 is the sweet spot.
-          cmake --build build --config Release -j 3 `
-            --target llama-server llama-quantize
+          cmake --build build --config Release -j 3
 
       # DiffusionGemma binaries (example targets present only in #24423 mix
       # builds): best-effort, never fail the job. See the Linux CUDA child for

--- a/.github/workflows/unsloth-prebuilt-cuda.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda.yml
@@ -176,6 +176,8 @@ jobs:
             -DGGML_CUDA_CUB_3DOT2=ON \
             -DLLAMA_BUILD_TESTS=OFF \
             -DLLAMA_BUILD_EXAMPLES=OFF \
+            -DLLAMA_BUILD_TOOLS=ON \
+            -DLLAMA_BUILD_SERVER=ON \
             -DCMAKE_CUDA_ARCHITECTURES="$(echo '${{ matrix.archs }}' | tr ' ' ';')" \
             -DCMAKE_INSTALL_RPATH='$ORIGIN' \
             -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
@@ -189,20 +191,19 @@ jobs:
         run: |
           set -eux
           # Backend modules (CPU variants, CUDA, RPC) build as ggml dependencies,
-          # so the server/quantize targets pull them in.
+          # so every tool pulls them in.
           # -j 3: this multi-arch nvcc build peaks at ~3 GB host RSS on the
           # 4 vCPU / 16 GB GitHub-hosted runners (x64 and arm64 alike, measured
           # over a 1s sampler), so 3 parallel TUs leave ~13 GB free. -j 4 adds
           # no speed (the runner is ~2 physical cores + HT), so 3 is the sweet spot.
-          cmake --build build --config Release -j 3 \
-            --target llama-server llama-quantize
-          strip build/bin/llama-server build/bin/llama-quantize || true
+          cmake --build build --config Release -j 3
+          strip build/bin/llama-* || true
 
       # The DiffusionGemma visual server + cli are example targets that exist
       # only when the source tree carries ggml-org/llama.cpp#24423 (a mix build).
-      # Build them best-effort and NEVER fail the job: the required server +
-      # quantize bundle above must publish even if these do not compile on a
-      # given toolchain. package_bundle.py ships them only if they were produced.
+      # Build them best-effort and NEVER fail the job: the full tool bundle
+      # above must publish even if these do not compile on a given toolchain.
+      # package_bundle.py ships them only if they were produced.
       - name: Build DiffusionGemma binaries (best-effort; mix builds only)
         working-directory: src
         run: |

--- a/.github/workflows/unsloth-prebuilt-vulkan.yml
+++ b/.github/workflows/unsloth-prebuilt-vulkan.yml
@@ -95,6 +95,8 @@ jobs:
             -DGGML_VULKAN=ON \
             -DLLAMA_BUILD_TESTS=OFF \
             -DLLAMA_BUILD_EXAMPLES=OFF \
+            -DLLAMA_BUILD_TOOLS=ON \
+            -DLLAMA_BUILD_SERVER=ON \
             -DCMAKE_INSTALL_RPATH='$ORIGIN' \
             -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
             -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=OFF \
@@ -106,10 +108,9 @@ jobs:
         run: |
           set -eux
           # Backend modules (CPU variants, Vulkan, RPC) build as ggml
-          # dependencies, so the server/quantize targets pull them in.
-          cmake --build build --config Release -j "$(nproc)" \
-            --target llama-server llama-quantize
-          strip build/bin/llama-server build/bin/llama-quantize || true
+          # dependencies, so every tool pulls them in.
+          cmake --build build --config Release -j "$(nproc)"
+          strip build/bin/llama-* || true
 
       # DiffusionGemma binaries (example targets present only in #24423 mix
       # builds): best-effort, never fail the job. See the CUDA child for the
@@ -217,6 +218,8 @@ jobs:
             -DGGML_VULKAN=ON `
             -DLLAMA_BUILD_TESTS=OFF `
             -DLLAMA_BUILD_EXAMPLES=OFF `
+            -DLLAMA_BUILD_TOOLS=ON `
+            -DLLAMA_BUILD_SERVER=ON `
             -DLLAMA_BUILD_BORINGSSL=ON `
             -DCMAKE_C_COMPILER_LAUNCHER=ccache `
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
@@ -224,8 +227,7 @@ jobs:
       - name: Build
         working-directory: src
         run: |
-          cmake --build build --config Release -j 3 `
-            --target llama-server llama-quantize
+          cmake --build build --config Release -j 3
 
       # DiffusionGemma binaries (#24423 mix builds only): best-effort, never
       # fail the job. See the CUDA child for the rationale.

--- a/scripts/unsloth/package_bundle.py
+++ b/scripts/unsloth/package_bundle.py
@@ -58,18 +58,21 @@ class PlatformStrategy:
     exe_suffix = ""
     archive_ext = ".tar.gz"
     rpath = ""
-    binaries = ["llama-server", "llama-quantize"]
-    # Extras shipped only when the build produced them (the DiffusionGemma
-    # binaries from a mix build that includes ggml-org/llama.cpp#24423). A plain
-    # upstream build never builds these, so -- unlike `binaries`, every one of
-    # which must exist -- their absence is not an error.
-    optional_binaries = ["llama-diffusion-gemma-visual-server", "llama-diffusion-cli"]
+    # Required core: these must exist or packaging fails loudly. Every other
+    # executable the build produced is discovered and shipped too (see curate).
+    binaries = ["llama-server", "llama-cli", "llama-quantize"]
+    lib_suffix_re = r"\.so(\.\d+)*$"  # POSIX shared-lib suffix to exclude; Windows keys on .exe
 
     def shipped_binaries(self) -> list[str]:
         return [b + self.exe_suffix for b in self.binaries]
 
-    def optional_shipped_binaries(self) -> list[str]:
-        return [b + self.exe_suffix for b in self.optional_binaries]
+    def is_executable(self, path: Path) -> bool:
+        """True if `path` is a program to ship (not a shared library)."""
+        if not path.is_file():
+            return False
+        if self.exe_suffix:  # Windows: an executable is exactly a .exe
+            return path.suffix.lower() == self.exe_suffix
+        return not re.search(self.lib_suffix_re, path.name) and os.access(path, os.X_OK)
 
     def local_needed(self, path: Path, bin_dir: Path) -> list[str]:
         """Names of dynamic libs `path` needs that are *local* (live in bin_dir)."""
@@ -106,6 +109,7 @@ class LinuxStrategy(PlatformStrategy):
 class MacOSStrategy(PlatformStrategy):
     name = "macos"
     rpath = "@loader_path"
+    lib_suffix_re = r"\.dylib$"
 
     def local_needed(self, path: Path, bin_dir: Path) -> list[str]:
         out = _run(["otool", "-L", str(path)])
@@ -175,21 +179,24 @@ def _copy_one(strategy: PlatformStrategy, bin_dir: Path, stage: Path, name: str)
 
 def curate(strategy: PlatformStrategy, bin_dir: Path, stage: Path) -> None:
     roots: list[Path] = []
-    for b in strategy.shipped_binaries():
+    required = strategy.shipped_binaries()
+    for b in required:
         if not (bin_dir / b).exists():
             sys.exit(f"ERROR: missing {bin_dir / b}")
         shutil.copy2(bin_dir / b, stage / b)
         roots.append(stage / b)
 
-    # Optional binaries: ship the ones this build produced, skip the rest. They
-    # become roots too, so any library only they need is pulled into the closure
-    # (the DiffusionGemma binaries need only libllama/libggml/libllama-common,
-    # which llama-server already pulls, but treat them as roots for safety).
-    for b in strategy.optional_shipped_binaries():
-        src = bin_dir / b
-        if src.exists():
-            shutil.copy2(src, stage / b)
-            roots.append(stage / b)
+    # Ship every other executable the build produced, so a curated GPU bundle
+    # carries the same tool set as the full-build cpu/macos/rocm tarballs (which
+    # tar all of build/bin). Each becomes a root too, so any library only it
+    # needs is pulled into the closure. Runtime libraries that live outside
+    # bin_dir (e.g. the CUDA runtime) are never pulled in: the walk stays local.
+    required_set = set(required)
+    for p in sorted(bin_dir.iterdir()):
+        if p.name in required_set or not strategy.is_executable(p):
+            continue
+        _copy_one(strategy, bin_dir, stage, p.name)
+        roots.append(stage / p.name)
 
     # Backend modules are dlopen'd, so they never appear in the NEEDED graph;
     # copy them explicitly and treat them as extra roots so their own local


### PR DESCRIPTION
The CUDA, CUDA-Windows and Vulkan prebuilt bundles only shipped `llama-server` and `llama-quantize`. CPU/macOS/ROCm already ship the full tool set, so this brings the GPU bundles in line: every bundle now includes `llama-cli` and the rest of the tools. Follow-up to #28, which did the same for CPU.

- cuda / cuda-windows / vulkan: drop `--target llama-server llama-quantize` so the build produces the full tool set, like CPU/macOS/ROCm, and generalize the strip to `llama-*`.
- `package_bundle.py` (the CUDA packager): ship every executable the build produced instead of a fixed allowlist. The required core (`llama-server`, `llama-cli`, `llama-quantize`) must still exist or packaging fails loudly. The deliberately unbundled CUDA runtime stays out, since the dependency walk is local to `build/bin`.
- Add explicit `-DLLAMA_BUILD_TOOLS=ON -DLLAMA_BUILD_SERVER=ON` to the GPU configs, matching CPU/macOS (`llama-cli` is gated by `LLAMA_BUILD_SERVER`).
