### PR TITLE
Prebuilt: drop the stale GGML_METAL_USE_BF16 define

### DIFF
--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -328,7 +328,7 @@ jobs:
           # pins 13.3 (matches upstream's Intel leg, covers 2017 Intel Macs
           # capped at Ventura).
           MACOS_INCLUDE='[
-            {"build":"arm64","runner":"macos-26",      "expect_arch":"arm64", "deploy_target":"14.0","defines":"-DGGML_METAL_USE_BF16=ON -DGGML_METAL_EMBED_LIBRARY=ON"},
+            {"build":"arm64","runner":"macos-26",      "expect_arch":"arm64", "deploy_target":"14.0","defines":"-DGGML_METAL_EMBED_LIBRARY=ON"},
             {"build":"x64",  "runner":"macos-15-intel","expect_arch":"x86_64","deploy_target":"13.3","defines":"-DGGML_METAL=OFF"}
           ]'
           MACOS_INCLUDE="$(echo "$MACOS_INCLUDE" | jq -c .)"

--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -11,6 +11,7 @@
   "prs": [
     "https://github.com/ggml-org/llama.cpp/pull/24423/commits/c3fb97241295c196e09b783e705e84b96cd1bd74",
     "https://github.com/ggml-org/llama.cpp/pull/24523/commits/66f43aa655a07999c7746fe9ff5ede94835e921e",
-    "https://github.com/ggml-org/llama.cpp/pull/25731/commits/ce16fff2ad1d1ddfb39365fedfb4fcfd6db178f1"
+    "https://github.com/ggml-org/llama.cpp/pull/25731/commits/ce16fff2ad1d1ddfb39365fedfb4fcfd6db178f1",
+    "https://github.com/unslothai/llama.cpp/pull/37/commits/c417c7f2fd98e29048c4bdfd9482e759c11acfd2"
   ]
 }

--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -11,7 +11,6 @@
   "prs": [
     "https://github.com/ggml-org/llama.cpp/pull/24423/commits/c3fb97241295c196e09b783e705e84b96cd1bd74",
     "https://github.com/ggml-org/llama.cpp/pull/24523/commits/66f43aa655a07999c7746fe9ff5ede94835e921e",
-    "https://github.com/ggml-org/llama.cpp/pull/25731/commits/ce16fff2ad1d1ddfb39365fedfb4fcfd6db178f1",
-    "https://github.com/unslothai/llama.cpp/pull/37/commits/c417c7f2fd98e29048c4bdfd9482e759c11acfd2"
+    "https://github.com/ggml-org/llama.cpp/pull/25731/commits/ce16fff2ad1d1ddfb39365fedfb4fcfd6db178f1"
   ]
 }


### PR DESCRIPTION
## Summary

Removes the stale `-DGGML_METAL_USE_BF16=ON` define from the macOS arm64 prebuilt matrix.

The option no longer exists in the current source tree: bf16 support is runtime-probed by ggml (`has_bfloat` via `supportsFamily:` checks in `ggml-metal-device.m`, with the `GGML_METAL_BF16_DISABLE` env override). Passing the define was a no-op CMake cache variable, so this changes nothing in the produced binaries; it only stops passing a flag CMake ignores.

## Not included

The macOS 14 paravirtual mmap fix (PR #37) is intentionally not pinned here; whether to carry that patch is a separate decision. Until then, macOS 14 virtual machines (GitHub macos-14 runners) keep the known mmap staleness quirk with large models; bare metal Macs are unaffected.

## Verification

- Grepping the current build tree for GGML_METAL_USE_BF16 returns nothing outside this workflow line.
- The candidate build from run 29926603382 (which included this removal) passed the minos load gate and produced correct output on the macos-14/15/26 staging checks.
