### PR TITLE
Add the repin bot

### DIFF
--- a/.github/workflows/unsloth-repin-bot.yml
+++ b/.github/workflows/unsloth-repin-bot.yml
@@ -1,0 +1,207 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+name: Unsloth repin bot
+
+# Preflight says the pins stopped merging. This does the mechanical half of the
+# fix: merge the base tag into each pin branch we own, resolve the add/add
+# collisions that cause almost all of these, and open a PR moving the pins.
+#
+# It opens a PR and stops. It never merges it, never touches a branch belonging
+# to somebody else, and never repins past a commit a human reviewed -- the pin
+# file exists to guarantee that only reviewed code ships, and a bot that can
+# widen it on its own has removed the guarantee.
+
+on:
+  workflow_run:
+    workflows: ['Unsloth pin preflight']
+    types: [completed]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: unsloth-repin-bot
+  cancel-in-progress: false
+
+env:
+  # Branch the bot parks its proposal on. Reused every run so a week of
+  # breakage is one PR to review, not seven.
+  REPIN_BRANCH: unsloth/auto-repin
+
+jobs:
+  repin:
+    name: Repin against the current base tag
+    # A preflight that passed has nothing to fix.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-22.04
+    steps:
+      # Without this, checkout leaves a github.com extraheader carrying
+      # GITHUB_TOKEN, which would win over the REPIN_TOKEN in our push URLs.
+      - uses: actions/checkout@v6
+        with: { persist-credentials: false }
+
+      - name: Resolve base tag
+        id: base
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          AGE_H="${UNSLOTH_LLAMA_MIN_RELEASE_AGE_HOURS:-6}"
+          CUTOFF="$(date -u -d "-${AGE_H} hours" +%s)"
+          BASE="$(gh api 'repos/ggml-org/llama.cpp/releases?per_page=100' \
+            --jq "[.[] | select(.draft==false and .prerelease==false) | select((.published_at|fromdateiso8601) <= ${CUTOFF})] | max_by(.published_at|fromdateiso8601) | .tag_name")"
+          if [ -z "$BASE" ] || [ "$BASE" = "null" ]; then
+            echo "::warning::no aged upstream release found; nothing to repin onto"
+            echo "base=" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          echo "base $BASE"
+          echo "base=$BASE" >> "$GITHUB_OUTPUT"
+
+      - name: Merge and repin
+        id: repin
+        if: ${{ steps.base.outputs.base != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          python3 scripts/unsloth/repin.py \
+            --pr-set scripts/unsloth/pr-set.json \
+            --base "${{ steps.base.outputs.base }}" \
+            --work "${RUNNER_TEMP}/repin" \
+            --report "${RUNNER_TEMP}/repin.json" \
+            --markdown "${RUNNER_TEMP}/repin.md"
+          CHANGED="$(jq -r '.changed' "${RUNNER_TEMP}/repin.json")"
+          BLOCKED="$(jq -r '[.results[] | select(.action == "conflict" or .action == "third-party")] | length' "${RUNNER_TEMP}/repin.json")"
+          echo "changed=$CHANGED" >> "$GITHUB_OUTPUT"
+          echo "blocked=$BLOCKED" >> "$GITHUB_OUTPUT"
+
+      - name: Push the merged branches and open the PR
+        id: push
+        if: ${{ steps.repin.outputs.changed != '' && steps.repin.outputs.changed != '0' }}
+        env:
+          # Pushing to danielhanchen/llama.cpp is cross-repo, which GITHUB_TOKEN
+          # cannot do at all, and these merges carry upstream's own workflow
+          # changes, which needs workflow write. Without the secret the bot
+          # still reports; it just cannot act.
+          REPIN_TOKEN: ${{ secrets.REPIN_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          BASE: ${{ steps.base.outputs.base }}
+        run: |
+          set -uo pipefail
+          if [ -z "${REPIN_TOKEN:-}" ]; then
+            echo "::warning::REPIN_TOKEN is not set; reporting the repin instead of pushing it"
+            echo "mode=report" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Push every merged branch before touching the pin file: a pin whose
+          # commit is not on a remote is a pin the nightly cannot fetch.
+          FAILED=""
+          while read -r path head_repo head_ref new_sha; do
+            echo "pushing ${new_sha:0:10} to ${head_repo}:${head_ref}"
+            # No -x anywhere in this step; the URL carries the token.
+            if ! git -C "$path" push \
+                 "https://x-access-token:${REPIN_TOKEN}@github.com/${head_repo}.git" \
+                 "HEAD:refs/heads/${head_ref}" 2>&1 | sed "s/${REPIN_TOKEN}/***/g"; then
+              FAILED="${FAILED} ${head_repo}:${head_ref}"
+            fi
+          done < <(jq -r '.results[] | select(.action == "repin")
+                          | "\(.repo_path) \(.head_repo) \(.head_ref) \(.new_sha)"' "${RUNNER_TEMP}/repin.json")
+
+          if [ -n "$FAILED" ]; then
+            echo "::error::could not push:${FAILED}"
+            echo "mode=pushfail" >> "$GITHUB_OUTPUT"
+            echo "failed=${FAILED}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git config user.name  'unsloth-repin-bot'
+          git config user.email 'unsloth-repin-bot@users.noreply.github.com'
+          git checkout -q -B "${REPIN_BRANCH}"
+          git add scripts/unsloth/pr-set.json
+          git commit -qm "Repin PR set onto ${BASE}"
+          # Force: the branch is a rolling proposal against whatever base tag is
+          # current, so yesterday's version is not worth preserving.
+          git push -q --force \
+            "https://x-access-token:${REPIN_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "HEAD:refs/heads/${REPIN_BRANCH}" 2>&1 | sed "s/${REPIN_TOKEN}/***/g"
+
+          {
+            cat "${RUNNER_TEMP}/repin.md"
+            echo
+            echo "Opened automatically after [pin preflight](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/workflows/unsloth-pin-preflight.yml) failed. Review the resolutions above before merging; the bot does not merge its own PRs."
+          } > "${RUNNER_TEMP}/body.md"
+
+          EXISTING="$(GH_TOKEN="${REPIN_TOKEN}" gh pr list --repo "${GITHUB_REPOSITORY}" \
+            --head "${REPIN_BRANCH}" --state open --json number --jq '.[0].number' 2>/dev/null || true)"
+          if [ -n "$EXISTING" ] && [ "$EXISTING" != "null" ]; then
+            GH_TOKEN="${REPIN_TOKEN}" gh pr edit "$EXISTING" --repo "${GITHUB_REPOSITORY}" \
+              --title "Repin PR set onto ${BASE}" --body-file "${RUNNER_TEMP}/body.md" >/dev/null
+            echo "updated PR #${EXISTING}"
+            echo "pr=${EXISTING}" >> "$GITHUB_OUTPUT"
+          else
+            URL="$(GH_TOKEN="${REPIN_TOKEN}" gh pr create --repo "${GITHUB_REPOSITORY}" \
+              --base master --head "${REPIN_BRANCH}" \
+              --title "Repin PR set onto ${BASE}" --body-file "${RUNNER_TEMP}/body.md" 2>&1 | tail -1)"
+            echo "opened ${URL}"
+            echo "pr=${URL}" >> "$GITHUB_OUTPUT"
+          fi
+          echo "mode=pushed" >> "$GITHUB_OUTPUT"
+
+      - name: Report
+        id: report
+        if: ${{ always() && steps.base.outputs.base != '' }}
+        env:
+          CHANGED: ${{ steps.repin.outputs.changed }}
+          BLOCKED: ${{ steps.repin.outputs.blocked }}
+          OUTCOME: ${{ steps.repin.outcome }}
+          MODE: ${{ steps.push.outputs.mode }}
+          PR: ${{ steps.push.outputs.pr }}
+          FAILED: ${{ steps.push.outputs.failed }}
+        run: |
+          set -uo pipefail
+          # Only shout when a human has something to do. A run that repinned
+          # everything and opened a PR is already visible as a PR.
+          STATUS=success
+          # A crash in the repin step leaves no report at all, which must not
+          # read as "nothing to do" -- that is the green-run-does-nothing hole.
+          [ "${OUTCOME:-}" = "success" ] || STATUS=failure
+          {
+            echo 'details<<ALERT_EOF'
+            cat "${RUNNER_TEMP}/repin.md" 2>/dev/null \
+              || echo "The repin step did not finish (outcome: ${OUTCOME:-unknown}); no report was produced."
+            echo
+            case "${MODE:-}" in
+              pushed)   echo "Proposed in ${PR}." ;;
+              report)   STATUS=failure
+                        echo "\`REPIN_TOKEN\` is not configured, so nothing was pushed. Reproduce locally:"
+                        echo
+                        echo '```'
+                        echo "git checkout <pin sha> && git merge <base tag>"
+                        echo "python3 scripts/unsloth/additive_merge.py --repo ."
+                        echo '```' ;;
+              pushfail) STATUS=failure
+                        echo "Could not push:${FAILED}. \`REPIN_TOKEN\` likely lacks contents or workflow write on those repositories." ;;
+              *)        [ "${CHANGED:-0}" = "0" ] && echo "Nothing could be repinned automatically." ;;
+            esac
+            if [ "${BLOCKED:-0}" != "0" ]; then
+              STATUS=failure
+              echo
+              echo "${BLOCKED} pin(s) need a human, see the table above."
+            fi
+            echo 'ALERT_EOF'
+          } >> "$GITHUB_OUTPUT"
+          echo "status=${STATUS}" >> "$GITHUB_OUTPUT"
+
+      - name: Alert
+        if: ${{ always() && steps.report.outputs.status != '' }}
+        uses: ./.github/actions/prebuilt-alert
+        with:
+          status: ${{ steps.report.outputs.status }}
+          key: llama-repin-bot
+          title: 'Pins need a manual repin'
+          details: ${{ steps.report.outputs.details }}
+          token: ${{ github.token }}

--- a/scripts/unsloth/additive_merge.py
+++ b/scripts/unsloth/additive_merge.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+"""Resolve merge conflicts that are provably pure add/add, and only those.
+
+The conflict that keeps breaking the nightly is always the same shape: upstream
+registers a new architecture in a fallthrough group and one of our pinned PRs
+registers another one at the same spot. Neither side changed a line the other
+side touched -- both only added, at a place where the merge base had nothing.
+The union of the two additions is the resolution, and it is mechanical.
+
+Anything else is left conflicted and reported. In particular a conflict where
+the merge base is non-empty means at least one side *edited* shared text, and
+picking a side or unioning them is a guess. This script never guesses.
+
+Reads a conflicted work tree, writes resolutions in place, exits 0 if every
+conflict in every file was resolved and 1 otherwise. `--report` emits JSON
+describing what it did for the caller to quote in a PR body.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+OURS = "<<<<<<< "
+BASE = "||||||| "
+SEP = "======="
+THEIRS = ">>>>>>> "
+
+
+class Unresolvable(Exception):
+    """A conflict this script is not allowed to decide."""
+
+
+def parse_conflicts(lines: list[str]) -> list[tuple[int, int, list[str], list[str], list[str]]]:
+    """Split diff3-style content into (start, end, ours, base, theirs) regions.
+
+    Raises Unresolvable if the markers do not nest as diff3 promises, which
+    means the file is not in the state we think it is.
+    """
+    regions = []
+    i = 0
+    n = len(lines)
+    while i < n:
+        if not lines[i].startswith(OURS):
+            i += 1
+            continue
+        start = i
+        ours: list[str] = []
+        base: list[str] = []
+        theirs: list[str] = []
+        cur = ours
+        seen_base = False
+        i += 1
+        while True:
+            if i >= n:
+                raise Unresolvable(f"unterminated conflict starting at line {start + 1}")
+            ln = lines[i]
+            if ln.startswith(OURS):
+                raise Unresolvable(f"nested conflict marker at line {i + 1}")
+            if ln.startswith(BASE):
+                cur = base
+                seen_base = True
+            elif ln.rstrip("\n") == SEP:
+                cur = theirs
+            elif ln.startswith(THEIRS):
+                i += 1
+                break
+            else:
+                cur.append(ln)
+            i += 1
+        if not seen_base:
+            # Without the base section we cannot tell add/add from edit/edit.
+            raise Unresolvable(
+                f"conflict at line {start + 1} has no base section; "
+                "re-checkout with --conflict=diff3"
+            )
+        regions.append((start, i, ours, base, theirs))
+    return regions
+
+
+def nonblank(lines: list[str]) -> list[str]:
+    return [ln.strip() for ln in lines if ln.strip()]
+
+
+def resolve_region(ours: list[str], base: list[str], theirs: list[str]) -> list[str]:
+    """Return the union, or raise if this region is not a pure add/add."""
+    if nonblank(base):
+        raise Unresolvable(
+            "merge base is not empty, so at least one side edited existing text"
+        )
+    if not nonblank(ours) or not nonblank(theirs):
+        # One side added and the other added nothing: git would not have
+        # conflicted, so seeing this means the region is not what we expect.
+        raise Unresolvable("one side of the conflict is empty")
+    if ours == theirs:
+        # Both sides added byte-identical text; one copy is the resolution.
+        return list(ours)
+    shared = set(nonblank(ours)) & set(nonblank(theirs))
+    if shared:
+        # Overlapping content is the signature of one construct added twice,
+        # not two independent additions. Unioning it would duplicate code.
+        raise Unresolvable(
+            "both sides add the same line(s), so this is one change made twice: "
+            + ", ".join(sorted(shared)[:3])
+        )
+    # Upstream first, then ours: the same order a human repin produces.
+    return list(theirs) + list(ours)
+
+
+def decide_file(path: Path) -> tuple[str, list[dict]]:
+    """Return the resolved content and a per-hunk record, without writing."""
+    lines = path.read_text(encoding="utf-8", errors="surrogateescape").splitlines(keepends=True)
+    regions = parse_conflicts(lines)
+    if not regions:
+        raise Unresolvable("no conflict markers found")
+
+    out: list[str] = []
+    prev = 0
+    hunks = []
+    for start, end, ours, base, theirs in regions:
+        resolution = resolve_region(ours, base, theirs)
+        out.extend(lines[prev:start])
+        out.extend(resolution)
+        prev = end
+        hunks.append(
+            {
+                "ours": "".join(ours),
+                "theirs": "".join(theirs),
+                "resolution": "".join(resolution),
+            }
+        )
+    out.extend(lines[prev:])
+    return "".join(out), hunks
+
+
+def conflicted_files(repo: Path) -> list[str]:
+    r = subprocess.run(
+        ["git", "diff", "--name-only", "--diff-filter=U"],
+        cwd=repo, capture_output=True, text=True, check=True,
+    )
+    return [f for f in r.stdout.splitlines() if f]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--repo", default=".", help="conflicted work tree")
+    ap.add_argument("--report", help="write a JSON report here")
+    ap.add_argument("--dry-run", action="store_true", help="decide, but do not write")
+    args = ap.parse_args()
+
+    repo = Path(args.repo).resolve()
+    files = conflicted_files(repo)
+    report: dict = {"resolved": [], "refused": [], "ok": False}
+
+    if not files:
+        report["refused"].append({"file": "-", "reason": "no conflicted files"})
+
+    # Decide every file before writing any of them. A refusal on the second
+    # file must not leave the first one already rewritten on disk: the caller
+    # would then be looking at a tree that is neither the conflict nor the
+    # resolution.
+    pending: list[tuple[Path, str]] = []
+    for f in files:
+        try:
+            content, hunks = decide_file(repo / f)
+            pending.append((repo / f, content))
+            report["resolved"].append({"file": f, "hunks": hunks})
+        except Unresolvable as e:
+            report["refused"].append({"file": f, "reason": str(e)})
+        except OSError as e:
+            report["refused"].append({"file": f, "reason": f"cannot read: {e}"})
+
+    report["ok"] = bool(files) and not report["refused"]
+
+    if report["ok"] and not args.dry_run:
+        for p, content in pending:
+            p.write_text(content, encoding="utf-8", errors="surrogateescape")
+        subprocess.run(["git", "add", "--"] + files, cwd=repo, check=True)
+
+    for r in report["resolved"]:
+        print(f"resolved {r['file']}")
+    for r in report["refused"]:
+        print(f"refused  {r['file']}: {r['reason']}", file=sys.stderr)
+
+    if args.report:
+        Path(args.report).write_text(json.dumps(report, indent=2))
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/unsloth/repin.py
+++ b/scripts/unsloth/repin.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+"""Merge the current base tag into each pinned PR branch we control, and repin.
+
+The nightly builds an upstream release tag plus a list of pinned PR commits.
+Upstream moves several times a day, so a pin that merged yesterday routinely
+stops merging today -- that is what broke four nightlies in a week, and every
+fix was the same mechanical merge done by hand.
+
+This does that merge, and only where it is safe to:
+
+  * branches we own (see OWNED). A third-party PR is reported, never pushed to.
+  * pins that are still their branch head. If the author has pushed past the
+    pin, merging into the branch would silently widen the release to include
+    code nobody reviewed, which is the exact property the pin file exists to
+    hold. Report it and let a human decide.
+  * conflicts that additive_merge.py can prove are pure add/add. Anything else
+    is left alone and reported.
+
+Writes the new pins back to pr-set.json and prints a markdown report. Pushing
+and opening the PR is the caller's job; nothing here talks to a remote except
+to fetch.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Branches we may push to. Anything else gets a report line and no write.
+OWNED = ("unslothai/", "danielhanchen/")
+
+PIN_RE = re.compile(
+    r"^https://github\.com/([^/]+)/llama\.cpp/pull/(\d+)/commits/([0-9a-f]{40})/?$"
+)
+HERE = Path(__file__).resolve().parent
+
+
+def run(args, cwd=None, check=True, quiet=True):
+    r = subprocess.run(args, cwd=cwd, capture_output=True, text=True)
+    if check and r.returncode != 0:
+        raise RuntimeError(f"{' '.join(args[:4])}... failed: {r.stderr.strip()[:400]}")
+    if not quiet and r.stdout:
+        print(r.stdout.rstrip())
+    return r
+
+
+def gh_json(path):
+    r = run(["gh", "api", path], check=False)
+    if r.returncode != 0:
+        return None
+    try:
+        return json.loads(r.stdout)
+    except json.JSONDecodeError:
+        return None
+
+
+def load_pins(pr_set: Path) -> tuple[dict, list[dict]]:
+    data = json.loads(pr_set.read_text())
+    pins = []
+    for entry in data["prs"]:
+        url = entry if isinstance(entry, str) else entry["url"]
+        required = True if isinstance(entry, str) else entry.get("required", True)
+        m = PIN_RE.match(url)
+        if not m:
+            raise SystemExit(f"malformed pin: {url}")
+        pins.append(
+            {
+                "url": url,
+                "required": required,
+                "src": f"{m.group(1)}/llama.cpp",
+                "num": int(m.group(2)),
+                "sha": m.group(3),
+            }
+        )
+    return data, pins
+
+
+def repin_one(pin: dict, base: str, work: Path) -> dict:
+    """Try to bring one pin up to `base`. Never raises for an expected refusal."""
+    out = dict(pin, action="skip", note="", new_sha="", files=[], hunks=[])
+    pr = gh_json(f"repos/{pin['src']}/pulls/{pin['num']}")
+    if pr is None:
+        out["note"] = "could not read the PR from the API"
+        return out
+    if pr.get("state") != "open":
+        out["note"] = f"PR is {pr.get('state')}; not repinning a closed PR"
+        return out
+
+    head_repo = (pr.get("head", {}).get("repo") or {}).get("full_name")
+    head_ref = pr.get("head", {}).get("ref")
+    head_sha = pr.get("head", {}).get("sha")
+    out.update(head_repo=head_repo, head_ref=head_ref)
+
+    if not head_repo:
+        out["note"] = "head repository was deleted"
+        return out
+    if not head_repo.startswith(OWNED):
+        out["action"] = "third-party"
+        out["note"] = f"`{head_repo}` is not ours; ask the author to merge master"
+        return out
+    if head_sha != pin["sha"]:
+        out["note"] = (
+            f"branch head `{head_sha[:10]}` has moved past the pin `{pin['sha'][:10]}`; "
+            "repinning would pull in unreviewed commits"
+        )
+        return out
+
+    repo = work / f"r{pin['num']}"
+    run(["git", "clone", "-q", "--filter=blob:none", "--no-checkout",
+         f"https://github.com/{pin['src']}.git", str(repo)])
+    run(["git", "fetch", "-q", "--no-tags", "origin", pin["sha"]], cwd=repo, check=False)
+    r = run(["git", "fetch", "-q", "--no-tags",
+             "https://github.com/ggml-org/llama.cpp.git",
+             f"refs/tags/{base}:refs/tags/{base}"], cwd=repo, check=False)
+    if r.returncode != 0:
+        out["note"] = f"could not fetch base tag {base}"
+        return out
+    if run(["git", "rev-parse", "--verify", f"{pin['sha']}^{{commit}}"],
+           cwd=repo, check=False).returncode != 0:
+        out["note"] = f"pinned commit {pin['sha'][:10]} is gone (force-pushed away)"
+        return out
+
+    run(["git", "checkout", "-q", "--detach", pin["sha"]], cwd=repo)
+    if run(["git", "merge-base", "--is-ancestor", f"refs/tags/{base}", "HEAD"],
+           cwd=repo, check=False).returncode == 0:
+        out["note"] = f"already contains {base}"
+        return out
+
+    # diff3 is what makes the add/add proof possible: without the base section
+    # an edit/edit conflict is indistinguishable from an add/add one.
+    git_id = ["-c", "user.name=unsloth-repin-bot",
+              "-c", "user.email=unsloth-repin-bot@users.noreply.github.com"]
+    m = run(["git", "-c", "merge.conflictStyle=diff3", *git_id, "merge", "--no-ff",
+             "--no-edit", "-m", f"Merge {base} into {head_ref}", f"refs/tags/{base}"],
+            cwd=repo, check=False)
+
+    if m.returncode != 0:
+        report = work / f"res{pin['num']}.json"
+        rc = subprocess.run(
+            [sys.executable, str(HERE / "additive_merge.py"),
+             "--repo", str(repo), "--report", str(report)],
+            capture_output=True, text=True,
+        ).returncode
+        res = json.loads(report.read_text()) if report.exists() else {}
+        if rc != 0:
+            out["action"] = "conflict"
+            out["files"] = [x["file"] for x in res.get("refused", [])]
+            out["note"] = "; ".join(
+                f"`{x['file']}`: {x['reason']}" for x in res.get("refused", [])
+            ) or "merge conflicted"
+            run(["git", "merge", "--abort"], cwd=repo, check=False)
+            return out
+        out["hunks"] = [
+            {"file": f["file"], **h} for f in res.get("resolved", []) for h in f["hunks"]
+        ]
+        out["files"] = [f["file"] for f in res.get("resolved", [])]
+        run(["git", *git_id, "commit", "-q", "--no-edit"], cwd=repo)
+
+    new_sha = run(["git", "rev-parse", "HEAD"], cwd=repo).stdout.strip()
+    out["action"] = "repin"
+    out["new_sha"] = new_sha
+    out["repo_path"] = str(repo)
+    out["touches_workflows"] = bool(
+        run(["git", "diff", "--name-only", f"{pin['sha']}..HEAD", "--",
+             ".github/workflows"], cwd=repo).stdout.strip()
+    )
+    return out
+
+
+def markdown(base: str, results: list[dict]) -> str:
+    L = [f"Base tag: `{base}`", ""]
+    L += ["| pin | branch | outcome |", "|---|---|---|"]
+    for r in results:
+        pin = f"[`{r['src']}#{r['num']}`](https://github.com/{r['src']}/pull/{r['num']})"
+        branch = f"`{r.get('head_repo') or '?'}:{r.get('head_ref') or '?'}`"
+        if r["action"] == "repin":
+            what = f"repinned `{r['sha'][:10]}` to `{r['new_sha'][:10]}`"
+            if r["hunks"]:
+                what += f" ({len(r['hunks'])} add/add hunk(s) resolved)"
+        elif r["action"] == "conflict":
+            what = f"**conflict, not resolvable automatically** -- {r['note']}"
+        elif r["action"] == "third-party":
+            what = f"not ours -- {r['note']}"
+        else:
+            what = r["note"] or "no change"
+        L.append(f"| {pin} | {branch} | {what} |")
+    L.append("")
+
+    for r in results:
+        if not r.get("hunks"):
+            continue
+        L += [f"<details><summary>Resolutions for <code>{r['src']}#{r['num']}</code></summary>", ""]
+        for h in r["hunks"]:
+            L += [f"`{h['file']}`", "", "```diff"]
+            L += [f"-{x}" for x in h["ours"].rstrip("\n").split("\n")]
+            L += [f"-{x}" for x in h["theirs"].rstrip("\n").split("\n")]
+            L += [f"+{x}" for x in h["resolution"].rstrip("\n").split("\n")]
+            L += ["```", ""]
+        L += ["</details>", ""]
+
+    if any(r.get("touches_workflows") for r in results):
+        L += ["Some merges carry upstream changes under `.github/workflows/`, so the "
+              "push needs a token with workflow write permission.", ""]
+    return "\n".join(L)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--pr-set", required=True)
+    ap.add_argument("--base", required=True, help="upstream release tag to merge in")
+    ap.add_argument("--work", required=True, help="scratch directory for clones")
+    ap.add_argument("--report", help="write a JSON report here")
+    ap.add_argument("--markdown", help="write the human-readable report here")
+    args = ap.parse_args()
+
+    pr_set = Path(args.pr_set)
+    work = Path(args.work)
+    work.mkdir(parents=True, exist_ok=True)
+    _, pins = load_pins(pr_set)
+
+    results = []
+    for pin in pins:
+        try:
+            r = repin_one(pin, args.base, work)
+        except RuntimeError as e:
+            r = dict(pin, action="skip", note=f"error: {e}", new_sha="", files=[], hunks=[])
+        results.append(r)
+        print(f"{r['src']}#{r['num']}: {r['action']} {r['note']}".rstrip())
+
+    # Swap the shas in the raw text rather than re-serialising. Rewriting the
+    # JSON would reflow the whole file and bury a four-character change in a
+    # whole-file diff, which is the opposite of what a reviewer needs here.
+    text = pr_set.read_text()
+    changed = 0
+    for r in results:
+        if r["action"] != "repin":
+            continue
+        if r["sha"] not in text:
+            print(f"::warning::{r['src']}#{r['num']}: pin not found verbatim; not rewritten")
+            continue
+        text = text.replace(r["sha"], r["new_sha"])
+        changed += 1
+    if changed:
+        pr_set.write_text(text)
+
+    if args.report:
+        Path(args.report).write_text(json.dumps(
+            {"base": args.base, "changed": changed, "results": results}, indent=2))
+    if args.markdown:
+        Path(args.markdown).write_text(markdown(args.base, results))
+
+    blocked = [r for r in results if r["action"] in ("conflict", "third-party")]
+    print(f"\n{changed} repinned, {len(blocked)} needing a human")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/unsloth/test_additive_merge.py
+++ b/scripts/unsloth/test_additive_merge.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+"""Tests for additive_merge.py. Run: python3 scripts/unsloth/test_additive_merge.py
+
+Every case builds a real git conflict rather than a hand-written one, so the
+markers are exactly what git produces.
+"""
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent / "additive_merge.py"
+FAILS = []
+
+
+def check(name, cond, extra=""):
+    print(f"{'PASS' if cond else 'FAIL'}  {name}" + (f"  :: {extra}" if extra and not cond else ""))
+    if not cond:
+        FAILS.append(name)
+
+
+def git(repo, *args, **kw):
+    return subprocess.run(["git", "-c", "user.name=t", "-c", "user.email=t@t", *args],
+                          cwd=repo, capture_output=True, text=True, **kw)
+
+
+def make_conflict(base_txt, ours_txt, theirs_txt):
+    """Build a real git conflict, return (repo, conflicted file path)."""
+    d = Path(tempfile.mkdtemp(prefix="am_"))
+    git(d, "init", "-q", "-b", "main")
+    f = d / "f.c"
+    f.write_text(base_txt)
+    git(d, "add", "-A"); git(d, "commit", "-qm", "base")
+    git(d, "checkout", "-qb", "side")
+    f.write_text(theirs_txt)
+    git(d, "add", "-A"); git(d, "commit", "-qm", "theirs")
+    git(d, "checkout", "-q", "main")
+    f.write_text(ours_txt)
+    git(d, "add", "-A"); git(d, "commit", "-qm", "ours")
+    git(d, "-c", "merge.conflictStyle=diff3", "merge", "side")
+    return d, f
+
+
+def run(repo, *extra):
+    rep = repo / "r.json"
+    p = subprocess.run([sys.executable, str(SCRIPT), "--repo", str(repo), "--report", str(rep), *extra],
+                       capture_output=True, text=True)
+    return p.returncode, json.loads(rep.read_text()) if rep.exists() else {}
+
+
+# --- 1. pure add/add: the real recurring shape ------------------------------
+base = "switch (arch) {\n    case A:\n        break;\n}\n"
+ours = "switch (arch) {\n    case A:\n    case LLM_ARCH_INKLING:\n        break;\n}\n"
+theirs = "switch (arch) {\n    case A:\n    case LLM_ARCH_DEEPSEEK4:\n        break;\n}\n"
+repo, f = make_conflict(base, ours, theirs)
+rc, rep = run(repo)
+txt = f.read_text()
+check("add/add resolves", rc == 0 and rep["ok"], rep)
+check("add/add unions both labels",
+      "LLM_ARCH_DEEPSEEK4" in txt and "LLM_ARCH_INKLING" in txt and "<<<<" not in txt, txt)
+check("add/add puts upstream first (matches hand repin)",
+      txt.index("DEEPSEEK4") < txt.index("INKLING"), txt)
+check("add/add stages the file",
+      git(repo, "diff", "--name-only", "--diff-filter=U").stdout.strip() == "")
+
+# --- 2. edit/edit on a shared line: must refuse -----------------------------
+base = "if (a == X || a == Y) {\n"
+ours = "if (a == X || a == Y || a == KIMI) {\n"
+theirs = "if (a == X || a == Y || a == MINIMAX) {\n"
+repo, f = make_conflict(base, ours, theirs)
+rc, rep = run(repo)
+check("edit/edit refuses", rc == 1 and not rep["ok"])
+check("edit/edit says why", "base is not empty" in (rep["refused"][0]["reason"] if rep["refused"] else ""),
+      rep)
+check("edit/edit leaves markers in place", "<<<<" in f.read_text())
+
+# --- 3. same line added twice: must refuse, not duplicate -------------------
+base = "a\nz\n"
+ours = "a\ncase FOO:\n    break;\nz\n"
+theirs = "a\ncase FOO:\n    break;\nz\n"
+repo, f = make_conflict(base, ours, theirs)
+rc, rep = run(repo)
+check("identical add/add is not a conflict at all", rc == 1 and "no conflicted files" in json.dumps(rep))
+
+base = "a\nz\n"
+ours = "a\ncase FOO:\n    break;\nz\n"
+theirs = "a\ncase BAR:\n    break;\nz\n"
+repo, f = make_conflict(base, ours, theirs)
+rc, rep = run(repo)
+check("overlapping add/add refuses (shared 'break;')",
+      rc == 1 and "made twice" in json.dumps(rep), rep)
+
+# --- 4. one file good, one file bad: refuse the whole merge ----------------
+d = Path(tempfile.mkdtemp(prefix="am_"))
+git(d, "init", "-q", "-b", "main")
+(d / "good.c").write_text("x\ny\n")
+(d / "bad.c").write_text("if (a || b) {\n")
+git(d, "add", "-A"); git(d, "commit", "-qm", "base")
+git(d, "checkout", "-qb", "side")
+(d / "good.c").write_text("x\ncase UP:\ny\n")
+(d / "bad.c").write_text("if (a || b || up) {\n")
+git(d, "add", "-A"); git(d, "commit", "-qm", "theirs")
+git(d, "checkout", "-q", "main")
+(d / "good.c").write_text("x\ncase MINE:\ny\n")
+(d / "bad.c").write_text("if (a || b || mine) {\n")
+git(d, "add", "-A"); git(d, "commit", "-qm", "ours")
+git(d, "-c", "merge.conflictStyle=diff3", "merge", "side")
+rc, rep = run(d)
+check("mixed: overall refuses", rc == 1 and not rep["ok"])
+check("mixed: both files still unmerged in the index",
+      {ln.split("\t")[-1] for ln in git(d, "ls-files", "-u").stdout.splitlines()} == {"good.c", "bad.c"},
+      git(d, "ls-files", "-u").stdout)
+check("mixed: the resolvable file is NOT half-written",
+      "<<<<" in (d / "good.c").read_text(), (d / "good.c").read_text())
+
+# --- 5. dry-run writes nothing --------------------------------------------
+base = "switch (arch) {\n    case A:\n        break;\n}\n"
+ours = "switch (arch) {\n    case A:\n    case MINE:\n        break;\n}\n"
+theirs = "switch (arch) {\n    case A:\n    case UP:\n        break;\n}\n"
+repo, f = make_conflict(base, ours, theirs)
+before = f.read_text()
+rc, rep = run(repo, "--dry-run")
+check("dry-run reports ok", rc == 0 and rep["ok"])
+check("dry-run does not touch the file", f.read_text() == before)
+
+print()
+print(f"{len(FAILS)} failure(s)" + (": " + ", ".join(FAILS) if FAILS else ""))
+sys.exit(1 if FAILS else 0)


### PR DESCRIPTION
Four nightlies failed in a week, every one of them a pinned PR that merged yesterday and stopped merging today because the base tag moved under it. Preflight (#53) tells us that a few hours early. This does the other half: the merge itself.

## What it does

On a preflight failure, for each pin in `scripts/unsloth/pr-set.json`:

- merge the current base tag into the pin's branch
- resolve conflicts that are provably pure add/add, and only those
- push the merged branches and open a PR moving the pins

It opens the PR and stops. It does not merge it.

## What it refuses to do

The pin file exists so that only reviewed code ships, so the bot is written to be unable to widen it:

- **Branches we do not own.** `pwilkin/llama.cpp` (#26185) gets a report line, never a push. Only `unslothai/*` and `danielhanchen/*` are writable.
- **Pins the author has moved past.** If the branch head is ahead of the pin, repinning would pull in commits nobody reviewed. It reports and stops. All four pins are currently at their branch head, so this costs nothing today.
- **Conflicts it cannot prove are safe.** See below.

## The add/add rule

`scripts/unsloth/additive_merge.py` re-reads the conflict in diff3 style and resolves a hunk only when the merge base section is empty, which means both sides added text where there was none and neither edited the other's. That is exactly the recurring `case LLM_ARCH_FOO:` fallthrough collision. It additionally refuses when the two sides share a line, because that is one change made twice rather than two independent additions.

Anything else, including the common case of two PRs each appending a term to the same `if` condition, is left conflicted and reported. It never picks a side.

Decisions are made for every conflicted file before any of them is written, so a refusal on the second file cannot leave the first one half-resolved.

## Verification

`scripts/unsloth/test_additive_merge.py` builds real git conflicts and covers the resolve, the refusals, the partial-write guard and the dry run. 14 assertions, all passing.

The one that matters is the replay of the actual 08-02 breakage: base `b10229`, Inkling pinned at `02142bbc`, colliding with upstream's new `LLM_ARCH_DEEPSEEK4`. The resolver reproduces the resolution I made by hand in `1e6f9e4a` byte for byte.

Ran end to end against the live repos on today's base `b10236`:

| pin | outcome |
|---|---|
| `ggml-org#24423` | clean merge, repinned |
| `ggml-org#25731` | clean merge, repinned |
| `unslothai#48` | 1 add/add hunk resolved (`src/llama-arch.cpp`, `DEEPSEEK4`/`INKLING`), repinned |
| `ggml-org#26185` | not ours, reported |

## REPIN_TOKEN

The plan was for the bot to work without a `workflow`-scoped token. It cannot: pushing to `danielhanchen/llama.cpp` is cross-repo, which `GITHUB_TOKEN` cannot do at all, and the merges carry upstream's own `.github/workflows` changes, which needs workflow write. Dropping those paths from the merge would leave the branch permanently diverged there, which is worse.

So it needs a `REPIN_TOKEN` secret with contents and workflow write on `unslothai/llama.cpp` and `danielhanchen/llama.cpp`. Until that exists the bot still runs every step except the push, and files the report as an issue, so nothing here is blocked on the secret. Note it only ever pushes to feature branches and to its own proposal branch; `master` is only ever touched through a PR a human merges.
