### PR TITLE
Let a scheduled nightly supersede a wedged one

### DIFF
--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -80,7 +80,11 @@ env:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.inputs.tag || 'scheduled' }}
-  cancel-in-progress: false
+  # A nightly still in flight when the next one starts is stuck, not busy: a
+  # healthy run finishes in a couple of hours. Leaving this false lets one
+  # wedged run block every following nightly with nothing to show for it.
+  # Only the schedule supersedes; a manual dispatch never kills a live nightly.
+  cancel-in-progress: ${{ github.event_name == 'schedule' }}
 
 jobs:
   resolve:


### PR DESCRIPTION
Same fix as unslothai/whisper.cpp#8, found there first.

`schedule` and a blank-tag `workflow_dispatch` share one concurrency group, and `cancel-in-progress` was `false`. A run that wedges, waiting for a runner that never arrives, then blocks every following nightly indefinitely. The dead-man check would eventually notice the silence, but only after two days of not publishing.

A nightly still running when the next one starts is stuck rather than busy, since a healthy one finishes in a couple of hours, so the schedule now supersedes it. A manual dispatch still never cancels a live nightly.