### PR TITLE
Prebuilt: refresh stale PR pins for #24523 and #25731

### DIFF
--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -10,7 +10,7 @@
   ],
   "prs": [
     "https://github.com/ggml-org/llama.cpp/pull/24423/commits/c3fb97241295c196e09b783e705e84b96cd1bd74",
-    "https://github.com/ggml-org/llama.cpp/pull/24523/commits/66f43aa655a07999c7746fe9ff5ede94835e921e",
-    "https://github.com/ggml-org/llama.cpp/pull/25731/commits/ce16fff2ad1d1ddfb39365fedfb4fcfd6db178f1"
+    "https://github.com/ggml-org/llama.cpp/pull/24523/commits/a58a7fa6e89f9564f78caaf1f858c810c070b216",
+    "https://github.com/ggml-org/llama.cpp/pull/25731/commits/453c43816eacc18a6d69dcc4d7fab2966c6951c8"
   ]
 }


### PR DESCRIPTION
The nightly full release build fails while resolving the PR set:

```
ggml-org/llama.cpp#24523 (66f43aa655a07999c7746fe9ff5ede94835e921e) does not merge
cleanly onto b10107 + the PRs listed before it; reorder or drop it in
scripts/unsloth/pr-set.json
```

Both of the last two pins were stale. Verified by replaying the merge sequence locally against the real bases.

## #24523 (MiniMax-M3)

Pinned to `66f43aa6`, which was not even the PR head at the time. The resolver logged this itself:

```
note: ggml-org/llama.cpp#24523 is pinned to 66f43aa65... but its head has moved to 0b78558a6...
```

That commit conflicts in `common/chat.cpp` against both `b10107` and `b10133`. The PR has since been rebased onto current master, so this repins to its new head `a58a7fa6`, which merges cleanly.

## #25731 (TML Inkling)

Pinned to `ce16fff2`, which conflicts on its own onto `b10133` in `ggml/src/ggml-cuda/mmq.cuh`, `src/llama-model-saver.cpp` and `src/llama-vocab.h`. This never appeared in the log because the resolver stops at the first failing entry, which was #24523. Its current head `453c4381` merges cleanly by itself.

## Result

```
base b10133
  OK        #24423 @ c3fb97241
  OK        #24523 @ a58a7fa6e
  CONFLICT  #25731 @ 453c43816   common/chat.cpp, src/llama-arch.h
```

## Known remaining conflict

#24523 and #25731 conflict with each other. Both append a new `llm_arch` value immediately before `LLM_ARCH_UNKNOWN` (`LLM_ARCH_MINIMAX_M3` and `LLM_ARCH_INKLING`) and both add a chat parser in the same region of `common/chat.cpp`.

Reordering does not help, since whichever entry is applied second hits the identical conflict:

```
24423 + 24523 + 25731  ->  OK, OK, CONFLICT
24423 + 25731 + 24523  ->  OK, OK, CONFLICT
```

So this PR does not make the nightly green on its own. It fixes the two stale pins and moves the failure from #24523 to #25731. Deciding which of the two to carry is a separate call.

## Base requirement

The rebased #24523 needs a base of `b10133` or newer. `b10107` predates the rename of `common_chat_params::thinking_end_tag` to `thinking_end_tags`, which the rebased branch depends on. `b10133` is the first tag containing that rename, and the resolver picks the newest release aged at least 6h, so this is satisfied from today onward.