### PR TITLE
Mirror pins with REPIN_TOKEN instead of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/unsloth-pin-preflight.yml
+++ b/.github/workflows/unsloth-pin-preflight.yml
@@ -21,8 +21,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  # write is only for the refs/pins/* mirror below; nothing here pushes a branch.
-  contents: write
+  contents: read
   issues: write
 
 jobs:
@@ -31,6 +30,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       GH_TOKEN: ${{ github.token }}
+      REPIN_TOKEN: ${{ secrets.REPIN_TOKEN }}
     steps:
       - uses: actions/checkout@v6
 
@@ -50,7 +50,16 @@ jobs:
 
           git clone -q --filter=blob:none https://github.com/ggml-org/llama.cpp.git scratch
           cd scratch
-          MIRROR="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          # GITHUB_TOKEN cannot write a ref whose tree carries .github/workflows,
+          # and upstream commits always do. Verified against the live remote:
+          #   ! [remote rejected] ... -> refs/pins/c3fb9724...
+          #   (refusing to allow a Personal Access Token to create or update
+          #    workflow `.github/workflows/build-self-hosted.yml` without
+          #    `workflow` scope)
+          # The check applies to any ref, not just branches. So use REPIN_TOKEN
+          # when it exists and say plainly what is unprotected when it does not.
+          MIRROR_TOKEN="${REPIN_TOKEN:-}"
+          MIRROR="https://x-access-token:${MIRROR_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git fetch -q --no-tags origin "refs/tags/${BASE}:refs/tags/${BASE}"
           git checkout -q --detach "refs/tags/${BASE}"
 
@@ -62,6 +71,10 @@ jobs:
           # Done first, and past failures, so a conflict in an early pin does
           # not leave the later ones unmirrored.
           while read -r url; do
+            if [ -z "$MIRROR_TOKEN" ]; then
+              echo "::warning::REPIN_TOKEN is not set, so pins are not mirrored; a force-push can still delete reviewed code"
+              break
+            fi
             SRC="$(sed -E 's|https://github.com/([^/]+)/llama.cpp/pull/.*|\1|' <<<"$url")/llama.cpp"
             SHA="$(sed -E 's|.*/commits/([0-9a-f]{40})/?$|\1|' <<<"$url")"
             if git ls-remote --exit-code "$MIRROR" "refs/pins/${SHA}" >/dev/null 2>&1; then
@@ -75,7 +88,7 @@ jobs:
             if git push -q "$MIRROR" "${SHA}:refs/pins/${SHA}" 2>&1 | sed "s|${GH_TOKEN}|***|g"; then
               echo "mirrored ${SHA:0:10}"
             else
-              echo "::warning::could not push refs/pins/${SHA:0:10}"
+              echo "::warning::could not push refs/pins/${SHA:0:10}; REPIN_TOKEN needs workflow scope"
             fi
           done < <(jq -r '.prs[] | if type == "string" then . else .url end' \
                      ../scripts/unsloth/pr-set.json)


### PR DESCRIPTION
Follow-up to #58, which as merged would not have worked.

I tested the mirror push against the live remote instead of assuming, and it is rejected:

```
! [remote rejected] c3fb9724... -> refs/pins/c3fb9724...
  (refusing to allow a Personal Access Token to create or update workflow
   `.github/workflows/build-self-hosted.yml` without `workflow` scope)
```

The workflow-scope check applies to **any** ref, not just branches and tags, and every upstream commit carries `.github/workflows`. So `GITHUB_TOKEN`, which has no workflow permission, cannot write `refs/pins/*` at all. #58 would have logged a warning every night and mirrored nothing, which is worse than not having the feature, because the fallback in `resolve` would have looked like protection that was not there.

The mirror now uses `REPIN_TOKEN` (the same secret the repin bot needs, which has workflow scope) and says plainly when it is absent:

```
::warning::REPIN_TOKEN is not set, so pins are not mirrored; a force-push can still delete reviewed code
```

`contents: write` on the job goes back to `contents: read`, since `GITHUB_TOKEN` is no longer the thing doing the writing.

The `resolve` fallback from #58 is unchanged and is already useful: I mirrored all four current pins by hand, so they are protected as of now.

```
refs/pins/04d6828b2b555ef300bae8096663c6e675afdd47
refs/pins/1e6f9e4a59138004e7936b543464afad71024a74
refs/pins/c3fb97241295c196e09b783e705e84b96cd1bd74
refs/pins/daef2b3e1b5b1ac7b575f13b13a9450cb2d02862
```
