### PR TITLE
CPU prebuilts: build the Linux arm64 bundle on ubuntu-22.04-arm (glibc 2.35 floor)

### DIFF
--- a/.github/workflows/unsloth-prebuilt-cpu.yml
+++ b/.github/workflows/unsloth-prebuilt-cpu.yml
@@ -20,6 +20,8 @@ name: "Unsloth prebuilt: CPU"
 # assemble_metadata.py derives the manifest entry from the filename), $ORIGIN
 # RPATH on Linux. arm64 extends llama-cpp-binaries (x64-only) so the release
 # covers the arm64 CPU hosts that previously fell back to ggml-org upstream.
+# Both Linux legs build on ubuntu-22.04 so the bundles keep a glibc 2.35 /
+# GLIBCXX <= 3.4.30 floor and load on Ubuntu 22.04 and Debian 12 hosts.
 
 on:
   workflow_call:
@@ -51,7 +53,7 @@ jobs:
       matrix:
         include:
           - { arch: x64,   runner: ubuntu-22.04 }
-          - { arch: arm64, runner: ubuntu-24.04-arm }
+          - { arch: arm64, runner: ubuntu-22.04-arm }
     steps:
       # The parent's resolve job built the source tree (upstream base + any mix
       # PRs, with the build number/commit and Unsloth fingerprint baked
@@ -75,17 +77,21 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential libssl-dev ninja-build
 
-      # ggml-org's release.yml applies this GCC-14 workaround on every
-      # ubuntu-24.04 leg (our arm64 runner); the default toolchain there
-      # miscompiles ggml. Matches the gcc-14 step in our CUDA arm64 child.
-      - name: Toolchain workaround (GCC 14 on arm64)
+      # arm64 builds on ubuntu-22.04-arm so the bundle keeps the x64 leg's
+      # loader floor (a 24.04 build needs GLIBC_2.38 and fails to load on
+      # Ubuntu 22.04 / Debian 12). Jammy's gcc can't target armv9.2-a+sme and
+      # a PPA gcc would raise the libstdc++ floor back, so use clang, which
+      # links against the system libstdc++.
+      - name: Toolchain (clang 19 on arm64)
         if: matrix.arch == 'arm64'
         run: |
           set -eux
-          sudo apt-get install -y gcc-14 g++-14
+          wget -q https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 19
           {
-            echo "CC=gcc-14"
-            echo "CXX=g++-14"
+            echo "CC=clang-19"
+            echo "CXX=clang++-19"
           } >> "$GITHUB_ENV"
 
       - name: ccache


### PR DESCRIPTION
The Linux arm64 CPU bundle is built on ubuntu-24.04-arm, so it requires GLIBC_2.38 / GLIBCXX_3.4.32. It fails to load on Ubuntu 22.04 or Debian 12 arm64 with a version-not-found loader error (found by @danielhanchen's runner matrix in unslothai/unsloth#6311). The x64 leg builds on ubuntu-22.04 and does not have this problem. Upstream's own ubuntu-arm64 bundle has the identical floor, so this was inherited, not new.

## Fix

Build the arm64 leg on ubuntu-22.04-arm, matching the x64 leg's base. The bundle's floor drops to GLIBC_2.34 / GLIBCXX_3.4.30, which Ubuntu 22.04 and Debian 12 satisfy.

The toolchain step changes with it. Jammy's gcc (<= 12) cannot target the armv9.2-a+sme CPU variants that GGML_CPU_ALL_VARIANTS fans out, and a toolchain-PPA gcc would reference newer libstdc++ symbols and recreate the floor this PR removes. So the arm64 leg now uses clang 19 from apt.llvm.org, which compiles the SME variants while linking against the system (jammy) libstdc++. This replaces the GCC-14 miscompile workaround, only needed on the ubuntu-24.04 runner. clang-built ggml CPU bundles are already the norm elsewhere: upstream's Windows CPU releases, macOS, and Android all use clang.

## Verification

Ran the full prebuilt workflow with this change on my fork (https://github.com/oobabooga/llama.cpp/actions/runs/28913632512): linux/arm64 and linux/x64 CPU jobs green. The produced arm64 bundle has floors GLIBC_2.34 / GLIBCXX_3.4.30 (was GLIBC_2.38 / GLIBCXX_3.4.32), ships all 8 CPU variant libraries including both armv9.2 SME legs, and keeps the same NEEDED set and $ORIGIN RUNPATH.

Then ran the bundle on a real ubuntu-22.04-arm runner (glibc 2.35, the host class that failed before): ldd resolves, llama-server --version passes, and llama-completion generates correct text from a tiny GGUF end to end (https://github.com/oobabooga/llama.cpp/actions/runs/28915006185).
