### PR TITLE
Prebuilt: record the ggml tree id as the release ABI key

### DIFF
--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -97,6 +97,8 @@ jobs:
       prs: ${{ steps.r.outputs.prs }}
       source_artifact: ${{ steps.r.outputs.source_artifact }}
       commit: ${{ steps.r.outputs.commit }}
+      ggml_tree: ${{ steps.r.outputs.ggml_tree }}
+      ggml_version: ${{ steps.r.outputs.ggml_version }}
       exists: ${{ steps.r.outputs.exists }}
       cuda_matrix: ${{ steps.r.outputs.cuda_matrix }}
       win_cuda_matrix: ${{ steps.r.outputs.win_cuda_matrix }}
@@ -231,6 +233,8 @@ jobs:
           fi
           SRC_ARTIFACT="app-source-${TAG}"
           COMMIT=""
+          GGML_TREE=""
+          GGML_VERSION=""
 
           # Only PUBLISHED releases count as "exists"; a leftover draft (from
           # a failed prior publish) should not block today's rebuild.
@@ -275,6 +279,18 @@ jobs:
               git checkout -q --detach "refs/tags/${BASE}"
             fi
             COMMIT="$(git rev-parse HEAD)"
+            # ABI key for anything compiled against our ggml (whisper.cpp slim
+            # bundles). The tree id changes only when ggml/ contents change, so
+            # a release that touches nothing under ggml/ does not force a
+            # rebuild downstream. The -mix- tag suffix is a hash of the PR set,
+            # not a ggml identity: it stays constant while the base tag moves.
+            GGML_TREE="$(git rev-parse HEAD:ggml)"
+            GGML_VERSION="$(sed -nE 's/^set\(GGML_VERSION_(MAJOR|MINOR|PATCH) ([0-9]+)\)$/\2/p' ggml/CMakeLists.txt | paste -sd. -)"
+            printf '%s' "$GGML_TREE" | grep -qE '^[0-9a-f]{40}$' \
+              || { echo "could not resolve the ggml tree id" >&2; exit 1; }
+            printf '%s' "$GGML_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$' \
+              || { echo "could not parse GGML_VERSION from ggml/CMakeLists.txt" >&2; exit 1; }
+            echo "ggml tree ${GGML_TREE} (version ${GGML_VERSION})"
 
             # The tarball ships without .git, where cmake/build-info.cmake falls
             # back to its defaults; bake real values into those defaults so
@@ -354,6 +370,8 @@ jobs:
             echo "prs=$PRS"
             echo "source_artifact=$SRC_ARTIFACT"
             echo "commit=$COMMIT"
+            echo "ggml_tree=$GGML_TREE"
+            echo "ggml_version=$GGML_VERSION"
             echo "exists=$EXISTS"
             echo "cuda_matrix={\"include\":$CUDA_INCLUDE}"
             echo "win_cuda_matrix={\"include\":$WIN_CUDA_INCLUDE}"
@@ -542,6 +560,8 @@ jobs:
             --source-repo '${{ needs.resolve.outputs.repo }}' \
             --base-tag '${{ needs.resolve.outputs.base }}' \
             --pr-set "$PRS_JSON" \
+            --ggml-tree '${{ needs.resolve.outputs.ggml_tree }}' \
+            --ggml-version '${{ needs.resolve.outputs.ggml_version }}' \
             --commit '${{ needs.resolve.outputs.commit }}' \
             --dist dist --out dist \
             --publish-repo "$GITHUB_REPOSITORY"

--- a/scripts/unsloth/assemble_metadata.py
+++ b/scripts/unsloth/assemble_metadata.py
@@ -298,6 +298,9 @@ def main() -> int:
     ap.add_argument("--pr-set", default="[]",
                     help='JSON array of merged PRs: [{"repo":..,"number":..,"sha":..,"url":..,"title":..},..]')
     ap.add_argument("--commit", required=True)
+    ap.add_argument("--ggml-tree", default=None,
+                    help="git tree id of ggml/ in the built source; ABI key for paired builds")
+    ap.add_argument("--ggml-version", default=None)
     ap.add_argument("--dist", required=True, type=Path, help="dir holding the built app-*.tar.gz bundles")
     ap.add_argument("--out", required=True, type=Path, help="dir to write the two JSON sidecars into")
     ap.add_argument("--publish-repo", required=True, help="repo the bundles+manifest are published to")
@@ -496,6 +499,12 @@ def main() -> int:
         "upstream_repo": UPSTREAM_REPO,
         "upstream_tag": base_tag,
         "merged_prs": pr_set,
+        # ABI key for anything compiled against this release's ggml, e.g.
+        # whisper.cpp slim bundles. Changes only when ggml/ contents change.
+        # The -mix- tag suffix hashes the PR set, not ggml, so it stays
+        # constant while the base tag (and ggml with it) moves.
+        "ggml_tree": args.ggml_tree,
+        "ggml_version": args.ggml_version,
     }
     manifest = {
         **common,


### PR DESCRIPTION
whisper.cpp slim bundles ship no `libggml*` and load against the ggml of a paired llama install, so they need an exact ABI identity for the ggml they were compiled against. Today they pair on the `-mix-` suffix of our tag, on the assumption that it is a ggml commit.

It is not. `resolve` computes it as:

```bash
SETHASH="$(jq -r 'map("\(.repo)#\(.number):\(.sha)") | join("\n")' <<<"$PRS" | sha256sum | cut -c1-7)"
TAG="${BASE}-mix-${SETHASH}"
```

That hashes the pinned PR set only. The base tag is the prefix, not part of the hash, so while pins are stable the suffix is **constant** as the base tag, and the real ggml, move underneath it. In our own published release list:

| suffix | releases sharing it | base span |
|---|---|---|
| `53618c5` | 8 | b9909 to b10001 |
| `2d6bd50` | 6 | b9625 to b9739 |
| `1f1aaa4` | 6 | b9767 to b9827 |
| `2c8b9c1` | 2 | b10173, b10181 |

And those are genuinely different ggml trees (`git rev-parse <tag>:ggml`):

```
b10173  8f3c6e197debb027f500df9f76e710e137f9fe68
b10181  e96ffb0e063f66952b0c54796a74755b6041c867
b10225  740c55b5cd13e6b4a8e2bdf0fd3ad94d398d3a80
```

So a consumer pairing on the suffix concludes "still compatible" across spans where ggml changed by up to ~92 upstream builds. The slim design exists to make that pairing an ABI identity rather than cross-version luck, and the key it pairs on does not track ggml at all.

## What this records

`resolve` now captures `git rev-parse HEAD:ggml` on the merged tree and threads it into `llama-prebuilt-manifest.json` as `ggml_tree`, with `ggml_version` alongside.

A tree id is the right granularity: it changes only when `ggml/` contents change, so a release that touches nothing under `ggml/` correctly does **not** force a downstream rebuild, while any real ggml change does.

`ggml_version` is recorded for diagnostics but is deliberately not the key. It reads `0.18.0` for all three trees above, so on its own it would be exactly the cross-version luck the slim design is trying to avoid.

The manifest previously carried no ggml identity at all. `source_commit` does not fill the gap: for a mix build it is a throwaway merge made on the runner and never pushed, so it resolves nowhere.

## Verification

Extraction run against the real tags:

```
b10225  tree=740c55b5cd13...  version=0.18.0  (tree_ok=1 ver_ok=1)
b10229  tree=91f37a576b81...  version=0.18.0  (tree_ok=1 ver_ok=1)
b10235  tree=3e0f62d09d57...  version=0.18.0  (tree_ok=1 ver_ok=1)
```

Distinct trees, identical versions, both format guards pass. Also `bash -n` over every `run:` block, `ast.parse` on `assemble_metadata.py`, and a scope check that `args` is live where the manifest dict is built.

Both values are initialised empty alongside `COMMIT`, so the scheduled no-op path (where the source tree is never checked out) still emits defined outputs.

## Scope

Nothing consumes these yet. whisper.cpp switches its pairing over separately, falling back to the current suffix comparison for releases published before this lands so there is no rebuild loop during the transition. The Studio installer's `llama_runtime_pairs()` needs the matching change too and lives in neither repo.