### PR TITLE
Give the ROCm builds a ccache, and stop capping every cache at 500 MB

### DIFF
--- a/.github/workflows/unsloth-prebuilt-cpu.yml
+++ b/.github/workflows/unsloth-prebuilt-cpu.yml
@@ -95,13 +95,14 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.20
+        uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: cpu-linux-${{ matrix.arch }}-${{ inputs.tag }}
           restore-keys: |
             cpu-linux-${{ matrix.arch }}
           append-timestamp: false
           variant: ccache
+          max-size: 2G
           save: false
 
       - name: Configure
@@ -219,13 +220,14 @@ jobs:
           tar -xzf "srcpkg/llama.cpp-source-${{ inputs.tag }}.tar.gz" -C src --strip-components=1
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.20
+        uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: cpu-windows-${{ matrix.arch }}-${{ inputs.tag }}
           restore-keys: |
             cpu-windows-${{ matrix.arch }}
           append-timestamp: false
           variant: ccache
+          max-size: 2G
           save: false
 
       - name: Install Ninja

--- a/.github/workflows/unsloth-prebuilt-cuda-windows.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda-windows.yml
@@ -74,13 +74,14 @@ jobs:
           tar -xzf "srcpkg/llama.cpp-source-${{ inputs.tag }}.tar.gz" -C src --strip-components=1
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.20
+        uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-${{ inputs.tag }}
           restore-keys: |
             cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}
           append-timestamp: false
           variant: ccache
+          max-size: 2G
           save: false
 
       - uses: actions/setup-python@v6

--- a/.github/workflows/unsloth-prebuilt-cuda.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda.yml
@@ -93,13 +93,14 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.20
+        uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ inputs.tag }}
           restore-keys: |
             cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}
           append-timestamp: false
           variant: ccache
+          max-size: 2G
           save: false
 
       # Jimver has no mapping for CUDA 13.3 yet, so for that version we pull the

--- a/.github/workflows/unsloth-prebuilt-macos.yml
+++ b/.github/workflows/unsloth-prebuilt-macos.yml
@@ -68,12 +68,32 @@ jobs:
           mkdir -p src
           tar -xzf "srcpkg/llama.cpp-source-${{ inputs.tag }}.tar.gz" -C src --strip-components=1
 
+      # The macOS legs were the last build jobs without a compiler cache. Metal's
+      # backend is Objective-C, and the arm64 leg is the only one that builds it
+      # (the x64 leg passes -DGGML_METAL=OFF), so the OBJC launchers matter here
+      # in a way they do not elsewhere. Setting a launcher for a language this
+      # build never enables is inert, so both are set unconditionally.
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2.23
+        with:
+          key: macos-${{ matrix.build }}-${{ matrix.deploy_target }}-${{ inputs.tag }}
+          restore-keys: |
+            macos-${{ matrix.build }}-${{ matrix.deploy_target }}
+          append-timestamp: false
+          variant: ccache
+          max-size: 2G
+          save: false
+
       - name: Build (deployment target ${{ matrix.deploy_target }})
         working-directory: src
         run: |
           set -euo pipefail
           cmake -B build \
             ${{ matrix.defines }} \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_OBJC_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_OBJCXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_OSX_DEPLOYMENT_TARGET=${{ matrix.deploy_target }} \
             -DCMAKE_INSTALL_RPATH='@loader_path' \
             -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
@@ -127,3 +147,13 @@ jobs:
           name: app-${{ inputs.tag }}-macos-${{ matrix.build }}
           path: dist/llama-${{ inputs.tag }}-bin-macos-${{ matrix.build }}.tar.gz
           if-no-files-found: error
+
+      - name: Evict stale ccache files
+        continue-on-error: true
+        run: ccache --evict-older-than 14d
+
+      - name: Save ccache
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ github.workspace }}/.ccache
+          key: ccache-macos-${{ matrix.build }}-${{ matrix.deploy_target }}-${{ inputs.tag }}-

--- a/.github/workflows/unsloth-prebuilt-rocm.yml
+++ b/.github/workflows/unsloth-prebuilt-rocm.yml
@@ -260,6 +260,22 @@ jobs:
         # Extract the tarball
         tar -xzf rocm.tar.gz -C C:\opt\rocm --strip-components=1
 
+    # Keyed per gfx target and OS: the seven targets compile different device
+    # code from the same host sources, so a shared cache would mostly miss.
+    # save: false -- the explicit actions/cache/save step at the end of the job
+    # runs after packaging, so a failed package step does not persist a cache
+    # for a bundle that never shipped (same pattern as the CPU/CUDA children).
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2.23
+      with:
+        key: rocm-windows-${{ matrix.gfx_target }}-${{ inputs.tag }}
+        restore-keys: |
+          rocm-windows-${{ matrix.gfx_target }}
+        append-timestamp: false
+        variant: ccache
+        max-size: 2G
+        save: false
+
     # The parent's resolve job built the source tree (upstream base + any mix
     # PRs, with the build number/commit and Unsloth fingerprint baked
     # into cmake/build-info.cmake) and uploaded it as an artifact; extract it
@@ -320,6 +336,8 @@ jobs:
         cd build
 
         REM Configure the project
+        REM Only the C/CXX launchers here: ggml-hip forces CXX_IS_HIPCC on
+        REM WIN32, so the device sources compile as C++, not the HIP language.
         cmake .. -G Ninja ^
           -DCMAKE_C_COMPILER="C:\opt\rocm\lib\llvm\bin\clang.exe" ^
           -DCMAKE_CXX_COMPILER="C:\opt\rocm\lib\llvm\bin\clang++.exe" ^
@@ -337,6 +355,8 @@ jobs:
           -DLLAMA_BUILD_BORINGSSL=ON ^
           -DGGML_NATIVE=OFF ^
           -DGGML_STATIC=OFF ^
+          -DCMAKE_C_COMPILER_LAUNCHER=ccache ^
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache ^
           -DCMAKE_SYSTEM_NAME=Windows
 
         REM Build the project
@@ -437,6 +457,23 @@ jobs:
         name: app-${{ inputs.tag }}-windows-x64-rocm-${{ matrix.gfx_target }}
         path: dist/app-${{ inputs.tag }}-windows-x64-rocm-${{ matrix.gfx_target }}.zip
         if-no-files-found: error
+
+    # ROCm is the first backend here to run device code through ccache, so log
+    # the hit rate: a non-zero "unsupported source language" would mean the
+    # device TUs are falling through to the real compiler uncached.
+    - name: ccache stats
+      continue-on-error: true
+      run: ccache --show-stats -v
+
+    - name: Evict stale ccache files
+      continue-on-error: true
+      run: ccache --evict-older-than 14d
+
+    - name: Save ccache
+      uses: actions/cache/save@v6
+      with:
+        path: ${{ github.workspace }}\.ccache
+        key: ccache-rocm-windows-${{ matrix.gfx_target }}-${{ inputs.tag }}-
 
   build-ubuntu:
     name: linux/${{ matrix.gfx_target }}
@@ -610,6 +647,18 @@ jobs:
 
         echo "ROCm environment variables set successfully"
 
+    # See the Windows job for why the key is per gfx target and why save: false.
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2.23
+      with:
+        key: rocm-linux-${{ matrix.gfx_target }}-${{ inputs.tag }}
+        restore-keys: |
+          rocm-linux-${{ matrix.gfx_target }}
+        append-timestamp: false
+        variant: ccache
+        max-size: 2G
+        save: false
+
     # The parent's resolve job built the source tree (upstream base + any mix
     # PRs, with the build number/commit and Unsloth fingerprint baked
     # into cmake/build-info.cmake) and uploaded it as an artifact; extract it
@@ -653,6 +702,10 @@ jobs:
         cd build
 
         # Configure the project
+        # CMAKE_HIP_COMPILER_LAUNCHER is needed here but not on Windows: the
+        # CXX compiler is ROCm's clang++ (not hipcc), so ggml-hip leaves
+        # CXX_IS_HIPCC false and calls enable_language(HIP), putting the device
+        # sources on the HIP language rather than CXX.
         cmake .. -G Ninja \
           -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang \
           -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++ \
@@ -670,6 +723,9 @@ jobs:
           -DLLAMA_BUILD_BORINGSSL=ON \
           -DGGML_NATIVE=OFF \
           -DGGML_STATIC=OFF \
+          -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_HIP_COMPILER_LAUNCHER=ccache \
           -DCMAKE_SYSTEM_NAME=Linux
 
         # Build the project
@@ -781,3 +837,18 @@ jobs:
         name: app-${{ inputs.tag }}-linux-x64-rocm-${{ matrix.gfx_target }}
         path: dist/app-${{ inputs.tag }}-linux-x64-rocm-${{ matrix.gfx_target }}.tar.gz
         if-no-files-found: error
+
+    # See the Windows job: logs whether the HIP-language TUs actually cache.
+    - name: ccache stats
+      continue-on-error: true
+      run: ccache --show-stats -v
+
+    - name: Evict stale ccache files
+      continue-on-error: true
+      run: ccache --evict-older-than 14d
+
+    - name: Save ccache
+      uses: actions/cache/save@v6
+      with:
+        path: ${{ github.workspace }}/.ccache
+        key: ccache-rocm-linux-${{ matrix.gfx_target }}-${{ inputs.tag }}-

--- a/.github/workflows/unsloth-prebuilt-vulkan.yml
+++ b/.github/workflows/unsloth-prebuilt-vulkan.yml
@@ -100,13 +100,14 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.20
+        uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: vulkan-linux-${{ matrix.arch }}-${{ inputs.tag }}
           restore-keys: |
             vulkan-linux-${{ matrix.arch }}
           append-timestamp: false
           variant: ccache
+          max-size: 2G
           save: false
 
       # Ubuntu 22.04 has an arm64 Vulkan loader, but its headers are too old for
@@ -254,13 +255,14 @@ jobs:
           tar -xzf "srcpkg/llama.cpp-source-${{ inputs.tag }}.tar.gz" -C src --strip-components=1
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.20
+        uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: vulkan-windows-x64-${{ inputs.tag }}
           restore-keys: |
             vulkan-windows-x64
           append-timestamp: false
           variant: ccache
+          max-size: 2G
           save: false
 
       - name: Install Ninja


### PR DESCRIPTION
## What

Two related ccache changes:

1. Give the ROCm build legs a ccache. They had none at all. That is 14 of the 38 build jobs (7 gfx targets x 2 OSes).
2. Set `max-size` on every ccache step. It was never set anywhere, so all six existing steps were running on `hendrikmuhs/ccache-action`'s default of `500MB`. Now `2G`.

Also bumps `hendrikmuhs/ccache-action` from `v1.2.20` to `v1.2.23` in the same pass.

## Why

`Build Llama.cpp + ROCm` is 317 job-minutes, 49% of a full run, and every one of those minutes recompiles a tree that barely changed since the night before.

On the legs that do have a cache, 500 MB is below the working set: every CUDA leg sitting on the ceiling still misses 40-190 translation units per run, while every leg that stays under it converges to a 99%+ hit rate. Restore + save costs 0.1-0.3 min per job at ~460 MB, so a bigger cache costs nothing measurable in transfer time.

## ROCm specifics

The two OSes need different launcher flags, and the reason is in `ggml/src/ggml-hip/CMakeLists.txt`:

- **Windows** sets `CXX_IS_HIPCC TRUE` unconditionally under `if (WIN32)`, which skips `enable_language(HIP)` and puts the device sources on `LANGUAGE CXX`. So only `CMAKE_C_COMPILER_LAUNCHER` / `CMAKE_CXX_COMPILER_LAUNCHER` are needed.
- **Linux** sets `CXX_IS_HIPCC` from `string(REGEX MATCH "hipcc(\.bat)?$" ...)` against `CMAKE_CXX_COMPILER`. We pass `/opt/rocm/llvm/bin/clang++`, which does not match, so the `else()` branch runs `enable_language(HIP)` and the device sources are on the HIP language. That needs `CMAKE_HIP_COMPILER_LAUNCHER` as well, or the `.cu` TUs, which are the expensive ones, never touch the cache.

Cache keys are scoped per gfx target and per OS so the seven targets do not collide. `--offload-arch` is part of ccache's hash anyway, so a shared cache would be correct but would mostly miss.

### Does ccache actually cache HIP?

Yes, and this is worth spelling out because sccache is the tool usually named for this.

- HIP has been a first-class language in ccache since 4.0 (2020), per `doc/news.adoc`.
- ccache carries a regression suite for exactly this, `test/suites/profiling_hip_clang.bash`, which asserts both a direct and a preprocessed cache hit for `clang -x hip --cuda-gpu-arch=gfxNNNN`, and asserts a miss when the arch changes.
- The Windows `.cu`-as-C++ path is even more boring: CMake emits an explicit `-x c++`, so it goes through ccache's plain C++ path.
- Nothing HIP-related is on ccache's `TOO_HARD` list. `--offload-arch`, `-fgpu-rdc` and friends fall through to "keep and hash", which is both cacheable and correct.

Prior art for `CMAKE_HIP_COMPILER_LAUNCHER=ccache` specifically: ROCm/aotriton, Viskores, PaddlePaddle, vLLM's ROCm Dockerfile, MIOpen.

The downside risk is small either way: when ccache cannot handle a TU it `exec`s the real compiler unchanged, so the worst case is no speedup rather than a broken build.

## Measured vs projected

**Measured:**
- ROCm is 317 job-min, 49% of the run, with no cache.
- `max-size` is unset in all six existing steps, and the action defaults it to `500MB` (checked in `action.yml` at both v1.2.20 and v1.2.23).
- Legs pinned at the 500 MB ceiling still miss 40-190 TUs; legs below it reach 99%+.
- A warm same-mix-hash run took 636 job-min against 1,961 cold for the same commit.
- Restore + save is 0.1-0.3 min per job at ~460 MB.

**Projected, not observed:**
- ~230-250 job-min saved on ROCm, and the ROCm critical path dropping from 44 min to roughly 12.
- The hit rate the ROCm legs will actually reach.

To close that gap rather than argue about it, both ROCm jobs now run `ccache --show-stats -v` after the build. The first nightly will say plainly what the hit rate is, and a non-zero "unsupported source language" would be the signal that the device TUs are falling through uncached.

## Cache storage budget, worth watching

Raising the ceiling has a storage consequence that the eviction policy will otherwise sort out for us, badly. Current state, measured just now via the API:

- 74 active cache entries, 23.5 GB total.
- 22 ccache-using build jobs today, so about 4 tag generations alive per leg. `inputs.tag` is in the save key, so every nightly writes a new entry per leg and old ones sit until the 7-day access expiry.
- This PR takes that to 36 legs and raises the per-leg ceiling 4x.

The repo cache limit is currently 50 GB. Generations, not per-leg size, are what dominate that number, so the follow-up that actually bounds it is upstream's `.github/actions/ccache-clear` composite, which prunes older generations of the same key prefix. Happy to do that as a separate PR. If cache usage does run over the limit, the failure mode is LRU eviction, i.e. degrading back towards today's hit rates, not a build failure.

## Notes for whoever reads the keys next

The trailing `-` on the manual `actions/cache/save` keys looks like a typo and is not. `ccache-action` builds its restore key as `"ccache-" + key + "-"` because `append-timestamp` is read with `core.getInput`, so the string `"false"` is still truthy on the restore side. The manual save keys have to carry that trailing dash to match, and the new ROCm ones do too. Removing it would silently break the exact-key path.

## Also worth flagging, not changed here

- `ubuntu-22.04` deprecation starts 2026-09-17 with 24-hour brownouts and explicitly longer queue times, fully unsupported 2027-04-17. Every tail job and most build legs are on it.
- Upstream now uses `ggml-org/ccache-action@v1.2.21`, a maintained fork, plus an hourly `build-cache.yml` pre-warm cron. Both are reasonable follow-ups.
- The macOS legs still have no ccache. Left alone deliberately to keep this PR to one subject.

## Verification

Static only, no dispatch. The org runner pool is saturated and a full prebuilt run is 38 jobs.

- All workflows parse, and `actionlint` (plus shellcheck) is clean on the changed files apart from pre-existing findings.
- The `v1.2.20` to `v1.2.23` upgrade was checked against both tags' sources rather than assumed: key construction, `cacheDir()` and the `save: false` skip logic are byte-identical, so existing saved caches still hit. The real changes are in the installer path, ccache 4.9 to 4.13.3 and Node 20 to 24.
- The HIP launcher flags were checked against `ggml/src/ggml-hip/CMakeLists.txt` in this tree, not from memory.
