### PR TITLE
Prebuilt: dry-run the pin merges before the nightly

### DIFF
--- a/.github/workflows/unsloth-pin-preflight.yml
+++ b/.github/workflows/unsloth-pin-preflight.yml
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+name: Unsloth pin preflight
+
+# Runs the nightly's merge a few hours early, on the same base tag it will
+# pick, and files the conflict before the schedule burns 39 build jobs on it.
+#
+# unsloth-pr-set-lint.yml checks that pins are well formed and belong to their
+# PR, which catches a bad edit. It cannot catch the failure that actually
+# recurs: a pin that was fine yesterday and stops merging today because the
+# base tag moved under it. That is what killed 08-02, and four nights in a
+# week between the two causes.
+
+on:
+  schedule:
+    - cron: '47 16 * * *'
+  push:
+    paths:
+      - scripts/unsloth/pr-set.json
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  preflight:
+    name: Dry-run the pin merges
+    runs-on: ubuntu-22.04
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve base and dry-run the merges
+        id: p
+        run: |
+          set -uo pipefail
+          AGE_H="${UNSLOTH_LLAMA_MIN_RELEASE_AGE_HOURS:-6}"
+          CUTOFF="$(date -u -d "-${AGE_H} hours" +%s)"
+          BASE="$(gh api 'repos/ggml-org/llama.cpp/releases?per_page=100' \
+            --jq "[.[] | select(.draft==false and .prerelease==false) | select((.published_at|fromdateiso8601) <= ${CUTOFF})] | max_by(.published_at|fromdateiso8601) | .tag_name")"
+          if [ -z "$BASE" ] || [ "$BASE" = "null" ]; then
+            echo "::warning::no aged upstream release found; skipping"
+            echo "status=skip" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          echo "base $BASE"
+
+          git clone -q --filter=blob:none https://github.com/ggml-org/llama.cpp.git scratch
+          cd scratch
+          git fetch -q --no-tags origin "refs/tags/${BASE}:refs/tags/${BASE}"
+          git checkout -q --detach "refs/tags/${BASE}"
+
+          PROBLEMS=""
+          while read -r url REQUIRED; do
+            SRC="$(sed -E 's|https://github.com/([^/]+)/llama.cpp/pull/.*|\1|' <<<"$url")/llama.cpp"
+            NUM="$(sed -E 's|.*/pull/([0-9]+)/commits/.*|\1|' <<<"$url")"
+            SHA="$(sed -E 's|.*/commits/([0-9a-f]{40})/?$|\1|' <<<"$url")"
+
+            STATE="$(gh api "repos/${SRC}/pulls/${NUM}" --jq .state 2>/dev/null || echo unknown)"
+            if [ "$STATE" != "open" ]; then
+              if [ "$REQUIRED" != "false" ]; then
+                PROBLEMS="${PROBLEMS}- \`${SRC}#${NUM}\` is **${STATE}** and is required; the nightly will refuse.\n"
+              fi
+              continue
+            fi
+            if ! git fetch -q --no-tags "https://github.com/${SRC}.git" "$SHA" 2>/dev/null; then
+              PROBLEMS="${PROBLEMS}- \`${SRC}#${NUM}\` pinned commit \`${SHA:0:10}\` cannot be fetched; it was probably force-pushed away.\n"
+              continue
+            fi
+            if git -c user.name=preflight -c user.email=preflight@local \
+                 merge --no-ff --no-edit -m "probe ${SRC}#${NUM}" "$SHA" >/dev/null 2>&1; then
+              echo "ok ${SRC}#${NUM}"
+              continue
+            fi
+            FILES="$(git diff --name-only --diff-filter=U | sed 's/^/  /')"
+            HUNKS="$(git diff --diff-filter=U -U0 2>/dev/null | grep -E '^\+|^-' | grep -vE '^(\+\+\+|---)' | head -20)"
+            git merge --abort 2>/dev/null
+            PROBLEMS="${PROBLEMS}- \`${SRC}#${NUM}\` (\`${SHA:0:10}\`) does not merge onto \`${BASE}\` + the pins before it.\n\n  Conflicting files:\n\n\`\`\`\n${FILES}\n\`\`\`\n\n  <details><summary>conflict hunks</summary>\n\n\`\`\`diff\n${HUNKS}\n\`\`\`\n\n  </details>\n"
+            # Stop here, like resolve does. Probing later pins against a tree
+            # missing this one reports conflicts that are consequences of it.
+            PROBLEMS="${PROBLEMS}\nLater pins were not probed; fix this one first.\n"
+            break
+          done < <(jq -r '.prs[] | if type == "string" then {url: ., required: true} else . end
+                          | "\(.url)\t\(if .required == null then true else .required end)"' \
+                     ../scripts/unsloth/pr-set.json | tr '\t' ' ')
+
+          if [ -z "$PROBLEMS" ]; then
+            echo "all pins merge cleanly onto ${BASE}"
+            echo "status=success" >> "$GITHUB_OUTPUT"
+            echo "details=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "status=failure" >> "$GITHUB_OUTPUT"
+          {
+            echo 'details<<ALERT_EOF'
+            echo "Tonight's nightly will fail on base \`${BASE}\` unless \`scripts/unsloth/pr-set.json\` is repinned."
+            echo
+            printf '%b' "$PROBLEMS"
+            echo
+            echo "For a pin on a branch we control, merge \`${BASE}\` into it and repin. For a third-party PR, wait for the author to merge master or drop the pin."
+            echo 'ALERT_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Alert
+        if: ${{ steps.p.outputs.status != 'skip' }}
+        uses: ./.github/actions/prebuilt-alert
+        with:
+          status: ${{ steps.p.outputs.status }}
+          key: llama-pin-preflight
+          title: 'Pinned PRs no longer merge onto the current base tag'
+          details: ${{ steps.p.outputs.details }}
+          token: ${{ github.token }}

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -97,6 +97,8 @@ jobs:
       prs: ${{ steps.r.outputs.prs }}
       source_artifact: ${{ steps.r.outputs.source_artifact }}
       commit: ${{ steps.r.outputs.commit }}
+      ggml_tree: ${{ steps.r.outputs.ggml_tree }}
+      ggml_version: ${{ steps.r.outputs.ggml_version }}
       exists: ${{ steps.r.outputs.exists }}
       cuda_matrix: ${{ steps.r.outputs.cuda_matrix }}
       win_cuda_matrix: ${{ steps.r.outputs.win_cuda_matrix }}
@@ -231,6 +233,8 @@ jobs:
           fi
           SRC_ARTIFACT="app-source-${TAG}"
           COMMIT=""
+          GGML_TREE=""
+          GGML_VERSION=""
 
           # Only PUBLISHED releases count as "exists"; a leftover draft (from
           # a failed prior publish) should not block today's rebuild.
@@ -275,6 +279,18 @@ jobs:
               git checkout -q --detach "refs/tags/${BASE}"
             fi
             COMMIT="$(git rev-parse HEAD)"
+            # ABI key for anything compiled against our ggml (whisper.cpp slim
+            # bundles). The tree id changes only when ggml/ contents change, so
+            # a release that touches nothing under ggml/ does not force a
+            # rebuild downstream. The -mix- tag suffix is a hash of the PR set,
+            # not a ggml identity: it stays constant while the base tag moves.
+            GGML_TREE="$(git rev-parse HEAD:ggml)"
+            GGML_VERSION="$(sed -nE 's/^set\(GGML_VERSION_(MAJOR|MINOR|PATCH) ([0-9]+)\)$/\2/p' ggml/CMakeLists.txt | paste -sd. -)"
+            printf '%s' "$GGML_TREE" | grep -qE '^[0-9a-f]{40}$' \
+              || { echo "could not resolve the ggml tree id" >&2; exit 1; }
+            printf '%s' "$GGML_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$' \
+              || { echo "could not parse GGML_VERSION from ggml/CMakeLists.txt" >&2; exit 1; }
+            echo "ggml tree ${GGML_TREE} (version ${GGML_VERSION})"
 
             # The tarball ships without .git, where cmake/build-info.cmake falls
             # back to its defaults; bake real values into those defaults so
@@ -354,6 +370,8 @@ jobs:
             echo "prs=$PRS"
             echo "source_artifact=$SRC_ARTIFACT"
             echo "commit=$COMMIT"
+            echo "ggml_tree=$GGML_TREE"
+            echo "ggml_version=$GGML_VERSION"
             echo "exists=$EXISTS"
             echo "cuda_matrix={\"include\":$CUDA_INCLUDE}"
             echo "win_cuda_matrix={\"include\":$WIN_CUDA_INCLUDE}"
@@ -542,6 +560,8 @@ jobs:
             --source-repo '${{ needs.resolve.outputs.repo }}' \
             --base-tag '${{ needs.resolve.outputs.base }}' \
             --pr-set "$PRS_JSON" \
+            --ggml-tree '${{ needs.resolve.outputs.ggml_tree }}' \
+            --ggml-version '${{ needs.resolve.outputs.ggml_version }}' \
             --commit '${{ needs.resolve.outputs.commit }}' \
             --dist dist --out dist \
             --publish-repo "$GITHUB_REPOSITORY"

--- a/scripts/unsloth/assemble_metadata.py
+++ b/scripts/unsloth/assemble_metadata.py
@@ -298,6 +298,9 @@ def main() -> int:
     ap.add_argument("--pr-set", default="[]",
                     help='JSON array of merged PRs: [{"repo":..,"number":..,"sha":..,"url":..,"title":..},..]')
     ap.add_argument("--commit", required=True)
+    ap.add_argument("--ggml-tree", default=None,
+                    help="git tree id of ggml/ in the built source; ABI key for paired builds")
+    ap.add_argument("--ggml-version", default=None)
     ap.add_argument("--dist", required=True, type=Path, help="dir holding the built app-*.tar.gz bundles")
     ap.add_argument("--out", required=True, type=Path, help="dir to write the two JSON sidecars into")
     ap.add_argument("--publish-repo", required=True, help="repo the bundles+manifest are published to")
@@ -496,6 +499,12 @@ def main() -> int:
         "upstream_repo": UPSTREAM_REPO,
         "upstream_tag": base_tag,
         "merged_prs": pr_set,
+        # ABI key for anything compiled against this release's ggml, e.g.
+        # whisper.cpp slim bundles. Changes only when ggml/ contents change.
+        # The -mix- tag suffix hashes the PR set, not ggml, so it stays
+        # constant while the base tag (and ggml with it) moves.
+        "ggml_tree": args.ggml_tree,
+        "ggml_version": args.ggml_version,
     }
     manifest = {
         **common,


### PR DESCRIPTION
`unsloth-pr-set-lint.yml` checks that pins are well formed and belong to their PR, which catches a bad edit. It cannot catch the failure that actually recurs: a pin that was fine yesterday and stops merging today because the base tag moved under it.

That is what killed 08-02. Between that and pins being force-pushed away, the nightly failed four times in a week, and every one was found by hand well after the fact.

## What it does

Runs the same merge the nightly will run, onto the same base tag it will pick, a few hours before the schedule. On a conflict it files an issue naming the pin, the conflicting files and the hunks, so the repin can happen before the schedule burns 39 build jobs on a resolve that was always going to refuse.

It stops at the first conflicting pin rather than probing the rest. I had it report everything at first, and on the real 08-02 data that produced this:

```
  ok       c3fb972412
  CONFLICT 02142bbc33 -> src/llama-arch.cpp
  CONFLICT daef2b3e1b -> src/llama-arch.cpp
  CONFLICT 04d6828b2b -> tests/test-llama-archs.cpp
```

Only the first is real. The other two merge onto a tree missing Inkling, so they are consequences of it. `resolve` exits on the first failure and this now matches.

## Verification

Both real cases, against the actual tags:

**Old pin set on b10229**, the 08-02 breakage:

```
  ok       c3fb972412
  CONFLICT 02142bbc33 -> src/llama-arch.cpp
      ++<<<<<<< HEAD
      ++=======
      +         case LLM_ARCH_INKLING:
      ++>>>>>>> 02142bbc33d477880a89dc5854a2c611d36e3494
  => status=failure (issue filed)
```

**Current pin set on b10235**, which is what tonight will build:

```
  ok       c3fb972412
  ok       1e6f9e4a59
  ok       daef2b3e1b
  ok       04d6828b2b
  => status=success
```

Also `bash -n` on the run block, and the URL parsing checked against all four live entries.

## Not included

Mirroring reviewed pins to `refs/pins/<sha>` so a force-push cannot prune them, which is the other half of the 07-31 failure. That needs a token with `workflow` scope: upstream history routinely touches `.github/workflows` and `GITHUB_TOKEN` is refused such a push. It waits for the App token that the whisper chaining also needs.