### PR TITLE
Make alerting survive -e and always write the run summary

### DIFF
--- a/.github/actions/prebuilt-alert/action.yml
+++ b/.github/actions/prebuilt-alert/action.yml
@@ -41,9 +41,12 @@ runs:
         RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         REPO: ${{ github.repository }}
       run: |
+        # GitHub runs `shell: bash` with -e, which `set -uo pipefail` does not
+        # undo. Alerting must never fail the run it reports on, so turn it off
+        # explicitly; every gh call below is already individually tolerated.
+        set +e
         set -uo pipefail
 
-        # Alerting must never fail the run it reports on, so gh calls are tolerated.
         case "$STATUS" in
           failure|success) ;;
           *) echo "::warning::prebuilt-alert: unknown status '$STATUS'"; exit 0 ;;
@@ -79,6 +82,16 @@ runs:
           "$RUN_URL" \
           "$DETAILS")"
 
+        # The run summary always works: no token, no permission, no repo
+        # setting. Issues can be disabled (they are on a fresh fork), and an
+        # alert nobody can read is the failure this whole pipeline keeps
+        # having, so write the details somewhere visible before trying.
+        {
+          echo "## ${TITLE}"
+          echo
+          echo "$DETAILS"
+        } >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+
         if [ -n "$EXISTING" ]; then
           # Comment rather than open a second issue, so an outage is one thread.
           gh issue comment "$EXISTING" --repo "$REPO" --body "$BODY" >/dev/null 2>&1 \
@@ -89,11 +102,18 @@ runs:
           gh label create "$LABEL" --repo "$REPO" --color B60205 \
             --description "Prebuilt release pipeline is failing" >/dev/null 2>&1 || true
           NEW="$(gh issue create --repo "$REPO" --title "$TITLE" --label "$LABEL" \
-                   --body "$BODY" 2>/dev/null | tail -1)"
-          if [ -n "$NEW" ]; then
-            echo "opened $NEW ($KEY)"
-          else
-            # The one case worth shouting about: a real failure went unreported.
-            echo "::error::prebuilt-alert: could not open an issue for ${KEY}; the failure at ${RUN_URL} is unreported"
-          fi
+                   --body "$BODY" 2>&1 | tail -1)"
+          case "$NEW" in
+            https://*) echo "opened $NEW ($KEY)" ;;
+            *)
+              # The one case worth shouting about: a real failure went
+              # unreported. Name the usual cause so it is actionable.
+              if [ "$(gh api "repos/${REPO}" --jq .has_issues 2>/dev/null)" = "false" ]; then
+                echo "::error::prebuilt-alert: issues are disabled on ${REPO}, so ${KEY} cannot be tracked; see the run summary for details"
+              else
+                echo "::error::prebuilt-alert: could not open an issue for ${KEY} (${NEW}); the failure at ${RUN_URL} is unreported"
+              fi
+              ;;
+          esac
         fi
+        exit 0


### PR DESCRIPTION
I dispatched the repin bot to exercise its main body, which had only ever hit its skip branch. The bot worked. The alerting underneath it did not, and it turns out none of it ever has.

Two compounding bugs.

**The step aborted before it could report anything.** The action runs `set -uo pipefail` with a comment saying alerting must never fail the run it reports on. But GitHub invokes `shell: bash` as `/usr/bin/bash --noprofile --norc -e -o pipefail`, and `set -uo pipefail` does not undo the `-e` that is already in effect. So the first non-zero command killed the step with no output at all, which is why the failure looked like a mystery exit 1 rather than a diagnosable error. Now `set +e` explicitly, and the script ends in `exit 0`.

**Issues are disabled on this repository.** `has_issues=false`, which is the default for a fork. Every alert this pipeline can raise ends in `gh issue create`, so every one of them would have failed silently. The success path returns early without touching the API, which is why the preflight and dead-man runs have all been green and nothing looked wrong. My reports of "no open `prebuilt-failure` issues" were vacuous; there could never have been any.

So the alert now writes to `$GITHUB_STEP_SUMMARY` **before** trying the API. That needs no token, no permission and no repository setting, so the details are always readable on the run page even when the issue cannot be opened. If creation then fails, the error message names the cause instead of guessing:

```
::error::prebuilt-alert: issues are disabled on unslothai/llama.cpp, so llama-repin-bot cannot be tracked; see the run summary for details
```

I also stopped discarding `gh issue create`'s stderr, so the real API message reaches the log, and switched the success test from "output is non-empty" to "output is a URL", since the previous check treated an error message as success.

This makes failures visible. It does not make them tracked. Enabling Issues on the fork is a call for you rather than me, since a fork of a project this popular will attract bug reports meant for upstream. Until then the run summary is the alert.
