### PR TITLE
Treat a cancelled job as a failed pipeline, not a healthy one

### DIFF
--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -743,7 +743,11 @@ jobs:
         run: |
           set -uo pipefail
           # 'skipped' is healthy: a scheduled no-op skips every build job.
-          FAILED="$(jq -r 'to_entries | map(select(.value.result == "failure") | .key) | join(", ")' <<<"$NEEDS_JSON")"
+          # 'cancelled' is not. On 08-05 every build passed and the publish job
+          # was cancelled 15s in by something outside the run, so nothing was
+          # released and this reported success: the silent no-publish we exist
+          # to catch. Anything that is not success or skipped counts.
+          FAILED="$(jq -r 'to_entries | map(select(.value.result != "success" and .value.result != "skipped") | "\(.key) (\(.value.result))") | join(", ")' <<<"$NEEDS_JSON")"
           if [ -z "$FAILED" ]; then
             echo "status=success" >> "$GITHUB_OUTPUT"
             echo "details=" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Tonight all 40 build jobs passed, then `Assemble metadata + publish` was cancelled 15 seconds in by something outside the run, mid artifact download. No release was published.

The health job reported success anyway, because it only counted `result == "failure"`. A cancelled job is neither failure nor skipped, so it fell through the filter.

That is the exact failure mode this alerting was built for: a green run that published nothing looks identical to a green run that had nothing to do. Now anything that is not `success` or `skipped` counts, and the reported result is named in the alert so a cancellation is not mistaken for a build failure.

`skipped` stays healthy, since a scheduled no-op skips every build job.