### PR TITLE
Prebuilds: key ccache on the source tag to stop cache eviction

### DIFF
--- a/.github/workflows/unsloth-prebuilt-cpu.yml
+++ b/.github/workflows/unsloth-prebuilt-cpu.yml
@@ -102,7 +102,7 @@ jobs:
             cpu-linux-${{ matrix.arch }}
           append-timestamp: false
           variant: ccache
-          evict-old-files: 14d
+          save: false
 
       - name: Configure
         working-directory: src
@@ -175,6 +175,16 @@ jobs:
           path: dist/app-${{ inputs.tag }}-linux-${{ matrix.arch }}-cpu.tar.gz
           if-no-files-found: error
 
+      - name: Evict stale ccache files
+        continue-on-error: true
+        run: ccache --evict-older-than 14d
+
+      - name: Save ccache
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ github.workspace }}/.ccache
+          key: ccache-cpu-linux-${{ matrix.arch }}-${{ inputs.tag }}-
+
   build-windows:
     name: windows/${{ matrix.arch }}
     # Single x64 runner for both arches: arm64 is cross-compiled with the clang
@@ -216,7 +226,7 @@ jobs:
             cpu-windows-${{ matrix.arch }}
           append-timestamp: false
           variant: ccache
-          evict-old-files: 14d
+          save: false
 
       - name: Install Ninja
         run: choco install ninja --no-progress
@@ -307,3 +317,13 @@ jobs:
           name: app-${{ inputs.tag }}-windows-${{ matrix.arch }}-cpu
           path: dist/app-${{ inputs.tag }}-windows-${{ matrix.arch }}-cpu.zip
           if-no-files-found: error
+
+      - name: Evict stale ccache files
+        continue-on-error: true
+        run: ccache --evict-older-than 14d
+
+      - name: Save ccache
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ github.workspace }}\.ccache
+          key: ccache-cpu-windows-${{ matrix.arch }}-${{ inputs.tag }}-

--- a/.github/workflows/unsloth-prebuilt-cpu.yml
+++ b/.github/workflows/unsloth-prebuilt-cpu.yml
@@ -97,7 +97,10 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.20
         with:
-          key: cpu-linux-${{ matrix.arch }}
+          key: cpu-linux-${{ matrix.arch }}-${{ inputs.tag }}
+          restore-keys: |
+            cpu-linux-${{ matrix.arch }}
+          append-timestamp: false
           variant: ccache
           evict-old-files: 14d
 
@@ -208,7 +211,10 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.20
         with:
-          key: cpu-windows-${{ matrix.arch }}
+          key: cpu-windows-${{ matrix.arch }}-${{ inputs.tag }}
+          restore-keys: |
+            cpu-windows-${{ matrix.arch }}
+          append-timestamp: false
           variant: ccache
           evict-old-files: 14d
 

--- a/.github/workflows/unsloth-prebuilt-cuda-windows.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda-windows.yml
@@ -76,7 +76,10 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.20
         with:
-          key: cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}
+          key: cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-${{ inputs.tag }}
+          restore-keys: |
+            cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}
+          append-timestamp: false
           variant: ccache
           evict-old-files: 14d
 

--- a/.github/workflows/unsloth-prebuilt-cuda-windows.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda-windows.yml
@@ -81,8 +81,7 @@ jobs:
             cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}
           append-timestamp: false
           variant: ccache
-          evict-old-files: 14d
-          max-size: 2G
+          save: false
 
       - uses: actions/setup-python@v6
         with:
@@ -231,3 +230,13 @@ jobs:
           name: app-${{ inputs.tag }}-windows-x64-${{ matrix.profile }}
           path: dist/app-${{ inputs.tag }}-windows-x64-${{ matrix.profile }}.zip
           if-no-files-found: error
+
+      - name: Evict stale ccache files
+        continue-on-error: true
+        run: ccache --evict-older-than 14d
+
+      - name: Save ccache
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ github.workspace }}\.ccache
+          key: ccache-cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-${{ inputs.tag }}-

--- a/.github/workflows/unsloth-prebuilt-cuda-windows.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda-windows.yml
@@ -82,6 +82,7 @@ jobs:
           append-timestamp: false
           variant: ccache
           evict-old-files: 14d
+          max-size: 2G
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/unsloth-prebuilt-cuda.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda.yml
@@ -100,8 +100,7 @@ jobs:
             cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}
           append-timestamp: false
           variant: ccache
-          evict-old-files: 14d
-          max-size: 2G
+          save: false
 
       # Jimver has no mapping for CUDA 13.3 yet, so for that version we pull the
       # toolkit components straight from NVIDIA's redist CDN (same source Jimver
@@ -254,3 +253,13 @@ jobs:
           name: app-${{ inputs.tag }}-linux-${{ matrix.arch }}-${{ matrix.profile }}
           path: dist/app-${{ inputs.tag }}-linux-${{ matrix.arch }}-${{ matrix.profile }}.tar.gz
           if-no-files-found: error
+
+      - name: Evict stale ccache files
+        continue-on-error: true
+        run: ccache --evict-older-than 14d
+
+      - name: Save ccache
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ github.workspace }}/.ccache
+          key: ccache-cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ inputs.tag }}-

--- a/.github/workflows/unsloth-prebuilt-cuda.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda.yml
@@ -95,7 +95,10 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.20
         with:
-          key: cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}
+          key: cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ inputs.tag }}
+          restore-keys: |
+            cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}
+          append-timestamp: false
           variant: ccache
           evict-old-files: 14d
 

--- a/.github/workflows/unsloth-prebuilt-cuda.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda.yml
@@ -101,6 +101,7 @@ jobs:
           append-timestamp: false
           variant: ccache
           evict-old-files: 14d
+          max-size: 2G
 
       # Jimver has no mapping for CUDA 13.3 yet, so for that version we pull the
       # toolkit components straight from NVIDIA's redist CDN (same source Jimver

--- a/.github/workflows/unsloth-prebuilt-vulkan.yml
+++ b/.github/workflows/unsloth-prebuilt-vulkan.yml
@@ -75,7 +75,10 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.20
         with:
-          key: vulkan-linux-x64
+          key: vulkan-linux-x64-${{ inputs.tag }}
+          restore-keys: |
+            vulkan-linux-x64
+          append-timestamp: false
           variant: ccache
           evict-old-files: 14d
 
@@ -177,7 +180,10 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.20
         with:
-          key: vulkan-windows-x64
+          key: vulkan-windows-x64-${{ inputs.tag }}
+          restore-keys: |
+            vulkan-windows-x64
+          append-timestamp: false
           variant: ccache
           evict-old-files: 14d
 

--- a/.github/workflows/unsloth-prebuilt-vulkan.yml
+++ b/.github/workflows/unsloth-prebuilt-vulkan.yml
@@ -80,7 +80,7 @@ jobs:
             vulkan-linux-x64
           append-timestamp: false
           variant: ccache
-          evict-old-files: 14d
+          save: false
 
       - name: Configure
         working-directory: src
@@ -154,6 +154,16 @@ jobs:
           path: dist/app-${{ inputs.tag }}-linux-x64-vulkan.tar.gz
           if-no-files-found: error
 
+      - name: Evict stale ccache files
+        continue-on-error: true
+        run: ccache --evict-older-than 14d
+
+      - name: Save ccache
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ github.workspace }}/.ccache
+          key: ccache-vulkan-linux-x64-${{ inputs.tag }}-
+
   build-windows:
     name: windows/x64
     runs-on: windows-2022
@@ -185,7 +195,7 @@ jobs:
             vulkan-windows-x64
           append-timestamp: false
           variant: ccache
-          evict-old-files: 14d
+          save: false
 
       - name: Install Ninja
         run: choco install ninja --no-progress
@@ -274,3 +284,13 @@ jobs:
           name: app-${{ inputs.tag }}-windows-x64-vulkan
           path: dist/app-${{ inputs.tag }}-windows-x64-vulkan.zip
           if-no-files-found: error
+
+      - name: Evict stale ccache files
+        continue-on-error: true
+        run: ccache --evict-older-than 14d
+
+      - name: Save ccache
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ github.workspace }}\.ccache
+          key: ccache-vulkan-windows-x64-${{ inputs.tag }}-


### PR DESCRIPTION
Prebuilt jobs normally finish in about 20-25 minutes with a warm ccache, but can take 2-3 hours after their cache is evicted.

The eviction is caused by workflow reruns. GitHub limits cache storage to 10 GB per repository, and the current timestamped keys make every rerun save a new set of 21 cache entries. A few reruns can fill the repository and evict the large CUDA caches.

## Change

This PR makes the source tag part of each cache key and disables timestamp appending. As a result:

- A same-tag rerun restores the exact cache and cannot create a duplicate.
- A new tag can start from the latest compatible cache through a prefix match.
- A cache is saved only after a successful build, so failed builds cannot publish partial results.

This applies to the CUDA, CUDA Windows, CPU, and Vulkan workflows. ROCm and macOS do not use ccache.

## Validation

The b10075 workflow was run twice at the same commit with the same 500 MB ccache limit. The first run had to start from an older b10043 cache and then saved the completed b10075 cache. The second run restored that exact b10075 cache.

| `cuda12-portable` | [First b10075 run](https://github.com/oobabooga/llama.cpp/actions/runs/29833020240) | [Same-tag rerun](https://github.com/oobabooga/llama.cpp/actions/runs/29853922544) |
|---|---:|---:|
| Linux | 2h02m, 5.5% cache hits | 25m02s, 90.8% cache hits |
| Windows | 3h19m, 9.4% cache hits | 21m14s, 92.9% cache hits |

After the rerun, b10075 still had exactly 21 cache entries totaling about 6.0 GiB. The rerun restored the fast path without adding another cache generation.
