### PR TITLE
Fail the preflight run when a pin does not merge, so the repin bot fires

### DIFF
--- a/.github/workflows/unsloth-pin-preflight.yml
+++ b/.github/workflows/unsloth-pin-preflight.yml
@@ -158,3 +158,14 @@ jobs:
           title: 'Pinned PRs no longer merge onto the current base tag'
           details: ${{ steps.p.outputs.details }}
           token: ${{ github.token }}
+
+      # The probe reports through its output, so without this the run still
+      # ends green and unsloth-repin-bot.yml, which waits for a failed
+      # workflow_run, never fires. On 08-05 the Inkling pin stopped merging
+      # onto b10280, the alert said so, the run said success, and the bot
+      # skipped. Fails last so the alert is always posted first.
+      - name: Fail the run when a pin does not merge
+        if: ${{ steps.p.outputs.status == 'failure' }}
+        run: |
+          echo "::error::pins do not merge onto the current base tag; see the alert above"
+          exit 1


### PR DESCRIPTION
Today the preflight did its job and found that `ggml-org/llama.cpp#25731` (Inkling) no longer merges onto `b10280`. It wrote the alert, listed the conflicting files and quoted the hunks.

Then the run finished green, because the probe reports through a step output and nothing after it fails the job.

`unsloth-repin-bot.yml` triggers on `workflow_run.conclusion == 'failure'`, so it skipped. The one automation built to react to this never heard about it, and the only remaining signal was an alert on a repo with issues disabled.

This fails the run when the probe failed. It runs after the alert step, so the alert is still posted first and the details are not lost.