### PR TITLE
Prebuilt: repin Inkling after merging b10229 into the branch

### DIFF
--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -10,7 +10,7 @@
   ],
   "prs": [
     "https://github.com/ggml-org/llama.cpp/pull/24423/commits/c3fb97241295c196e09b783e705e84b96cd1bd74",
-    "https://github.com/ggml-org/llama.cpp/pull/25731/commits/02142bbc33d477880a89dc5854a2c611d36e3494",
+    "https://github.com/ggml-org/llama.cpp/pull/25731/commits/1e6f9e4a59138004e7936b543464afad71024a74",
     "https://github.com/unslothai/llama.cpp/pull/48/commits/daef2b3e1b5b1ac7b575f13b13a9450cb2d02862",
     "https://github.com/ggml-org/llama.cpp/pull/26185/commits/04d6828b2b555ef300bae8096663c6e675afdd47"
   ]


### PR DESCRIPTION
Last night's schedule ([30767267935](https://github.com/unslothai/llama.cpp/actions/runs/30767267935)) failed in `Resolve tag`:

```
ggml-org/llama.cpp#25731 (02142bbc33d477880a89dc5854a2c611d36e3494) does not merge
cleanly onto b10229 + the PRs listed before it; reorder or drop it in
scripts/unsloth/pr-set.json
```

This is **not** the pin rot that broke 07-31 and 08-01. All four pins passed the membership gate this time, and each was still at its PR head. Straightforward upstream drift instead.

## Cause

Between b10226 and b10229, upstream added `LLM_ARCH_DEEPSEEK4` to the same fallthrough group in `src/llama-arch.cpp` that Inkling registers in:

```c
        case LLM_ARCH_QWEN35:
        case LLM_ARCH_QWEN35MOE:
<<<<<<< HEAD
        case LLM_ARCH_INKLING:
=======
        case LLM_ARCH_DEEPSEEK4:
>>>>>>> b10229
            return true;
```

The resolver merges pins onto the base tag and has no conflict resolution, so it refused. b10225-mix-345e1e3 published fine yesterday because the base was b10225, before `DEEPSEEK4` landed.

## Fix

Resolved on the branch, not here. `b10229` is merged into `add-inkling` and both cases are kept, since both arches belong in that group. That is the last-writer problem this repo keeps hitting: whoever merges second has to know about the first.

The pin moves `02142bbc` -> `1e6f9e4a`. Nothing else changes:

| PR | pin | change |
|---|---|---|
| ggml-org#24423 DiffusionGemma | `c3fb9724` | unchanged |
| ggml-org#25731 Inkling | `1e6f9e4a` | was `02142bbc` |
| unslothai#48 Kimi-K3 fixes + MoonViT-3d | `daef2b3e` | unchanged |
| ggml-org#26185 Kimi-K3 text | `04d6828b` | unchanged |

unslothai#48 needed nothing. It already carries b10223, and `DEEPSEEK4` does not land anywhere Kimi-K3 registers.

Side benefit: ggml-org#25731's own `mergeable` state against master had gone red for exactly this conflict. It is back to `true`.

## Verification

Replayed the resolver's merge sequence against b10229:

```
OK   c3fb972412  (24423)
OK   1e6f9e4a59  (25731, new pin)
OK   daef2b3e1b  (48)
OK   04d6828b2b  (26185)   <- still a no-op
UNMERGED PATHS: 0
```

Merged tree builds clean with `-DGGML_CUDA=ON -DLLAMA_BUILD_TESTS=ON`. `test-chat` passes; `test-llama-archs -a kimi-k3` is OK on CUDA and CPU (NMSE 8.77e-08).

The new Inkling head also `merge-tree`s clean against upstream master, which is six commits past b10229, so tonight's tag should resolve without another repin.