### PR TITLE
Mirror pinned commits to refs/pins

### DIFF
--- a/.github/workflows/unsloth-pin-preflight.yml
+++ b/.github/workflows/unsloth-pin-preflight.yml
@@ -21,7 +21,8 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  # write is only for the refs/pins/* mirror below; nothing here pushes a branch.
+  contents: write
   issues: write
 
 jobs:
@@ -49,8 +50,35 @@ jobs:
 
           git clone -q --filter=blob:none https://github.com/ggml-org/llama.cpp.git scratch
           cd scratch
+          MIRROR="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git fetch -q --no-tags origin "refs/tags/${BASE}:refs/tags/${BASE}"
           git checkout -q --detach "refs/tags/${BASE}"
+
+          # Mirror every pin to refs/pins/<sha> before probing anything. The
+          # 07-31 outage was a reviewed commit pruned out of its PR by a force
+          # push, which no amount of checking can recover from after the fact.
+          # A ref of our own keeps the object alive; resolve falls back to it.
+          # All these repos are in one fork network, so this transfers nothing.
+          # Done first, and past failures, so a conflict in an early pin does
+          # not leave the later ones unmirrored.
+          while read -r url; do
+            SRC="$(sed -E 's|https://github.com/([^/]+)/llama.cpp/pull/.*|\1|' <<<"$url")/llama.cpp"
+            SHA="$(sed -E 's|.*/commits/([0-9a-f]{40})/?$|\1|' <<<"$url")"
+            if git ls-remote --exit-code "$MIRROR" "refs/pins/${SHA}" >/dev/null 2>&1; then
+              echo "mirrored already: ${SHA:0:10}"
+              continue
+            fi
+            if ! git fetch -q --no-tags "https://github.com/${SRC}.git" "$SHA" 2>/dev/null; then
+              echo "::warning::cannot mirror ${SHA:0:10}; it is already unfetchable from ${SRC}"
+              continue
+            fi
+            if git push -q "$MIRROR" "${SHA}:refs/pins/${SHA}" 2>&1 | sed "s|${GH_TOKEN}|***|g"; then
+              echo "mirrored ${SHA:0:10}"
+            else
+              echo "::warning::could not push refs/pins/${SHA:0:10}"
+            fi
+          done < <(jq -r '.prs[] | if type == "string" then . else .url end' \
+                     ../scripts/unsloth/pr-set.json)
 
           PROBLEMS=""
           while read -r url REQUIRED; do

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -270,8 +270,16 @@ jobs:
               # sha are machine fields, so the space-delimited read is safe;
               # titles stay out of this loop).
               while read -r SRC NUM SHA; do
-                git fetch -q --no-tags "https://github.com/${SRC}.git" "$SHA" \
-                  || { echo "could not fetch commit ${SHA} for ${SRC}#${NUM}; it may have been pruned after a force-push -- update or remove the pin in scripts/unsloth/pr-set.json" >&2; exit 1; }
+                # The PR's own repo first, then our refs/pins mirror, which is
+                # the only copy left once an author force-pushes the reviewed
+                # commit out of the PR. That is what took the nightly down on
+                # 07-31, and it is unrecoverable without a ref of our own.
+                git fetch -q --no-tags "https://github.com/${SRC}.git" "$SHA" 2>/dev/null \
+                  || git fetch -q --no-tags origin "refs/pins/${SHA}" 2>/dev/null \
+                  || { echo "could not fetch commit ${SHA} for ${SRC}#${NUM}; it is gone from ${SRC} and was never mirrored to refs/pins -- update or remove the pin in scripts/unsloth/pr-set.json" >&2; exit 1; }
+                if ! git rev-parse --verify -q "${SHA}^{commit}" >/dev/null; then
+                  echo "fetched something for ${SRC}#${NUM} but ${SHA} is still missing" >&2; exit 1
+                fi
                 git -c user.name='github-actions[bot]' -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
                   merge --no-ff --no-edit -m "Merge ${SRC}#${NUM} @ ${SHA}" "$SHA" \
                   || { echo "${SRC}#${NUM} (${SHA}) does not merge cleanly onto ${BASE} + the PRs listed before it; reorder or drop it in scripts/unsloth/pr-set.json" >&2; exit 1; }


### PR DESCRIPTION
The 07-31 nightly died because `cf67f0d2` was force-pushed out of ggml-org#26185 eleven minutes before the schedule ran. The commit had been reviewed and pinned; once it stopped being reachable from any ref, it was simply gone, and the only options were to repin onto whatever the author had replaced it with or drop the architecture from the release. Neither is a fix, and no amount of checking beforehand helps, because the object is destroyed after the check and before the build.

The missing piece is a ref of our own. Preflight now mirrors every pinned commit to `refs/pins/<sha>` in this repository, and `resolve` falls back to that mirror when the pin's own repository no longer has it:

```bash
git fetch -q --no-tags "https://github.com/${SRC}.git" "$SHA" 2>/dev/null \
  || git fetch -q --no-tags origin "refs/pins/${SHA}" 2>/dev/null \
  || { echo "...gone from ${SRC} and was never mirrored..."; exit 1; }
```

Notes:

- Every repo involved is in the same fork network, so the mirror push transfers no objects. It creates a ref pointing at something GitHub already stores.
- Mirroring happens before the merge probe and continues past individual failures, so a conflict in an early pin cannot leave later pins unmirrored. The probe loop still stops at the first conflict, as `resolve` does.
- Existing refs are skipped via `ls-remote`, so this is cheap on the normal path.
- Push failures are `::warning::` only. A mirror that cannot be written is worth knowing about, but it is not a reason to fail a check whose actual job is reporting merge conflicts.
- `resolve` additionally verifies the sha resolves to a commit after fetching, so a fetch that succeeds without producing the object cannot slip through to a merge.

`contents: write` on preflight is new and is only for `refs/pins/*`. Nothing in this workflow pushes a branch or a tag.
