### PR TITLE
Repin PR #25731 to current head after force-push

### DIFF
--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -11,6 +11,6 @@
   "prs": [
     "https://github.com/ggml-org/llama.cpp/pull/24423/commits/c3fb97241295c196e09b783e705e84b96cd1bd74",
     "https://github.com/ggml-org/llama.cpp/pull/24523/commits/66f43aa655a07999c7746fe9ff5ede94835e921e",
-    "https://github.com/ggml-org/llama.cpp/pull/25731/commits/a015409e6c27b84f60d688823d4c0126a11571fd"
+    "https://github.com/ggml-org/llama.cpp/pull/25731/commits/ce16fff2ad1d1ddfb39365fedfb4fcfd6db178f1"
   ]
 }


### PR DESCRIPTION
The `add-inkling` branch (ggml-org/llama.cpp#25731) was force-pushed, so the pinned commit `a015409e` is no longer part of that PR's commit list. The nightly prebuilt's Resolve tag step verifies each pin is a commit of its PR, so it refuses `a015409e` and aborts the whole matrix:

```
refusing ggml-org/llama.cpp#25731: pinned commit a015409e... is not a commit of that PR (wrong paste, or force-pushed away); fix the pin in scripts/unsloth/pr-set.json
```

This repins the entry to the PR's current head `ce16fff2`. The other two pins (#24423, #24523) are unaffected.

Failed run: https://github.com/unslothai/llama.cpp/actions/runs/29660981114/job/88123469005