### PR TITLE
Report git's stderr when a merge fails without leaving conflicts

### DIFF
--- a/scripts/unsloth/repin.py
+++ b/scripts/unsloth/repin.py
@@ -150,10 +150,18 @@ def repin_one(pin: dict, base: str, work: Path) -> dict:
         res = json.loads(report.read_text()) if report.exists() else {}
         if rc != 0:
             out["action"] = "conflict"
-            out["files"] = [x["file"] for x in res.get("refused", [])]
-            out["note"] = "; ".join(
-                f"`{x['file']}`: {x['reason']}" for x in res.get("refused", [])
-            ) or "merge conflicted"
+            refused = res.get("refused", [])
+            out["files"] = [x["file"] for x in refused if x["file"] != "-"]
+            if out["files"]:
+                out["note"] = "; ".join(f"`{x['file']}`: {x['reason']}" for x in refused)
+            else:
+                # git refused the merge without leaving a single conflicted
+                # file, so the conflict report explains nothing. Its stderr is
+                # the only thing that does, and discarding it turns a
+                # diagnosable failure into "no conflicted files".
+                tail = ((m.stderr or "") + (m.stdout or "")).strip().splitlines()
+                out["note"] = ("merge failed with no conflicts: " + " / ".join(tail[-3:])
+                               if tail else "merge failed and git said nothing")
             run(["git", "merge", "--abort"], cwd=repo, check=False)
             return out
         out["hunks"] = [


### PR DESCRIPTION
The repin bot reported this for #24423:

```
**conflict, not resolvable automatically** -- `-`: no conflicted files
```

Which is not a thing that can happen. `git merge` returned non-zero, then `additive_merge.py` found nothing in `--diff-filter=U`, and the placeholder for "there were no conflicted files" got rendered as though it were the reason the conflict could not be resolved.

I could not reproduce it locally: against today's base the same merge succeeds cleanly with `Merge made by the 'ort' strategy`. So whatever git objected to on the runner was environmental rather than a real conflict, and the one piece of evidence that would have identified it, git's stderr, was being thrown away.

Now when the merge fails and leaves no conflicted files, the report carries the last few lines of git's actual output instead of a placeholder. The genuine-conflict path is unchanged, and `-` is filtered out of the file list so it can no longer be printed as a filename.

This is the same failure shape as the alerting bug in #62: a diagnostic that reported something other than what happened, which cost more time than the underlying fault would have. Tests still pass (14 assertions).