### PR TITLE
Prebuilt: repin the PR set on Inkling and Kimi-K3

### DIFF
--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -10,7 +10,8 @@
   ],
   "prs": [
     "https://github.com/ggml-org/llama.cpp/pull/24423/commits/c3fb97241295c196e09b783e705e84b96cd1bd74",
-    "https://github.com/ggml-org/llama.cpp/pull/24523/commits/baee0f5b24ec8ceac109ecf07988cb5440c03a6d",
-    "https://github.com/unslothai/llama.cpp/pull/40/commits/233cedbe9c37df1c9ca7b11634c580e45974b046"
+    "https://github.com/ggml-org/llama.cpp/pull/25731/commits/79ca732e11e9b875f29c6a6cb65150978e6ec014",
+    "https://github.com/unslothai/llama.cpp/pull/44/commits/23fac110127ba3ac56bd8b370eb0205a67564d55",
+    "https://github.com/ggml-org/llama.cpp/pull/26185/commits/cf67f0d24511864d2d3da0769108fd6fc16d00d1"
   ]
 }


### PR DESCRIPTION
Fixes the nightly. Run 30401043818 failed in `Resolve tag` and every build job was skipped:

```
CONFLICT (content): Merge conflict in src/models/models.h
CONFLICT (content): Merge conflict in tests/test-backend-ops.cpp
unslothai/llama.cpp#40 (233cedbe) does not merge cleanly onto b10165 + the PRs listed before it
```

unslothai#40 was a combined branch carrying MiniMax-M3 and Inkling. Upstream master now ships its own MiniMax-M3 (#24908), so #40's copy collides with it. ggml-org#24523 is closed, so that entry was already inert.

## New set

| # | PR | pin |
| - | -- | --- |
| 1 | ggml-org#24423 DiffusionGemma | `c3fb9724` (unchanged) |
| 2 | ggml-org#25731 TML Inkling | `79ca732e` |
| 3 | unslothai#44 Kimi-K3 fixes + MoonViT-3d | `23fac110` |
| 4 | ggml-org#26185 Kimi-K3 text | `cf67f0d2` |

Both #25731 and #44 were `mergeable: false` before this; their conflicts are fixed on their own branches rather than in a fork-side mirror, so the pins point at the real PRs.

- #25731 was cut before MiniMax-M3, Nanbeige4.2, the WebGPU arch-skip rework and the RPC v5 bump landed. All conflicts were add/add collisions at the same insertion point, kept on both sides. The one judgement call is `RPC_PROTO_PATCH_VERSION`: master reset it to 0 when it went to proto 5 at 101 ops, Inkling adds an op, so it is now 1.
- #44 sits on #26185's head, which predates the Parakeet clip graph and the WebGPU skip-list rework. For `tests/test-llama-archs.cpp`, upstream replaced the skip list with DEEPSEEK32/GLM_DSA after fixing the binding alias issues (#25931); KIMI_K3 is appended to that list since upstream never evaluated it.
- #44 also merges #25731. Inkling and Kimi-K3 both register a new arch in `llm_arch_is_hybrid`, `llm_arch_supports_sm_tensor`, `llama_model_mapping`, `llama_model_rope_type` and `tools/mtmd/CMakeLists.txt`, so they cannot go in as two independent heads.

## Ordering

#26185 has to come after #44, not before it. #44 was rebased onto #26185's head, so #26185 is an ancestor and the resolver reports `Already up to date`. Listed before #44 it conflicts on `tests/test-llama-archs.cpp`. It stays in the set so the release manifest names it, but note it is a strict no-op for the build and it is the one entry that can break the nightly for nothing if pwilkin force-pushes the pin away.

## Verification

Replayed the resolver's merge loop locally against b10173 (the tag `latest` resolves to right now), in list order:

```
--- ggml-org#24423   ok
--- ggml-org#25731   ok
--- unslothai#44     ok
--- ggml-org#26185   Already up to date.
FINAL unmerged=[]
```

The merged tree builds clean: `cmake -B build -DGGML_CUDA=OFF -DLLAMA_CURL=OFF -DLLAMA_BUILD_TESTS=ON && cmake --build build -j 28`, exit 0. The lint checks in `unsloth-pr-set-lint.yml` were replayed locally and pass with no errors and no warnings: all four are open, all four pins are commits of their PR, all four pins equal their head.

Supersedes #43, which dropped Inkling along with MiniMax. #40 is no longer pinned.