### PR TITLE
Stop duplicate pin preflights from queueing against each other

### DIFF
--- a/.github/workflows/unsloth-pin-preflight.yml
+++ b/.github/workflows/unsloth-pin-preflight.yml
@@ -24,6 +24,13 @@ permissions:
   contents: read
   issues: write
 
+# Every run probes the same pins against the same base, so a second one adds
+# nothing and just competes for runners. On 08-04 a dispatch and the schedule
+# sat queued together for an hour. Newest wins: it sees the newest pr-set.json.
+concurrency:
+  group: unsloth-pin-preflight
+  cancel-in-progress: true
+
 jobs:
   preflight:
     name: Dry-run the pin merges


### PR DESCRIPTION
The preflight has no concurrency group, so a `workflow_dispatch`, the schedule and a `pr-set.json` push can all be in flight at once doing byte-identical work: same base tag, same pins, same probe.

That happened today. A dispatch at 17:47 and the schedule at 18:17 sat queued together for an hour against a hosted runner pool that was already slow, each waiting behind the other for no benefit.

One group, newest wins. A newer run is strictly better informed since it reads the newest `pr-set.json`, and cancelling the older one costs nothing because it had not started.