### PR TITLE
Prebuilt: drop the MiniMax-M3 and Inkling pins from the PR set

### DIFF
--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -9,8 +9,6 @@
     "tag + pins), so keep its pin open until the change lands upstream."
   ],
   "prs": [
-    "https://github.com/ggml-org/llama.cpp/pull/24423/commits/c3fb97241295c196e09b783e705e84b96cd1bd74",
-    "https://github.com/ggml-org/llama.cpp/pull/24523/commits/baee0f5b24ec8ceac109ecf07988cb5440c03a6d",
-    "https://github.com/unslothai/llama.cpp/pull/40/commits/233cedbe9c37df1c9ca7b11634c580e45974b046"
+    "https://github.com/ggml-org/llama.cpp/pull/24423/commits/c3fb97241295c196e09b783e705e84b96cd1bd74"
   ]
 }


### PR DESCRIPTION
Drops everything from `pr-set.json` except DiffusionGemma, to get the nightly building again.

## The problem

The nightly full release build has been failing since b10152. The newest published release is still b10107-mix-1911198.

Upstream master now ships its own MiniMax-M3. The `unslothai#40` branch carries a second copy of it, so the two collide and the merge step fails before anything is built.

## The change

Two entries come out.

`ggml-org#24523` (MiniMax-M3) is closed. The resolver already skips closed PRs, so this line has no effect today and is only cleanup.

`unslothai#40` is the entry that actually breaks the build. It existed for one reason: to let #24523 and Inkling sit in the set together, which they could not do otherwise. With #24523 gone that job no longer exists, and the MiniMax-M3 half of the branch now duplicates what upstream ships.

That leaves a single pin:

```
ggml-org #24423 (DiffusionGemma) @ c3fb97241
```

## What this means for Inkling

`ggml-org#25731` was in the set only by way of #40, so it comes out as well.

It cannot just be pinned on its own instead, because its current head does not merge onto master either. Putting it back needs a rebased branch, which is separate work, and pinning it as-is would leave the nightly red for a different reason.

## Verification

Replayed on b10165: the one remaining pin merges cleanly, with no unmerged paths. `pr-set.json` passes the checks in `unsloth-pr-set-lint.yml`.
