### PR TITLE
Bump DiffusionGemma #24423 pin to c3fb9724 (Add tool calling)

### DIFF
--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -9,7 +9,7 @@
     "tag + pins), so keep its pin open until the change lands upstream."
   ],
   "prs": [
-    "https://github.com/ggml-org/llama.cpp/pull/24423/commits/1d2faac2d8248c3d5df999712c42fe0fc72e7f07",
+    "https://github.com/ggml-org/llama.cpp/pull/24423/commits/c3fb97241295c196e09b783e705e84b96cd1bd74",
     "https://github.com/ggml-org/llama.cpp/pull/24523/commits/00f95bd2d59ed2d6408fa3777b43ff5bd5fdc79d",
     "https://github.com/ggml-org/llama.cpp/pull/25402/commits/15f732183bc1029df4b41ae2118364c3ccb6c162"
   ]


### PR DESCRIPTION
Bump the DiffusionGemma pin (ggml-org/llama.cpp#24423) from `1d2faac` to `c3fb9724`.

## Why

The current pin (`1d2faac`, "Fix merge conflicts", 2026-07-03) is one commit behind `c3fb9724` ("Add tool calling", 2026-07-04), which is the head of #24423. That commit adds the three lines that let the visual server read tools from the request:

```cpp
if (req.contains("tools")) {
    inputs.tools = common_chat_tools_parse_oaicompat(req.at("tools"));
}
```

Without it the shipped `llama-diffusion-gemma-visual-server` never renders the caller's tools into the chat template, so DiffusionGemma cannot produce schema-correct tool calls. This is the binary half of the DiffusionGemma tool-calling path that unslothai/unsloth#6851 and unslothai/unsloth-zoo#864 depend on.

## Verification

Built `c3fb9724` from source (single-arch CUDA sm_100) and ran it under Studio with `unsloth/diffusiongemma-26B-A4B-it-GGUF` (Q4_K_M):

- Before (pinned `1d2faac`): a plain OpenAI tools request returned "I do not have access to ... tools" (the model never saw the tool).
- After (`c3fb9724`): the same request returns a structured `tool_calls` array, `get_weather(location="San Francisco")`.
- `tool_choice: "none"` correctly suppresses the tool.

Plain chat and the diffusion visualization are unchanged.

Lint: the new URL matches the pr-set schema and `c3fb9724` is the current head of #24423.
