### PR TITLE
Prebuilt: finish the PR set repin

### DIFF
--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -10,7 +10,7 @@
   ],
   "prs": [
     "https://github.com/ggml-org/llama.cpp/pull/24423/commits/c3fb97241295c196e09b783e705e84b96cd1bd74",
-    "https://github.com/ggml-org/llama.cpp/pull/24523/commits/a58a7fa6e89f9564f78caaf1f858c810c070b216",
-    "https://github.com/ggml-org/llama.cpp/pull/25731/commits/453c43816eacc18a6d69dcc4d7fab2966c6951c8"
+    "https://github.com/ggml-org/llama.cpp/pull/24523/commits/baee0f5b24ec8ceac109ecf07988cb5440c03a6d",
+    "https://github.com/unslothai/llama.cpp/pull/40/commits/233cedbe9c37df1c9ca7b11634c580e45974b046"
   ]
 }


### PR DESCRIPTION
Follow-up to #39, which landed only the first of three commits, so master still pins commits that have since moved on and that conflict with each other.

Master today:

```
24523 @ a58a7fa6e   force-pushed away since
25731 @ 453c43816   superseded, and conflicts with 24523
```

## What changed on the two upstream PRs

**ggml-org/llama.cpp#24523** now places `LLM_ARCH_MINIMAX_M3` next to `LLM_ARCH_MINIMAX_M2` instead of at the tail of the enum, matching how `llama-arch.cpp` already groups the name table. That removes the `src/llama-arch.h` half of its collision with #25731, which appends `LLM_ARCH_INKLING` at the tail. New head `baee0f5b2`.

**ggml-org/llama.cpp#25731** has picked up current master and the `thinking_end_tags` rename, so it now builds on its own against `b10133` and newer. It previously did not: upstream 910196f6b renamed `common_chat_params::thinking_end_tag` to a vector, and that PR still assigned the old scalar.

## What #40 still carries

Only the `common/chat.cpp` half. Both PRs add a chat parser and a detection block in the same region, immediately before `namespace workaround {`. Unlike the enum, there is no principled alternative anchor: `chat.cpp` has no MiniMax-M2 parser for MiniMax-M3 to sit beside, so relocating one would be arbitrary and would break again on the next upstream edit near it.

## Verification

Replaying the resolver sequence on `b10133`:

```
OK  ggml-org #24423    @ c3fb97241
OK  ggml-org #24523    @ baee0f5b2
OK  unslothai #40      @ 233cedbe9
```

All three pins pass the membership check (21, 5 and 5 commits respectively, all under the 250 cap, each pin equal to its PR head). The merged tree is API-consistent: `chat.h` declares `thinking_end_tags`, and no scalar assignment remains.

`llama`, `llama-common`, `test-llama-archs` and `test-chat` build against the merged tree with zero errors. `test-chat` passes; `test-llama-archs` exits 0 with `minimax-m3` at 0.00e+00.

Drop the #40 entry and repin #25731 upstream once either PR lands.