### PR TITLE
Repin Inkling and kimi-k3 so the nightly merges onto b10289

### DIFF
--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -10,8 +10,8 @@
   ],
   "prs": [
     "https://github.com/ggml-org/llama.cpp/pull/24423/commits/c3fb97241295c196e09b783e705e84b96cd1bd74",
-    "https://github.com/ggml-org/llama.cpp/pull/25731/commits/1e6f9e4a59138004e7936b543464afad71024a74",
-    "https://github.com/unslothai/llama.cpp/pull/48/commits/daef2b3e1b5b1ac7b575f13b13a9450cb2d02862",
+    "https://github.com/ggml-org/llama.cpp/pull/25731/commits/3fd7901cb40248fb4b959ce84f9be97e868e2e62",
+    "https://github.com/unslothai/llama.cpp/pull/48/commits/522ef818d44035b74478f63f3ecad878abed3d50",
     "https://github.com/ggml-org/llama.cpp/pull/26185/commits/04d6828b2b555ef300bae8096663c6e675afdd47"
   ]
 }

--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -11,7 +11,7 @@
   "prs": [
     "https://github.com/ggml-org/llama.cpp/pull/24423/commits/c3fb97241295c196e09b783e705e84b96cd1bd74",
     "https://github.com/ggml-org/llama.cpp/pull/25731/commits/3fd7901cb40248fb4b959ce84f9be97e868e2e62",
-    "https://github.com/unslothai/llama.cpp/pull/48/commits/522ef818d44035b74478f63f3ecad878abed3d50",
+    "https://github.com/unslothai/llama.cpp/pull/48/commits/768d2a481a99cb75ec9a03b95dadbd35e7acf496",
     "https://github.com/ggml-org/llama.cpp/pull/26185/commits/04d6828b2b555ef300bae8096663c6e675afdd47"
   ]
 }


### PR DESCRIPTION
The nightly has failed since 08-05: `ggml-org#25731` (Inkling) stopped merging once the base moved to b10280, and it stayed broken through b10285 and b10289.

Two pins move:

- `ggml-org#25731`: `1e6f9e4a59` -> `3fd7901cb4`. The author merged master this morning, which resolves it upstream.
- `unslothai#48`: `daef2b3e1b` -> `522ef818d4`. Our branch is stacked on Inkling, so the newer Inkling head conflicted with our older copy of it. I merged the new head into our branch; the only conflict was the WebGPU skip list, where our side is a superset (it adds MINIMAX_M3 and KIMI_K3 to their DEEPSEEK32/GLM_DSA), so the union is our side.

`ggml-org#26185` deliberately stays at `04d6828b2b`. Its newer head `a614fab10b` drops `case LLM_ARCH_INKLING` and KIMI_K3 from the WebGPU skip list, so it conflicts against the pins ahead of it. Newest is not always mergeable.

Verified by replaying the nightly's own merge sequence onto `b10289` before opening this:

```
ok #24423 @ c3fb972412
ok #25731 @ 3fd7901cb4
ok #48   @ 522ef818d4
ok #26185 @ 04d6828b2b
```