### PR TITLE
GPU prebuilts: add a cuda12-legacy bundle for Maxwell/Pascal GPUs

### DIFF
--- a/.github/workflows/unsloth-prebuilt-cuda-windows.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda-windows.yml
@@ -45,11 +45,6 @@ jobs:
   build:
     name: x64/${{ matrix.profile }}
     runs-on: ${{ matrix.runner }}
-    # cuda12-legacy (Maxwell/Pascal PTX floors) is best-effort: the merged mix
-    # PRs may not compile for old archs, and a failure there must not sink the
-    # release. Every other profile stays hard-required so a partial set can't
-    # publish.
-    continue-on-error: ${{ matrix.klass == 'legacy' }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(inputs.matrix) }}

--- a/.github/workflows/unsloth-prebuilt-cuda-windows.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda-windows.yml
@@ -45,6 +45,11 @@ jobs:
   build:
     name: x64/${{ matrix.profile }}
     runs-on: ${{ matrix.runner }}
+    # cuda12-legacy (Maxwell/Pascal PTX floors) is best-effort: the merged mix
+    # PRs may not compile for old archs, and a failure there must not sink the
+    # release. Every other profile stays hard-required so a partial set can't
+    # publish.
+    continue-on-error: ${{ matrix.klass == 'legacy' }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(inputs.matrix) }}
@@ -218,6 +223,7 @@ jobs:
           TOOLKIT_LINE: ${{ matrix.toolkit_line }}
           DOCKER_IMAGE: github-hosted ${{ matrix.runner }}, CUDA ${{ matrix.cuda }} ${{ matrix.cuda == '13.3' && '(NVIDIA redist)' || '(Jimver)' }}
           ARCHS: ${{ matrix.archs }}
+          SMS: ${{ matrix.sms }}
         run: python tooling/scripts/unsloth/package_bundle.py
 
       - name: Upload bundle artifact

--- a/.github/workflows/unsloth-prebuilt-cuda.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda.yml
@@ -40,11 +40,6 @@ jobs:
   build:
     name: ${{ matrix.arch }}/${{ matrix.profile }}
     runs-on: ${{ matrix.runner }}
-    # cuda12-legacy (Maxwell/Pascal PTX floors) is best-effort: the merged mix
-    # PRs may not compile for old archs, and a failure there must not sink the
-    # release. Every other profile stays hard-required so a partial set can't
-    # publish.
-    continue-on-error: ${{ matrix.klass == 'legacy' }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(inputs.matrix) }}

--- a/.github/workflows/unsloth-prebuilt-cuda.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda.yml
@@ -40,6 +40,11 @@ jobs:
   build:
     name: ${{ matrix.arch }}/${{ matrix.profile }}
     runs-on: ${{ matrix.runner }}
+    # cuda12-legacy (Maxwell/Pascal PTX floors) is best-effort: the merged mix
+    # PRs may not compile for old archs, and a failure there must not sink the
+    # release. Every other profile stays hard-required so a partial set can't
+    # publish.
+    continue-on-error: ${{ matrix.klass == 'legacy' }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(inputs.matrix) }}
@@ -241,6 +246,7 @@ jobs:
           TOOLKIT_LINE: ${{ matrix.toolkit_line }}
           DOCKER_IMAGE: github-hosted ${{ matrix.runner }}, CUDA ${{ matrix.cuda }} ${{ matrix.cuda == '13.3' && '(NVIDIA redist)' || '(Jimver)' }}
           ARCHS: ${{ matrix.archs }}
+          SMS: ${{ matrix.sms }}
         run: python3 tooling/scripts/unsloth/package_bundle.py
 
       - name: Upload bundle artifact

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -552,9 +552,8 @@ jobs:
           fail=0
           # A partial CUDA set (cuda13 without cuda12) silently strands the
           # cuda12-runtime majority; require matching x64 coverage on both lines.
-          # Only the older/newer/portable classes are symmetric across lines:
-          # cuda12-legacy is cuda12-only (CUDA 13 dropped Maxwell/Pascal) and
-          # best-effort, so `-n ... p` drops it rather than counting it here.
+          # cuda12-legacy has no cuda13 sibling, so `-nE ... p` drops it from
+          # this cross-line parity check; its presence is required separately below.
           for os in linux windows; do
             ext=$([ "$os" = windows ] && echo zip || echo tar.gz)
             c12=$(ls dist/app-*-"$os"-x64-cuda12-*."$ext" 2>/dev/null | sed -nE 's/.*cuda12-(older|newer|portable)\..*/\1/p' | sort -u | paste -sd, -)
@@ -564,10 +563,13 @@ jobs:
           done
           # Children passing is not the same as files landing in dist/ (a
           # download-artifact anomaly leaves green jobs and missing bundles),
-          # so assert presence of every non-CUDA-x64 line the installer
-          # selects from. The resolve-time input guard already pins publish
-          # runs to the full default matrix, so these names are exact.
+          # so assert presence of every line not covered by the parity check
+          # above (the non-CUDA-x64 lines, plus cuda12-legacy). The resolve-time
+          # input guard already pins publish runs to the full default matrix, so
+          # these names are exact.
           for f in \
+            "app-${TAG}-linux-x64-cuda12-legacy.tar.gz" \
+            "app-${TAG}-windows-x64-cuda12-legacy.zip" \
             "llama-${TAG}-bin-macos-arm64.tar.gz" \
             "llama-${TAG}-bin-macos-x64.tar.gz" \
             "app-${TAG}-linux-arm64-cuda13-portable.tar.gz" \

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -46,7 +46,7 @@ on:
         default: 'all'
         required: false
         type: choice
-        options: [all, cuda12-older, cuda12-newer, cuda12-portable, cuda13-older, cuda13-newer, cuda13-portable]
+        options: [all, cuda12-legacy, cuda12-older, cuda12-newer, cuda12-portable, cuda13-older, cuda13-newer, cuda13-portable]
       operating_systems:
         description: 'OSes for ROCm builds'
         default: 'windows,ubuntu'
@@ -301,6 +301,7 @@ jobs:
           # upstream) which Jimver lacks, so those install via NVIDIA redist in
           # the build children -- on the same runners, so the glibc floor holds.
           ALL='[
+            {"profile":"cuda12-legacy",  "arch":"x64",  "runner":"ubuntu-22.04",    "line":"cuda12","klass":"legacy",  "rank":5, "cuda":"12.8.0","toolkit_line":"12.8","archs":"50-virtual 61-virtual","sms":"50 52 60 61"},
             {"profile":"cuda12-older",   "arch":"x64",  "runner":"ubuntu-22.04",    "line":"cuda12","klass":"older",   "rank":10,"cuda":"12.8.0","toolkit_line":"12.8","archs":"70 75 80 86 89"},
             {"profile":"cuda12-newer",   "arch":"x64",  "runner":"ubuntu-22.04",    "line":"cuda12","klass":"newer",   "rank":20,"cuda":"12.8.0","toolkit_line":"12.8","archs":"86 89 90 100 120"},
             {"profile":"cuda12-portable","arch":"x64",  "runner":"ubuntu-22.04",    "line":"cuda12","klass":"portable","rank":30,"cuda":"12.8.0","toolkit_line":"12.8","archs":"70 75 80 86 89 90 100 120"},
@@ -551,10 +552,13 @@ jobs:
           fail=0
           # A partial CUDA set (cuda13 without cuda12) silently strands the
           # cuda12-runtime majority; require matching x64 coverage on both lines.
+          # Only the older/newer/portable classes are symmetric across lines:
+          # cuda12-legacy is cuda12-only (CUDA 13 dropped Maxwell/Pascal) and
+          # best-effort, so `-n ... p` drops it rather than counting it here.
           for os in linux windows; do
             ext=$([ "$os" = windows ] && echo zip || echo tar.gz)
-            c12=$(ls dist/app-*-"$os"-x64-cuda12-*."$ext" 2>/dev/null | sed -E 's/.*cuda12-(older|newer|portable)\..*/\1/' | sort -u | paste -sd, -)
-            c13=$(ls dist/app-*-"$os"-x64-cuda13-*."$ext" 2>/dev/null | sed -E 's/.*cuda13-(older|newer|portable)\..*/\1/' | sort -u | paste -sd, -)
+            c12=$(ls dist/app-*-"$os"-x64-cuda12-*."$ext" 2>/dev/null | sed -nE 's/.*cuda12-(older|newer|portable)\..*/\1/p' | sort -u | paste -sd, -)
+            c13=$(ls dist/app-*-"$os"-x64-cuda13-*."$ext" 2>/dev/null | sed -nE 's/.*cuda13-(older|newer|portable)\..*/\1/p' | sort -u | paste -sd, -)
             echo "$os x64 coverage: cuda12=[$c12] cuda13=[$c13]"
             [ -n "$c12" ] && [ "$c12" = "$c13" ] || { echo "ERROR: $os x64 cuda12/cuda13 coverage mismatch" >&2; fail=1; }
           done

--- a/scripts/unsloth/assemble_metadata.py
+++ b/scripts/unsloth/assemble_metadata.py
@@ -34,7 +34,7 @@ from pathlib import Path
 UPSTREAM_REPO = "ggml-org/llama.cpp"
 
 BUNDLE_RE = re.compile(
-    r"^app-(?P<tag>[^/]+)-(?P<platform>linux|windows)-(?P<arch>x64|arm64)-(?P<profile>cuda1[23]-(?:older|newer|portable))\.(?P<ext>tar\.gz|zip)$"
+    r"^app-(?P<tag>[^/]+)-(?P<platform>linux|windows)-(?P<arch>x64|arm64)-(?P<profile>cuda1[23]-(?:older|newer|portable|legacy))\.(?P<ext>tar\.gz|zip)$"
 )
 
 ROCM_BUNDLE_RE = re.compile(

--- a/scripts/unsloth/package_bundle.py
+++ b/scripts/unsloth/package_bundle.py
@@ -332,10 +332,7 @@ def read_config() -> dict:
         "rank": need("RANK"),
         "toolkit_line": need("TOOLKIT_LINE"),
         "archs": need("ARCHS"),
-        # Advertised compute capabilities. Optional: all-real profiles derive it
-        # from ARCHS, but a profile that builds PTX floors (e.g. "50-virtual")
-        # must state the concrete SMs it JIT-covers, since the floor int is not
-        # the coverage set.
+        # Advertised compute capabilities; optional (empty -> derived from ARCHS in main()).
         "sms": os.environ.get("SMS", ""),
         "platform": os.environ.get("PLATFORM", "linux"),
         "arch": os.environ.get("ARCH", "x64"),
@@ -351,12 +348,10 @@ def main() -> int:
     if strategy is None:
         sys.exit(f"ERROR: unknown PLATFORM '{cfg['platform']}' (have {sorted(STRATEGIES)})")
 
-    # ARCHS is the nvcc build directive and may carry -real/-virtual/a/f
-    # suffixes (e.g. the cuda12-legacy profile builds "50-virtual 61-virtual"
-    # PTX floors). The manifest's supported_sms must instead be the concrete
-    # compute capabilities the bundle runs on -- wider than a PTX floor -- so a
-    # suffixed profile declares its coverage explicitly via SMS. All-real
-    # profiles omit SMS and fall back to each arch's leading SM integer.
+    # supported_sms is the concrete coverage, which for a PTX floor (e.g. the
+    # cuda12-legacy "50-virtual 61-virtual") is wider than the arch int itself.
+    # So suffixed profiles declare it via SMS; all-real profiles fall back to
+    # each ARCHS entry's leading SM number.
     if cfg["sms"]:
         sms = [s for s in re.split(r"[ ;,]+", cfg["sms"]) if s]
     else:

--- a/scripts/unsloth/package_bundle.py
+++ b/scripts/unsloth/package_bundle.py
@@ -225,15 +225,15 @@ def detect_nvcc_sms() -> tuple[str, list[str], str]:
     return "available", sms, f"detected {len(sms)} SM targets"
 
 
-def write_metadata(stage: Path, strategy: PlatformStrategy, cfg: dict, archs: list[str]) -> None:
+def write_metadata(stage: Path, strategy: PlatformStrategy, cfg: dict, sms: list[str]) -> None:
     short = cfg["commit"][:7]
-    min_sm, max_sm = min(map(int, archs)), max(map(int, archs))
+    min_sm, max_sm = min(map(int, sms)), max(map(int, sms))
     nvcc_status, nvcc_sms, nvcc_msg = detect_nvcc_sms()
     # sm_103 (B300 / GB300 Blackwell Ultra) has no native build, but it JIT-runs
     # on the bundled compute_100 PTX, so any bundle that ships sm_100 also covers
     # it. Declare it in supported_sms (not the native nvcc build) so every
     # platform's manifest agrees -- Windows and arm64 reuse these x64 profiles.
-    supported_sms = list(archs)
+    supported_sms = list(sms)
     if "100" in supported_sms and "103" not in supported_sms:
         supported_sms = sorted([*supported_sms, "103"], key=int)
     note = f"CUDA {cfg['line'].removeprefix('cuda')} {cfg['klass']} bundle."
@@ -332,6 +332,11 @@ def read_config() -> dict:
         "rank": need("RANK"),
         "toolkit_line": need("TOOLKIT_LINE"),
         "archs": need("ARCHS"),
+        # Advertised compute capabilities. Optional: all-real profiles derive it
+        # from ARCHS, but a profile that builds PTX floors (e.g. "50-virtual")
+        # must state the concrete SMs it JIT-covers, since the floor int is not
+        # the coverage set.
+        "sms": os.environ.get("SMS", ""),
         "platform": os.environ.get("PLATFORM", "linux"),
         "arch": os.environ.get("ARCH", "x64"),
         "docker_image": os.environ.get("DOCKER_IMAGE", ""),
@@ -346,7 +351,16 @@ def main() -> int:
     if strategy is None:
         sys.exit(f"ERROR: unknown PLATFORM '{cfg['platform']}' (have {sorted(STRATEGIES)})")
 
-    archs = [a for a in re.split(r"[ ;,]+", cfg["archs"]) if a]
+    # ARCHS is the nvcc build directive and may carry -real/-virtual/a/f
+    # suffixes (e.g. the cuda12-legacy profile builds "50-virtual 61-virtual"
+    # PTX floors). The manifest's supported_sms must instead be the concrete
+    # compute capabilities the bundle runs on -- wider than a PTX floor -- so a
+    # suffixed profile declares its coverage explicitly via SMS. All-real
+    # profiles omit SMS and fall back to each arch's leading SM integer.
+    if cfg["sms"]:
+        sms = [s for s in re.split(r"[ ;,]+", cfg["sms"]) if s]
+    else:
+        sms = [re.match(r"\d+", a).group() for a in re.split(r"[ ;,]+", cfg["archs"]) if a]
     bin_dir = Path(cfg["bin_dir"])
     out_dir = Path(cfg["out_dir"])
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -354,7 +368,7 @@ def main() -> int:
     stage = Path(tempfile.mkdtemp())
     try:
         curate(strategy, bin_dir, stage)
-        write_metadata(stage, strategy, cfg, archs)
+        write_metadata(stage, strategy, cfg, sms)
 
         asset = f"app-{cfg['tag']}-{strategy.name}-{cfg['arch']}-{cfg['profile']}{strategy.archive_ext}"
         out_path = out_dir / asset


### PR DESCRIPTION
## Problem

Pre-Volta NVIDIA GPUs (Maxwell/Pascal, e.g. the GTX 10-series) cannot update llama.cpp in Studio. Updates fail with `approved checksum asset did not contain the selected prebuilt archive(s): llama-<tag>-bin-win-cuda-12.4-x64.zip` and revert to the installed build. Reported in unslothai/unsloth#7127.

## Root cause

Our CUDA bundles only target sm_70+, so these GPUs fall through to the upstream `cuda-12.4` archive, which the installer uses only if its checksum is in our manifest. `assemble_metadata.py` records that passthrough checksum only for vanilla releases, and every current release is a `-mix-` build, so the hash is never present.

## Fix

Add a `cuda12-legacy` bundle (Linux + Windows x64) built from the merged tree, covering Maxwell and Pascal via two PTX floors (`50-virtual 61-virtual`), the same targets upstream ships for these cards. It gets a manifest checksum like any `app-*` bundle and slots into the existing coverage-class selection, so sm_50 to sm_61 hosts pick it up automatically.

This is the complete fix. The Studio installer needs no companion change: selection is metadata-driven off the bundle's `supported_sms`, so it routes Pascal to this bundle on its own once the release ships it.

Boundaries: cuda12 only (CUDA 13 dropped these archs); below sm_50 (Kepler) and Jetson/Tegra out of scope. It's a required bundle like every other profile, so a compile failure blocks the release rather than silently shipping a coverage hole.

## Verification

Built and exercised live ([run](https://github.com/oobabooga/llama.cpp/actions/runs/29450244048)). Both legacy jobs compiled the merged tree for sm_50/61. Both bundles carry only `compute_50`/`compute_61` PTX (no SASS), the mix-PR binaries, and the Unsloth stamp. The Linux bundle's `llama-server` ran on a GGUF with GPU offload: it JITs the PTX floor onto the local card (an Ada here; a Pascal card JITs the same PTX natively) and served correct `/v1/chat/completions` and `/completion` responses.

Selection is also confirmed against a manifest carrying the bundle: sm_61 routes to `cuda12-legacy`, sm_86 stays on `cuda12-older`, and an unknown-capability host is not served it, so Studio picks it up with no change.
