### PR TITLE
Prebuilt: alert on nightly failure and on a stale release

### DIFF
--- a/.github/actions/prebuilt-alert/action.yml
+++ b/.github/actions/prebuilt-alert/action.yml
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+name: Prebuilt failure alert
+description: Open, update or close a deduplicated issue tracking prebuilt pipeline health.
+
+inputs:
+  status:
+    description: 'failure or success'
+    required: true
+  key:
+    description: 'Dedup key; all alerts sharing it collapse onto one issue'
+    required: true
+  title:
+    description: 'Issue title'
+    required: true
+  details:
+    description: 'Markdown describing what broke'
+    required: false
+    default: ''
+  label:
+    description: 'Label applied to the issue'
+    required: false
+    default: 'prebuilt-failure'
+  token:
+    description: 'Token with issues:write'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Open, update or close the tracking issue
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        STATUS: ${{ inputs.status }}
+        KEY: ${{ inputs.key }}
+        TITLE: ${{ inputs.title }}
+        DETAILS: ${{ inputs.details }}
+        LABEL: ${{ inputs.label }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        REPO: ${{ github.repository }}
+      run: |
+        set -uo pipefail
+
+        # Alerting must never fail the run it reports on, so gh calls are tolerated.
+        case "$STATUS" in
+          failure|success) ;;
+          *) echo "::warning::prebuilt-alert: unknown status '$STATUS'"; exit 0 ;;
+        esac
+
+        MARKER="<!-- prebuilt-alert:${KEY} -->"
+
+        # Scan open labelled issues rather than the search index, which lags by
+        # minutes and would double-open on back-to-back runs.
+        EXISTING=""
+        while read -r num; do
+          [ -n "$num" ] || continue
+          if gh issue view "$num" --repo "$REPO" --json body --jq .body 2>/dev/null | grep -qF "$MARKER"; then
+            EXISTING="$num"; break
+          fi
+        done < <(gh issue list --repo "$REPO" --label "$LABEL" --state open \
+                   --limit 100 --json number --jq '.[].number' 2>/dev/null || true)
+
+        if [ "$STATUS" = "success" ]; then
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --repo "$REPO" \
+              --body "Recovered: [\`${GITHUB_WORKFLOW}\` run](${RUN_URL}) succeeded. Closing." >/dev/null 2>&1 || true
+            gh issue close "$EXISTING" --repo "$REPO" >/dev/null 2>&1 \
+              || echo "::warning::prebuilt-alert: could not close #${EXISTING}"
+            echo "closed #${EXISTING} ($KEY)"
+          fi
+          exit 0
+        fi
+
+        BODY="$(printf '%s\n\n%s\n\n**Run:** %s\n\n%s\n' \
+          "$MARKER" \
+          "\`${GITHUB_WORKFLOW}\` failed on \`${GITHUB_EVENT_NAME}\`." \
+          "$RUN_URL" \
+          "$DETAILS")"
+
+        if [ -n "$EXISTING" ]; then
+          # Comment rather than open a second issue, so an outage is one thread.
+          gh issue comment "$EXISTING" --repo "$REPO" --body "$BODY" >/dev/null 2>&1 \
+            || echo "::warning::prebuilt-alert: could not comment on #${EXISTING}"
+          echo "updated #${EXISTING} ($KEY)"
+        else
+          # gh refuses to create with a label that does not exist yet.
+          gh label create "$LABEL" --repo "$REPO" --color B60205 \
+            --description "Prebuilt release pipeline is failing" >/dev/null 2>&1 || true
+          NEW="$(gh issue create --repo "$REPO" --title "$TITLE" --label "$LABEL" \
+                   --body "$BODY" 2>/dev/null | tail -1)"
+          if [ -n "$NEW" ]; then
+            echo "opened $NEW ($KEY)"
+          else
+            # The one case worth shouting about: a real failure went unreported.
+            echo "::error::prebuilt-alert: could not open an issue for ${KEY}; the failure at ${RUN_URL} is unreported"
+          fi
+        fi

--- a/.github/workflows/unsloth-pr-set-lint.yml
+++ b/.github/workflows/unsloth-pr-set-lint.yml
@@ -33,11 +33,17 @@ jobs:
       - run: |
           set -euo pipefail
           FILE=scripts/unsloth/pr-set.json
-          jq -e '.prs | type == "array" and all(.[]; type == "string")' "$FILE" >/dev/null \
-            || { echo "::error file=$FILE::.prs must be an array of PR url strings" >&2; exit 1; }
+          # Mirrors the resolve step's schema: a bare url string (required),
+          # or {"url": ..., "required": false} for a pin the release may ship
+          # without.
+          jq -e '.prs | type == "array" and all(.[];
+                   type == "string"
+                   or (type == "object" and (.url | type == "string")
+                       and ((if .required == null then true else .required end) | type == "boolean")))' "$FILE" >/dev/null \
+            || { echo "::error file=$FILE::.prs must be an array of PR url strings, or {url, required} objects" >&2; exit 1; }
           URL_RE='^https://github\.com/(ggml-org|unslothai)/llama\.cpp/pull/([0-9]+)/commits/([0-9a-f]{40})/?$'
           fail=0
-          for url in $(jq -r '.prs[]' "$FILE"); do
+          while read -r url REQUIRED; do
             if ! [[ "$url" =~ $URL_RE ]]; then
               echo "::error file=$FILE::malformed entry '$url' (expected https://github.com/{ggml-org,unslothai}/llama.cpp/pull/<n>/commits/<40-hex-sha>)"
               fail=1
@@ -53,7 +59,14 @@ jobs:
             STATE="$(jq -r .state <<<"$PR_JSON")"
             COMMITS="$(jq -r .commits <<<"$PR_JSON")"
             HEAD="$(jq -r .head <<<"$PR_JSON")"
-            [ "$STATE" = "open" ] || echo "::warning file=$FILE::${SRC}#${NUM} is ${STATE}; the nightly will skip this entry"
+            if [ "$STATE" != "open" ]; then
+              if [ "$REQUIRED" != "false" ]; then
+                echo "::error file=$FILE::${SRC}#${NUM} is ${STATE} and is a required entry; the nightly will refuse rather than publish without its architecture"
+                fail=1
+              else
+                echo "::warning file=$FILE::${SRC}#${NUM} is ${STATE}; the nightly will skip this optional entry"
+              fi
+            fi
             # The commits listing is capped at 250 by the API; past that the
             # membership check cannot be trusted, so skip it rather than
             # false-fail a legitimate giant PR.
@@ -65,6 +78,7 @@ jobs:
               continue
             fi
             [ "$PIN" = "$HEAD" ] || echo "::notice::${SRC}#${NUM} pin ${PIN} is behind its head ${HEAD}"
-            echo "OK: ${SRC}#${NUM} @ ${PIN} (${STATE})"
-          done
+            echo "OK: ${SRC}#${NUM} @ ${PIN} (${STATE}, required=${REQUIRED})"
+          done < <(jq -r '.prs[] | if type == "string" then {url: ., required: true} else . end
+                          | "\(.url)\t\(if .required == null then true else .required end)"' "$FILE" | tr '\t' ' ')
           exit "$fail"

--- a/.github/workflows/unsloth-prebuilt-deadman.yml
+++ b/.github/workflows/unsloth-prebuilt-deadman.yml
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+name: Unsloth prebuilt dead-man check
+
+# Watches the output, not the process: a run can go green while publishing
+# nothing, which no failure-triggered alert can see. Upstream cuts releases
+# several times a day, so two days of silence here is a fault, not a quiet
+# upstream.
+
+on:
+  schedule:
+    - cron: '23 9 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  STALE_DAYS: '2'
+
+jobs:
+  deadman:
+    name: Check publish freshness
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout (for the composite action)
+        uses: actions/checkout@v6
+        with: { persist-credentials: false }
+
+      - name: Check newest published release
+        id: c
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          LATEST="$(gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=30" \
+            --jq '[.[] | select(.draft==false and .prerelease==false)]
+                  | max_by(.published_at|fromdateiso8601)
+                  | "\(.tag_name)\t\(.published_at)"' 2>/dev/null || true)"
+
+          if [ -z "$LATEST" ] || [ "$LATEST" = "null" ]; then
+            # Do not manufacture an alert from an API hiccup.
+            echo "::warning::could not read the release list; skipping this check"
+            echo "status=skip" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          TAG="${LATEST%%$'\t'*}"
+          PUB="${LATEST##*$'\t'}"
+          AGE_D=$(( ( $(date -u +%s) - $(date -u -d "$PUB" +%s) ) / 86400 ))
+          echo "newest release ${TAG} published ${PUB} (${AGE_D}d ago); threshold ${STALE_DAYS}d"
+
+          if [ "$AGE_D" -le "${STALE_DAYS}" ]; then
+            echo "status=success" >> "$GITHUB_OUTPUT"
+            echo "details=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "status=failure" >> "$GITHUB_OUTPUT"
+          {
+            echo 'details<<ALERT_EOF'
+            echo "No prebuilt release has been published in **${AGE_D} days** (threshold ${STALE_DAYS})."
+            echo
+            echo "Newest release: \`${TAG}\`, published ${PUB}."
+            echo
+            echo "The nightly may be failing, or it may be completing green while"
+            echo "publishing nothing. Check the most recent runs of \`Unsloth prebuilt (full release)\`."
+            echo 'ALERT_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Alert
+        if: ${{ steps.c.outputs.status != 'skip' }}
+        uses: ./.github/actions/prebuilt-alert
+        with:
+          status: ${{ steps.c.outputs.status }}
+          key: llama-prebuilt-stale
+          title: 'No llama.cpp prebuilt release published recently'
+          details: ${{ steps.c.outputs.details }}
+          token: ${{ github.token }}

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -161,11 +161,17 @@ jobs:
           # pr-set.json _doc). unsloth-pr-set-lint.yml runs the same checks on every
           # push that edits the file, but that is only a tripwire -- a red
           # lint does not stop the schedule, so the gate must live here.
-          jq -e '.prs | type == "array" and all(.[]; type == "string")' scripts/unsloth/pr-set.json >/dev/null \
-            || { echo "scripts/unsloth/pr-set.json: .prs must be an array of PR url strings" >&2; exit 1; }
+          # An entry is a bare url string (required) or {"url", "required": false}.
+          # Bare strings stay valid, so the file needs no migration.
+          jq -e '.prs | type == "array" and all(.[];
+                   type == "string"
+                   or (type == "object" and (.url | type == "string")
+                       and ((if .required == null then true else .required end) | type == "boolean")))' \
+             scripts/unsloth/pr-set.json >/dev/null \
+            || { echo "scripts/unsloth/pr-set.json: .prs must be an array of PR url strings, or {url, required} objects" >&2; exit 1; }
           PRS='[]'
           URL_RE='^https://github\.com/(ggml-org|unslothai)/llama\.cpp/pull/([0-9]+)/commits/([0-9a-f]{40})/?$'
-          for url in $(jq -r '.prs[]' scripts/unsloth/pr-set.json); do
+          while read -r url REQUIRED; do
             [[ "$url" =~ $URL_RE ]] || { echo "refusing malformed PR url '$url' (expected https://github.com/{ggml-org,unslothai}/llama.cpp/pull/<n>/commits/<40-hex-sha>)" >&2; exit 1; }
             SRC="${BASH_REMATCH[1]}/llama.cpp"; NUM="${BASH_REMATCH[2]}"; SHA="${BASH_REMATCH[3]}"
             # Abort naming the entry on a gh failure (typo'd numbers 404).
@@ -178,7 +184,14 @@ jobs:
             N_COMMITS="$(jq -r '.commits' <<<"$PR_JSON")"
             TITLE="$(jq -r '.title' <<<"$PR_JSON")"
             if [ "$STATE" != "open" ]; then
-              echo "skipping ${SRC}#${NUM} (${STATE}): $url"
+              # A non-open pin drops out of $PRS, changing SETHASH and the tag, so
+              # the release would ship without that arch under a new tag. Refuse
+              # unless the entry is explicitly optional.
+              if [ "$REQUIRED" != "false" ]; then
+                echo "refusing ${SRC}#${NUM}: pin is ${STATE}, and it is a required entry; publishing without it would silently drop its architecture. Mark it \"required\": false in scripts/unsloth/pr-set.json to ship without it, or repin it." >&2
+                exit 1
+              fi
+              echo "::warning::skipping optional pin ${SRC}#${NUM} (${STATE}): $url"
               continue
             fi
             # A pin pasted from the wrong PR would build arbitrary code while
@@ -194,7 +207,8 @@ jobs:
             [ "$SHA" = "$HEAD" ] || echo "note: ${SRC}#${NUM} is pinned to ${SHA} but its head has moved to ${HEAD}"
             echo "including ${SRC}#${NUM} @ ${SHA}"
             PRS="$(jq -c --arg r "$SRC" --arg n "$NUM" --arg s "$SHA" --arg u "$url" --arg t "$TITLE" '. + [{repo: $r, number: ($n|tonumber), sha: $s, url: $u, title: $t}]' <<<"$PRS")"
-          done
+          done < <(jq -r '.prs[] | if type == "string" then {url: ., required: true} else . end
+                          | "\(.url)\t\(if .required == null then true else .required end)"' scripts/unsloth/pr-set.json | tr '\t' ' ')
 
           # Decide the tag and source repo first; the source tree is built
           # further down, only if this release isn't already published.
@@ -633,3 +647,66 @@ jobs:
             --notes "$NOTES" \
             dist/*
           gh release edit "$TAG" --repo "$REPO" --draft=false
+
+  # Without this a failed scheduled run is silent: GitHub emails only whoever
+  # last touched the cron file, which is how three nightlies failed unnoticed.
+  # Runs on publish-intent runs only, so subset test dispatches stay quiet.
+  alert:
+    name: Report pipeline health
+    needs: [resolve, build-cuda, build-windows-cuda, build-rocm, build-macos, build-cpu, build-vulkan, assemble]
+    if: ${{ always() && (github.event_name == 'schedule' || inputs.publish) }}
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      issues: write
+      actions: read
+    steps:
+      - name: Checkout (for the composite action)
+        uses: actions/checkout@v6
+        with: { persist-credentials: false }
+
+      - name: Summarise run
+        id: s
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          set -uo pipefail
+          # 'skipped' is healthy: a scheduled no-op skips every build job.
+          FAILED="$(jq -r 'to_entries | map(select(.value.result == "failure") | .key) | join(", ")' <<<"$NEEDS_JSON")"
+          if [ -z "$FAILED" ]; then
+            echo "status=success" >> "$GITHUB_OUTPUT"
+            echo "details=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "status=failure" >> "$GITHUB_OUTPUT"
+
+          # Quote the actual refusal so the issue says why, not just that a job failed.
+          REASON="$(gh run view "$GITHUB_RUN_ID" --repo "$GITHUB_REPOSITORY" --log-failed 2>/dev/null \
+            | grep -aE 'refusing |does not merge cleanly onto |could not fetch commit |ERROR: ' \
+            | sed -E 's/^[0-9-]+T[0-9:.]+Z //' | cut -c1-300 | head -5 || true)"
+
+          {
+            echo 'details<<ALERT_EOF'
+            echo "**Failed jobs:** ${FAILED}"
+            if [ -n "$REASON" ]; then
+              echo
+              echo 'Reported reason:'
+              echo
+              echo '```'
+              echo "$REASON"
+              echo '```'
+            fi
+            echo
+            echo "Nothing was published; the previous release remains \`Latest\`."
+            echo 'ALERT_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Alert
+        uses: ./.github/actions/prebuilt-alert
+        with:
+          status: ${{ steps.s.outputs.status }}
+          key: llama-prebuilt-nightly
+          title: 'Nightly llama.cpp prebuilt is failing'
+          details: ${{ steps.s.outputs.details }}
+          token: ${{ github.token }}


### PR DESCRIPTION
The nightly has no failure notification. There is no `if: failure()` step, no webhook and no issue creation anywhere in this repo, so a failed scheduled run only emails whoever last touched the cron file. That is how three nightlies in a row failed unnoticed:

| run | date | died in | cause |
|---|---|---|---|
| [30666643530](https://github.com/unslothai/llama.cpp/actions/runs/30666643530) | 07-31 | resolve | ggml-org#26185 pin force-pushed away |
| [30718507279](https://github.com/unslothai/llama.cpp/actions/runs/30718507279) | 08-01 | resolve | same |
| [30767267935](https://github.com/unslothai/llama.cpp/actions/runs/30767267935) | 08-02 | resolve | ggml-org#25731 stopped merging onto b10229 |

Each one skipped all 39 build jobs and published nothing, silently.

## What this adds

**`.github/actions/prebuilt-alert`** opens, updates or closes a deduplicated issue. Alerts sharing a key collapse onto one thread via a hidden marker, so a multi-night outage is one issue with a run-by-run history rather than one issue per night, and it closes itself on the next success. It scans open labelled issues rather than the search index, which lags by minutes and would double-open on back-to-back runs. Every `gh` call is tolerated so a broken alert cannot fail the run it reports on, with one exception: failing to open an issue is `::error::`, since that is the single case this exists to prevent.

**An alert job** on the orchestrator, gated on publish-intent runs so subset test dispatches stay quiet. It pulls the actual refusal out of the failed job log, so the issue says which pin broke:

```
ggml-org/llama.cpp#25731 (02142bbc) does not merge cleanly onto b10229 + the PRs listed before it
```

`skipped` counts as healthy, since a scheduled no-op legitimately skips every build job and assemble.

**`unsloth-prebuilt-deadman.yml`** watches the output instead of the process. A run can go green while publishing nothing, and nothing keyed off job failure can see that. Upstream cuts releases several times a day, so two days without one of ours is a fault rather than a quiet upstream.

## Silent capability regression in resolve

Separate from alerting, and worth its own look. Today a pinned PR that gets merged or closed upstream drops out of `$PRS` with a plain `echo`, not even a `::warning::`:

```bash
if [ "$STATE" != "open" ]; then
  echo "skipping ${SRC}#${NUM} (${STATE}): $url"
  continue
fi
```

That changes `SETHASH`, which changes the tag, so the release ships **without** that architecture under a brand new tag and nobody is told. A user loses Kimi-K3 or Inkling and only finds out when inference fails.

Entries in `scripts/unsloth/pr-set.json` may now be `{"url": "...", "required": false}`. Bare strings stay valid and mean required, so the file needs no migration. A non-open required pin refuses instead of quietly dropping. `unsloth-pr-set-lint.yml` takes the same schema.

One subtlety worth flagging for review: the required flag is read with an explicit null test, not `.required // true`. jq's `//` treats `false` as empty, so the obvious spelling silently reads `required: false` as `true` and the flag does nothing.

## Verification

- `bash -n` over every `run:` block in both workflows and the composite action, with `${{ }}` expressions substituted out. All parse.
- The pin loop exercised against the live `pr-set.json` for three cases: all pins open (all included), a required pin merged (refuses), a merged pin marked optional (skips, continues).
- The alert summary logic exercised for a healthy scheduled no-op, a resolve failure and a partial build failure.
- Reason extraction checked against the real 08-02 refusal text.

No secrets needed; `GITHUB_TOKEN` with `issues: write` covers it.