### PR TITLE
GPU prebuilts: add a Linux arm64 Vulkan bundle

### DIFF
--- a/.github/workflows/unsloth-prebuilt-vulkan.yml
+++ b/.github/workflows/unsloth-prebuilt-vulkan.yml
@@ -17,6 +17,8 @@ name: "Unsloth prebuilt: Vulkan"
 # The Vulkan loader (libvulkan.so.1 / vulkan-1.dll) is a system/driver library
 # resolved by the OS at runtime, so -- like llama-cpp-binaries -- it is not
 # bundled; only ggml's own libggml-vulkan backend module ships in the archive.
+# Both Linux legs use ubuntu-22.04 to keep a glibc 2.35 / GLIBCXX <= 3.4.30
+# floor. The arm64 leg supplies newer header-only SDK pieces at build time.
 
 on:
   workflow_call:
@@ -46,14 +48,13 @@ env:
 jobs:
   build-linux:
     name: linux/${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
     strategy:
+      fail-fast: false
       matrix:
         include:
-          - arch: x64
-            runner: ubuntu-22.04
-          - arch: arm64
-            runner: ubuntu-24.04-arm
-    runs-on: ${{ matrix.runner }}
+          - { arch: x64,   runner: ubuntu-22.04 }
+          - { arch: arm64, runner: ubuntu-22.04-arm }
     steps:
       # The parent's resolve job built the source tree (upstream base + any mix
       # PRs, with the build number/commit and Unsloth fingerprint baked
@@ -81,10 +82,22 @@ jobs:
             sudo apt-get install -y build-essential mesa-vulkan-drivers vulkan-sdk libssl-dev ninja-build
           else
             sudo apt-get update -y
-            sudo apt-get install -y gcc-14 g++-14 build-essential glslc libvulkan-dev spirv-headers libssl-dev ninja-build
-            echo "CC=gcc-14" >> "$GITHUB_ENV"
-            echo "CXX=g++-14" >> "$GITHUB_ENV"
+            sudo apt-get install -y build-essential libvulkan-dev spirv-headers libssl-dev ninja-build
           fi
+
+      # Match the CPU arm64 leg so the bundle retains Jammy's loader and
+      # libstdc++ floors. Jammy's gcc cannot target armv9.2-a+sme.
+      - name: Toolchain (clang 19 on arm64)
+        if: matrix.arch == 'arm64'
+        run: |
+          set -eux
+          wget -q https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 19
+          {
+            echo "CC=clang-19"
+            echo "CXX=clang++-19"
+          } >> "$GITHUB_ENV"
 
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.20
@@ -95,6 +108,45 @@ jobs:
           append-timestamp: false
           variant: ccache
           save: false
+
+      # Ubuntu 22.04 has an arm64 Vulkan loader, but its headers are too old for
+      # the current backend and it has no glslc package. Install matching pinned
+      # headers and build the shader compiler shipped with the LunarG SDK.
+      - name: Install Vulkan headers (arm64)
+        if: matrix.arch == 'arm64'
+        run: |
+          set -eux
+          package="$RUNNER_TEMP/vulkan-headers.deb"
+          staging="$RUNNER_TEMP/vulkan-headers"
+          curl -fsSL \
+            "https://packages.lunarg.com/vulkan/pool/main/v/vulkan-headers/vulkan-headers_1.4.313.0~rc1-1lunarg22.04-1_all.deb" \
+            -o "$package"
+          echo "587b2d8e79416b394170ab61557c98765570cd153730f819a917866d78f45e1a  $package" | sha256sum -c -
+          dpkg-deb -x "$package" "$staging"
+          sudo cp -a "$staging/usr/." /usr/local/
+
+      - name: Build glslc (arm64)
+        if: matrix.arch == 'arm64'
+        run: |
+          set -eux
+          archive="$RUNNER_TEMP/shaderc.tar.gz"
+          source="$RUNNER_TEMP/shaderc"
+          curl -fsSL \
+            "https://packages.lunarg.com/vulkan/pool/main/s/shaderc/shaderc_2025.2~rc1-1lunarg22.04.orig.tar.gz" \
+            -o "$archive"
+          echo "59c0c478f2f40a076e610587d099e39ed059cb7319fe464f8ba1bd07c6bf02c5  $archive" | sha256sum -c -
+          mkdir -p "$source"
+          tar -xzf "$archive" -C "$source"
+          cmake -S "$source" -B "$source/build" -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DSHADERC_SKIP_TESTS=ON \
+            -DSHADERC_SKIP_EXAMPLES=ON \
+            -DSHADERC_SKIP_COPYRIGHT_CHECK=ON \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          cmake --build "$source/build" --target glslc_exe -j "$(nproc)"
+          sudo install -m 0755 "$source/build/glslc/glslc" /usr/local/bin/glslc
+          glslc --version
 
       - name: Configure
         working-directory: src

--- a/.github/workflows/unsloth-prebuilt-vulkan.yml
+++ b/.github/workflows/unsloth-prebuilt-vulkan.yml
@@ -4,12 +4,12 @@
 name: "Unsloth prebuilt: Vulkan"
 
 # Reusable child of unsloth-prebuilt.yml. Builds the Vulkan bundles for
-# Linux x64 + Windows x64. Each job uploads a single app-*.{tar.gz|zip}
-# artifact for the parent's assemble step to pick up.
+# Linux x64/arm64 + Windows x64. Each matrix entry uploads a single
+# app-*.{tar.gz|zip} artifact for the parent's assemble step to pick up.
 #
 # Mirrors oobabooga/llama-cpp-binaries' build-wheels-vulkan.yml build recipe
 # (the CPU recipe plus GGML_VULKAN=ON and a Vulkan SDK install), adapted to
-# this repo's conventions: app-<tag>-<platform>-x64-vulkan archives packaged
+# this repo's conventions: app-<tag>-<platform>-<arch>-vulkan archives packaged
 # straight from build/bin like the ROCm/macOS children (no embedded
 # UNSLOTH_PREBUILT_INFO.json -- assemble_metadata.py derives the manifest entry
 # from the filename), MSVC + BoringSSL on Windows, $ORIGIN RPATH on Linux.
@@ -45,8 +45,15 @@ env:
 
 jobs:
   build-linux:
-    name: linux/x64
-    runs-on: ubuntu-22.04
+    name: linux/${{ matrix.arch }}
+    strategy:
+      matrix:
+        include:
+          - arch: x64
+            runner: ubuntu-22.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
       # The parent's resolve job built the source tree (upstream base + any mix
       # PRs, with the build number/commit and Unsloth fingerprint baked
@@ -67,17 +74,24 @@ jobs:
       - name: Install Vulkan SDK + build dependencies
         run: |
           set -eux
-          wget -qO - https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo apt-key add -
-          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-jammy.list https://packages.lunarg.com/vulkan/lunarg-vulkan-jammy.list
-          sudo apt-get update -y
-          sudo apt-get install -y build-essential mesa-vulkan-drivers vulkan-sdk libssl-dev ninja-build
+          if [ "${{ matrix.arch }}" = x64 ]; then
+            wget -qO - https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo apt-key add -
+            sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-jammy.list https://packages.lunarg.com/vulkan/lunarg-vulkan-jammy.list
+            sudo apt-get update -y
+            sudo apt-get install -y build-essential mesa-vulkan-drivers vulkan-sdk libssl-dev ninja-build
+          else
+            sudo apt-get update -y
+            sudo apt-get install -y gcc-14 g++-14 build-essential glslc libvulkan-dev spirv-headers libssl-dev ninja-build
+            echo "CC=gcc-14" >> "$GITHUB_ENV"
+            echo "CXX=g++-14" >> "$GITHUB_ENV"
+          fi
 
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.20
         with:
-          key: vulkan-linux-x64-${{ inputs.tag }}
+          key: vulkan-linux-${{ matrix.arch }}-${{ inputs.tag }}
           restore-keys: |
-            vulkan-linux-x64
+            vulkan-linux-${{ matrix.arch }}
           append-timestamp: false
           variant: ccache
           save: false
@@ -141,7 +155,7 @@ jobs:
       - name: Package bundle (tar.gz)
         run: |
           set -eux
-          ASSET="app-${{ inputs.tag }}-linux-x64-vulkan.tar.gz"
+          ASSET="app-${{ inputs.tag }}-linux-${{ matrix.arch }}-vulkan.tar.gz"
           cp src/LICENSE src/build/bin/
           mkdir -p dist
           (cd src/build/bin && tar -czf "${GITHUB_WORKSPACE}/dist/${ASSET}" .)
@@ -150,8 +164,8 @@ jobs:
       - name: Upload bundle artifact
         uses: actions/upload-artifact@v6
         with:
-          name: app-${{ inputs.tag }}-linux-x64-vulkan
-          path: dist/app-${{ inputs.tag }}-linux-x64-vulkan.tar.gz
+          name: app-${{ inputs.tag }}-linux-${{ matrix.arch }}-vulkan
+          path: dist/app-${{ inputs.tag }}-linux-${{ matrix.arch }}-vulkan.tar.gz
           if-no-files-found: error
 
       - name: Evict stale ccache files
@@ -162,7 +176,7 @@ jobs:
         uses: actions/cache/save@v6
         with:
           path: ${{ github.workspace }}/.ccache
-          key: ccache-vulkan-linux-x64-${{ inputs.tag }}-
+          key: ccache-vulkan-linux-${{ matrix.arch }}-${{ inputs.tag }}-
 
   build-windows:
     name: windows/x64

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -11,7 +11,7 @@ name: Unsloth prebuilt (full release)
 #   unsloth-prebuilt-rocm.yml          -- ROCm bundles (Windows + Ubuntu, per gfx target)
 #   unsloth-prebuilt-macos.yml         -- macOS bundles (arm64 Metal + x64 CPU)
 #   unsloth-prebuilt-cpu.yml           -- CPU-only bundles (Linux + Windows, x64 + arm64)
-#   unsloth-prebuilt-vulkan.yml        -- Vulkan bundles (Linux + Windows, x64)
+#   unsloth-prebuilt-vulkan.yml        -- Vulkan bundles (Linux x64/arm64 + Windows x64)
 #
 # Atomicity: the `assemble` job depends on all children. GitHub's default
 # `needs` semantics require all needs to succeed -- if any matrix entry in
@@ -578,6 +578,7 @@ jobs:
             "app-${TAG}-linux-arm64-cpu.tar.gz" \
             "app-${TAG}-windows-arm64-cpu.zip" \
             "app-${TAG}-linux-x64-vulkan.tar.gz" \
+            "app-${TAG}-linux-arm64-vulkan.tar.gz" \
             "app-${TAG}-windows-x64-vulkan.zip"; do
             [ -s "dist/$f" ] || { echo "ERROR: missing $f in dist/" >&2; fail=1; }
           done

--- a/scripts/unsloth/assemble_metadata.py
+++ b/scripts/unsloth/assemble_metadata.py
@@ -6,8 +6,9 @@
 Produces, matching the schema consumed by unslothai/unsloth's installer:
   - llama-prebuilt-manifest.json : describes every locally-built bundle in this
     release (CUDA x64/arm64 profiles + ROCm Linux/Windows per gfx target +
-    macOS arm64/x64 + CPU Linux/Windows x64+arm64 + Vulkan Linux/Windows x64),
-    with the dispatch metadata the installer needs to pick the right one.
+    macOS arm64/x64 + CPU Linux/Windows x64+arm64 + Vulkan Linux x64/arm64 and
+    Windows x64), with the dispatch metadata the installer needs to pick the
+    right one.
   - llama-prebuilt-sha256.json   : a cross-OS integrity index covering both the
     locally-built bundles AND the upstream ggml-org assets the installer still
     pulls (arm64 CPU + the Windows CUDA cudart/runtime) + the source tarballs.
@@ -44,14 +45,14 @@ ROCM_BUNDLE_RE = re.compile(
 # CPU-only and Vulkan bundles, built locally by unsloth-prebuilt-cpu.yml /
 # unsloth-prebuilt-vulkan.yml. Like ROCm/macOS they are raw build/bin archives
 # with no embedded UNSLOTH_PREBUILT_INFO.json, so everything in the manifest
-# entry is derived from the filename. CPU covers x64 + arm64 (the arm64 slices
-# supersede the upstream ggml-org CPU passthroughs); Vulkan is x64-only.
+# entry is derived from the filename. CPU covers Linux/Windows x64 + arm64;
+# Vulkan covers Linux x64 + arm64 and Windows x64.
 CPU_BUNDLE_RE = re.compile(
     r"^app-(?P<tag>[^/]+)-(?P<platform>linux|windows)-(?P<arch>x64|arm64)-cpu\.(?P<ext>tar\.gz|zip)$"
 )
 
 VULKAN_BUNDLE_RE = re.compile(
-    r"^app-(?P<tag>[^/]+)-(?P<platform>linux|windows)-x64-vulkan\.(?P<ext>tar\.gz|zip)$"
+    r"^app-(?P<tag>[^/]+)-(?P<target>linux-(?:x64|arm64)|windows-x64)-vulkan\.(?P<ext>tar\.gz|zip)$"
 )
 
 # macOS slices are built by unsloth-prebuilt-macos.yml and land in dist/ under
@@ -90,9 +91,10 @@ KIND_BY_CPU = {
     ("windows", "arm64"): {"manifest": "windows-arm64", "sha": "windows-arm64-app"},
 }
 
-KIND_BY_VULKAN_PLATFORM = {
-    "linux":   {"manifest": "linux-vulkan",   "sha": "linux-vulkan-app"},
-    "windows": {"manifest": "windows-vulkan", "sha": "windows-vulkan-app"},
+KIND_BY_VULKAN_TARGET = {
+    "linux-x64":   {"manifest": "linux-vulkan",       "sha": "linux-vulkan-app"},
+    "linux-arm64": {"manifest": "linux-vulkan",       "sha": "linux-arm64-vulkan-app"},
+    "windows-x64": {"manifest": "windows-vulkan",     "sha": "windows-vulkan-app"},
 }
 
 # macOS slices: install_kind / sha-index kind / manifest bundle_profile per arch.
@@ -217,7 +219,7 @@ def build_artifacts(
     rocm_bundles:    list of (asset_name, platform, gfx_target).
     macos_bundles:   list of (asset_name, arch).
     cpu_bundles:     list of (asset_name, platform, arch).
-    vulkan_bundles:  list of (asset_name, platform).
+    vulkan_bundles:  list of (asset_name, target).
 
     CUDA fields come from each bundle's own embedded metadata, so the manifest
     can never disagree with what was actually compiled. ROCm, macOS, CPU and
@@ -271,11 +273,12 @@ def build_artifacts(
             "coverage_class": None,
             "rank": 1000,
         })
-    for asset_name, platform in vulkan_bundles:
+    for asset_name, target in vulkan_bundles:
+        platform, arch = target.rsplit("-", 1)
         artifacts.append({
             "asset_name": asset_name,
-            "install_kind": KIND_BY_VULKAN_PLATFORM[platform]["manifest"],
-            "bundle_profile": f"{platform}-vulkan-x64",
+            "install_kind": KIND_BY_VULKAN_TARGET[target]["manifest"],
+            "bundle_profile": f"{platform}-vulkan-{arch}",
             "runtime_line": None,
             "coverage_class": None,
             "rank": 60,
@@ -403,19 +406,21 @@ def main() -> int:
     else:
         print("WARNING: no app-*-cpu.{tar.gz,zip} bundles found", file=sys.stderr)
 
-    vulkan_found = [(name, m.group("platform")) for name, m in scan_bundles(VULKAN_BUNDLE_RE)]
+    vulkan_found = [(name, m.group("target")) for name, m in scan_bundles(VULKAN_BUNDLE_RE)]
     if vulkan_found:
         with ThreadPoolExecutor(max_workers=4) as pool:
             vulkan_digests = list(pool.map(lambda b: sha256_file(args.dist / b[0]), vulkan_found))
-        for (name, platform), digest in zip(vulkan_found, vulkan_digests):
-            sha_artifacts[name] = base_entry(KIND_BY_VULKAN_PLATFORM[platform]["sha"], args.publish_repo, digest)
+        for (name, target), digest in zip(vulkan_found, vulkan_digests):
+            sha_artifacts[name] = base_entry(
+                KIND_BY_VULKAN_TARGET[target]["sha"], args.publish_repo, digest
+            )
     else:
         print("WARNING: no app-*-vulkan.{tar.gz,zip} bundles found", file=sys.stderr)
 
     # 2) upstream per-OS bundles: read GitHub's published asset.digest from the
     #    API response; fall back to a streaming hash if a digest is missing.
-    #    macOS + x64 CPU/Vulkan are absent here on purpose -- we build those
-    #    ourselves (1c/1d).
+    #    macOS and the locally-built CPU/Vulkan slices are absent here on
+    #    purpose -- we build those ourselves (1c/1d).
     #    A mix build has no upstream release for its tag, so the whole section
     #    is skipped; its uncovered hosts fall back to a source build of the
     #    merged tree instead of a vanilla upstream binary missing the PRs.
@@ -437,10 +442,10 @@ def main() -> int:
                 rf"llama-{re.escape(tag)}-bin-win-cuda-\d+\.\d+-x64\.zip", name
             ):
                 wanted.append((name, "windows-cuda-upstream"))
-        # x64 CPU + Vulkan are no longer passthroughs -- we build them ourselves
-        # (sections 1d above). arm64 CPU is now built too (1d emits the
-        # locally-built linux-arm64/windows-arm64 bundles), but the installer
-        # still selects the upstream arm64 asset until it is switched over to
+        # x64 CPU and all current Vulkan targets are no longer passthroughs --
+        # we build them ourselves (section 1d above). arm64 CPU is now built too
+        # (1d emits the locally-built linux-arm64/windows-arm64 bundles), but the
+        # installer still selects the upstream arm64 asset until it is switched to
         # those bundles; keep these passthrough checksums until that installer
         # flip lands, then drop them.
         for name, kind in (


### PR DESCRIPTION
The Vulkan prebuilt workflow published Linux x64 and Windows x64 bundles, while upstream also publishes Linux arm64. Fork releases therefore had no Vulkan artifact for Linux arm64 hosts.

## Fix

- build Linux Vulkan bundles as an x64/arm64 matrix
- use the upstream Ubuntu 24.04 ARM runner, GCC 14, and Vulkan package set
- keep cache keys and artifact names architecture-specific
- require the Linux arm64 archive before publishing a release
- include the new target in the manifest and checksum index with an architecture-specific profile

Windows remains x64-only, matching upstream.

## Verification

- The [full compilation run](https://github.com/oobabooga/llama.cpp/actions/runs/30381289880) successfully built and packaged the [Linux x64](https://github.com/oobabooga/llama.cpp/actions/runs/30381289880/job/90349579936), [Linux arm64](https://github.com/oobabooga/llama.cpp/actions/runs/30381289880/job/90349579910), and [Windows x64](https://github.com/oobabooga/llama.cpp/actions/runs/30381289880/job/90349579928) Vulkan bundles.
- A separate [runtime verification run](https://github.com/oobabooga/llama.cpp/actions/runs/30394289367) downloaded those exact bundles and exercised them on Linux x64, native Linux arm64 with `ubuntu-22.04-arm`, and Windows x64 runners.
- Each bundle started `llama-server`, loaded SmolLM2-135M-Instruct Q4_K_M, offloaded all 31 layers through Vulkan, allocated Vulkan model and KV buffers, and returned two chat completions.
- GitHub Actions workflow lint and YAML parsing passed.
- `ruff check scripts/unsloth/assemble_metadata.py`
- Focused metadata checks covered Linux x64, Linux arm64, and Windows x64, and rejected Windows arm64.
- End-to-end metadata assembly produced the expected Linux arm64 manifest and checksum entries.
- `git diff --check`
