### PR TITLE
Let the preflight actually push refs/pins, and report why when it cannot

### DIFF
--- a/.github/workflows/unsloth-pin-preflight.yml
+++ b/.github/workflows/unsloth-pin-preflight.yml
@@ -21,7 +21,11 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  # write, not read: the mirror step pushes refs/pins/<sha>. With read it
+  # failed every time with "Permission to unslothai/llama.cpp.git denied to
+  # github-actions[bot]" (403), and the only refs that existed were ones
+  # pushed by hand.
+  contents: write
   issues: write
 
 # Every run probes the same pins against the same base, so a second one adds
@@ -90,10 +94,12 @@ jobs:
               echo "::warning::cannot mirror ${SHA:0:10}; it is already unfetchable from ${SRC}"
               continue
             fi
-            if git push -q "$MIRROR" "${SHA}:refs/pins/${SHA}" 2>&1 | sed "s|${GH_TOKEN}|***|g"; then
+            # Report git's own error. Guessing the cause hid a 403 behind a
+            # workflow-scope message for a week.
+            if ERR="$(git push -q "$MIRROR" "${SHA}:refs/pins/${SHA}" 2>&1)"; then
               echo "mirrored ${SHA:0:10}"
             else
-              echo "::warning::could not mirror refs/pins/${SHA:0:10}; it adds a workflow file, which needs REPIN_TOKEN (workflow scope). That pin is still deletable by a force-push."
+              echo "::warning::could not mirror refs/pins/${SHA:0:10}: $(sed "s|${MIRROR_TOKEN}|***|g" <<<"$ERR" | tr '\n' ' '). A ref adding a workflow file needs REPIN_TOKEN (workflow scope); that pin stays deletable by a force-push."
             fi
           done < <(jq -r '.prs[] | if type == "string" then . else .url end' \
                      ../scripts/unsloth/pr-set.json)


### PR DESCRIPTION
The pin mirror has never worked from CI. Today's run on the repin branch shows why:

```
remote: Permission to unslothai/llama.cpp.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/unslothai/llama.cpp.git/': The requested URL returned error: 403
could not mirror refs/pins/3fd7901cb4; it adds a workflow file, which needs REPIN_TOKEN
```

The job declares `contents: read`, so the push cannot succeed for any ref. Every `refs/pins/*` that exists today was pushed by hand; the runs that reported `mirrored already` were reading those.

The warning also asserted a cause it never checked, so a plain 403 was reported for a week as a workflow-scope problem. It now quotes git's own message, with the token masked, and keeps the workflow-scope note as context rather than a diagnosis.

The 08-03 observation behind that note was real, but it applies only once the push is permitted at all.