### PR TITLE
Resolve pure add/add pin conflicts automatically, and pin the slim kimi-k3 PR

### DIFF
--- a/.github/workflows/unsloth-pin-preflight.yml
+++ b/.github/workflows/unsloth-pin-preflight.yml
@@ -122,8 +122,18 @@ jobs:
               continue
             fi
             if git -c user.name=preflight -c user.email=preflight@local \
+                 -c merge.conflictStyle=diff3 \
                  merge --no-ff --no-edit -m "probe ${SRC}#${NUM}" "$SHA" >/dev/null 2>&1; then
               echo "ok ${SRC}#${NUM}"
+              continue
+            fi
+            # Mirror resolve: a pure add/add is what the nightly will merge
+            # automatically, so reporting it as a conflict here is a false
+            # alarm. Anything additive_merge.py refuses is still a conflict.
+            if python3 ../scripts/unsloth/additive_merge.py >/dev/null 2>&1 \
+                 && [ -z "$(git diff --name-only --diff-filter=U)" ]; then
+              git -c user.name=preflight -c user.email=preflight@local commit -q --no-edit
+              echo "ok ${SRC}#${NUM} (additive resolve)"
               continue
             fi
             FILES="$(git diff --name-only --diff-filter=U | sed 's/^/  /')"

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -280,9 +280,26 @@ jobs:
                 if ! git rev-parse --verify -q "${SHA}^{commit}" >/dev/null; then
                   echo "fetched something for ${SRC}#${NUM} but ${SHA} is still missing" >&2; exit 1
                 fi
-                git -c user.name='github-actions[bot]' -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
-                  merge --no-ff --no-edit -m "Merge ${SRC}#${NUM} @ ${SHA}" "$SHA" \
-                  || { echo "${SRC}#${NUM} (${SHA}) does not merge cleanly onto ${BASE} + the PRs listed before it; reorder or drop it in scripts/unsloth/pr-set.json" >&2; exit 1; }
+                # diff3 so additive_merge.py can see the merge base and refuse
+                # anything that is not a pure add/add.
+                if ! git -c user.name='github-actions[bot]' -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+                       -c merge.conflictStyle=diff3 \
+                       merge --no-ff --no-edit -m "Merge ${SRC}#${NUM} @ ${SHA}" "$SHA"; then
+                  # The recurring conflict is two PRs adding a line to the same
+                  # architecture table, where the answer is always "keep both".
+                  # additive_merge.py resolves only that, and refuses when
+                  # either side edited existing text, so a real disagreement
+                  # still hard-fails here rather than being papered over.
+                  if python3 scripts/unsloth/additive_merge.py \
+                       && [ -z "$(git diff --name-only --diff-filter=U)" ]; then
+                    git -c user.name='github-actions[bot]' -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+                      commit -q --no-edit
+                    echo "::warning::${SRC}#${NUM} needed an additive merge; every conflict was a pure add/add and both sides were kept"
+                  else
+                    git merge --abort 2>/dev/null
+                    echo "${SRC}#${NUM} (${SHA}) does not merge cleanly onto ${BASE} + the PRs listed before it; reorder or drop it in scripts/unsloth/pr-set.json" >&2; exit 1
+                  fi
+                fi
               done < <(jq -r '.[] | "\(.repo) \(.number) \(.sha)"' <<<"$PRS")
             else
               # Plain build: only the base tree is needed. Shallow is fine -- the

--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -10,8 +10,7 @@
   ],
   "prs": [
     "https://github.com/ggml-org/llama.cpp/pull/24423/commits/c3fb97241295c196e09b783e705e84b96cd1bd74",
-    "https://github.com/ggml-org/llama.cpp/pull/25731/commits/1e6f9e4a59138004e7936b543464afad71024a74",
-    "https://github.com/unslothai/llama.cpp/pull/48/commits/daef2b3e1b5b1ac7b575f13b13a9450cb2d02862",
-    "https://github.com/ggml-org/llama.cpp/pull/26185/commits/04d6828b2b555ef300bae8096663c6e675afdd47"
+    "https://github.com/ggml-org/llama.cpp/pull/25731/commits/3fd7901cb40248fb4b959ce84f9be97e868e2e62",
+    "https://github.com/unslothai/llama.cpp/pull/70/commits/06d2326acbf515b10f8d6abeada09123d361acde"
   ]
 }


### PR DESCRIPTION
Two changes, both aimed at the failure that has cost the nightly three days.

**Pin set.** `unslothai#48` is replaced by `unslothai#70`, which carries only what is genuinely not upstream: the MoonViT-3d vision tower, the full-size loading fixes and the new SSM_A_NOSCAN change. `ggml-org#26185` drops out as a separate entry because #70 is built on it, so pinning both would merge the same commits twice. #48 duplicated the text-side work that 26185 has since absorbed, which is what forced a re-reconciliation every time either side moved.

**Resolve.** Every conflict that has broken the nightly this week has been the same shape: two PRs adding a line to the same architecture table, where the answer is always to keep both. `scripts/unsloth/additive_merge.py` already exists for exactly this and refuses anything else, so resolve now falls back to it on a conflicted merge, and only when it resolves every file. The merge runs with `merge.conflictStyle=diff3` so the script can see the merge base and tell a pure add/add from an edit. A genuine disagreement still hard-fails with the same message, and an automatic resolution is announced with a `::warning::` rather than passing silently.

Verified by replaying the nightly's own merge sequence onto `b10290`:

```
ok 24423 (clean)
ok 25731 (clean)
ok 70    (additive resolve)
```

The three conflicts in `src/llama-arch.cpp`, `src/llama-model.cpp` and `tools/mtmd/CMakeLists.txt` were all `case LLM_ARCH_KIMI_K3:` / source-list additions. The resulting tree has no conflict markers and every `models/*.cpp` the CMakeLists references resolves to a real file.