### PR TITLE
Report disk space on the CUDA Windows legs

### DIFF
--- a/.github/workflows/unsloth-prebuilt-cuda-windows.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda-windows.yml
@@ -52,6 +52,46 @@ jobs:
       run:
         shell: pwsh
     steps:
+      # The only build legs with no disk management: a 14 GB SSD that has to
+      # hold a full CUDA toolkit plus the largest object set in the matrix
+      # (7-8 architectures of nvcc output). The Linux CUDA legs already run
+      # jlumbroso/free-disk-space first; there is no Windows equivalent, so
+      # remove the preinstalled SDKs this build never touches. Best-effort:
+      # a locked or already-absent path must not fail the job. The before/after
+      # numbers are logged so the next runner death has evidence either way --
+      # `x64/cuda12-portable` ran 87 minutes and lost communication with the
+      # server, which skipped assemble and published nothing.
+      - name: Free disk space
+        continue-on-error: true
+        run: |
+          function Show-Free($when) {
+            $d = Get-PSDrive C
+            "{0}: C: {1:N1} GB free of {2:N1} GB" -f $when, ($d.Free / 1GB), (($d.Used + $d.Free) / 1GB)
+          }
+          Show-Free "before"
+          # Nothing here is used by the MSVC + Ninja + CUDA + Python toolchain.
+          # hostedtoolcache Python is NOT in this list: setup-python needs it.
+          $paths = @(
+            "C:\Android",
+            "C:\Program Files (x86)\Android",
+            "C:\ghcup",
+            "C:\hostedtoolcache\windows\CodeQL",
+            "C:\hostedtoolcache\windows\Java_Temurin-Hotspot_jdk",
+            "C:\hostedtoolcache\windows\Ruby",
+            "C:\hostedtoolcache\windows\go",
+            "C:\Program Files\Microsoft SDKs\Azure\CLI2",
+            "C:\Program Files\MongoDB",
+            "C:\Program Files\PostgreSQL",
+            "C:\Program Files\MySQL"
+          )
+          foreach ($p in $paths) {
+            if (Test-Path $p) {
+              Write-Host "removing $p"
+              Remove-Item -Recurse -Force $p -ErrorAction SilentlyContinue
+            }
+          }
+          Show-Free "after"
+
       - name: Checkout build tooling (this repo)
         uses: actions/checkout@v6
         with:
@@ -144,6 +184,14 @@ jobs:
 
       - name: Verify CUDA
         run: nvcc --version
+
+      # Headroom going into the build, with the toolkit and the restored ccache
+      # already on disk. This is the number to look at first if a leg dies
+      # mid-build.
+      - name: Report disk space before build
+        run: |
+          $d = Get-PSDrive C
+          "C: {0:N1} GB free of {1:N1} GB" -f ($d.Free / 1GB), (($d.Used + $d.Free) / 1GB)
 
       - name: Configure
         working-directory: src

--- a/.github/workflows/unsloth-prebuilt-cuda-windows.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda-windows.yml
@@ -52,21 +52,23 @@ jobs:
       run:
         shell: pwsh
     steps:
-      # The only build legs with no disk management: a 14 GB SSD that has to
-      # hold a full CUDA toolkit plus the largest object set in the matrix
-      # (7-8 architectures of nvcc output). The Linux CUDA legs already run
-      # jlumbroso/free-disk-space first; there is no Windows equivalent, so
+      # The only build legs with no disk management: the Linux CUDA legs run
+      # jlumbroso/free-disk-space first and there is no Windows equivalent, so
       # remove the preinstalled SDKs this build never touches. Best-effort:
-      # a locked or already-absent path must not fail the job. The before/after
-      # numbers are logged so the next runner death has evidence either way --
-      # `x64/cuda12-portable` ran 87 minutes and lost communication with the
-      # server, which skipped assemble and published nothing.
+      # a locked or already-absent path must not fail the job.
+      #
+      # The work is split across two volumes and every report here covers both,
+      # because a leg that dies mid-build can only be read against the volume it
+      # was writing to: the toolkit, the tool cache and Program Files are on C:,
+      # while GITHUB_WORKSPACE -- the source tree, the CMake build tree and the
+      # ccache -- is on D:. Only C: has anything worth reclaiming.
       - name: Free disk space
         continue-on-error: true
         run: |
           function Show-Free($when) {
-            $d = Get-PSDrive C
-            "{0}: C: {1:N1} GB free of {2:N1} GB" -f $when, ($d.Free / 1GB), (($d.Used + $d.Free) / 1GB)
+            Get-CimInstance Win32_LogicalDisk -Filter 'DriveType = 3' | Sort-Object DeviceID | ForEach-Object {
+              "{0}: {1} {2:N1} GB free of {3:N1} GB" -f $when, $_.DeviceID, ($_.FreeSpace / 1GB), ($_.Size / 1GB)
+            }
           }
           Show-Free "before"
           # Nothing here is used by the MSVC + Ninja + CUDA + Python toolchain.
@@ -185,13 +187,15 @@ jobs:
       - name: Verify CUDA
         run: nvcc --version
 
-      # Headroom going into the build, with the toolkit and the restored ccache
-      # already on disk. This is the number to look at first if a leg dies
-      # mid-build.
+      # Headroom going into the build, with the toolkit on C: and the restored
+      # ccache in the workspace on D:. First numbers to read if a leg dies
+      # mid-build; the build itself writes to the workspace volume.
       - name: Report disk space before build
         run: |
-          $d = Get-PSDrive C
-          "C: {0:N1} GB free of {1:N1} GB" -f ($d.Free / 1GB), (($d.Used + $d.Free) / 1GB)
+          "workspace: $env:GITHUB_WORKSPACE"
+          Get-CimInstance Win32_LogicalDisk -Filter 'DriveType = 3' | Sort-Object DeviceID | ForEach-Object {
+            "{0} {1:N1} GB free of {2:N1} GB" -f $_.DeviceID, ($_.FreeSpace / 1GB), ($_.Size / 1GB)
+          }
 
       - name: Configure
         working-directory: src

--- a/.github/workflows/unsloth-prebuilt-cuda-windows.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda-windows.yml
@@ -52,47 +52,27 @@ jobs:
       run:
         shell: pwsh
     steps:
-      # The only build legs with no disk management: the Linux CUDA legs run
-      # jlumbroso/free-disk-space first and there is no Windows equivalent, so
-      # remove the preinstalled SDKs this build never touches. Best-effort:
-      # a locked or already-absent path must not fail the job.
+      # Report both fixed volumes at job start. The work is split across two:
+      # the CUDA toolkit, the tool cache and Program Files land on C:, while
+      # GITHUB_WORKSPACE -- the source tree, the CMake build tree and the ccache
+      # -- is on D:. A leg that dies mid-build can only be read against the
+      # volume it was writing to, so both are printed here and again after the
+      # toolkit install.
       #
-      # The work is split across two volumes and every report here covers both,
-      # because a leg that dies mid-build can only be read against the volume it
-      # was writing to: the toolkit, the tool cache and Program Files are on C:,
-      # while GITHUB_WORKSPACE -- the source tree, the CMake build tree and the
-      # ccache -- is on D:. Only C: has anything worth reclaiming.
-      - name: Free disk space
-        continue-on-error: true
+      # No cleanup step, deliberately. One was written and then measured on a
+      # live windows-2022 runner: D: starts at 147.0 GB free of 150.0 and C: at
+      # 84.3 of 255.4, and the CUDA 12.8 toolkit is 4.79 GB, so C: never drops
+      # below about 106 GB. Reclaiming ~33 GB of preinstalled SDKs on every leg
+      # would have freed the volume that was not under pressure, on every
+      # release, forever. The 87-minute "runner lost communication" failure was
+      # not disk exhaustion, and unsloth-prebuilt-retry.yml already covers that
+      # class of infrastructure loss.
+      - name: Report disk space
         run: |
-          function Show-Free($when) {
-            Get-CimInstance Win32_LogicalDisk -Filter 'DriveType = 3' | Sort-Object DeviceID | ForEach-Object {
-              "{0}: {1} {2:N1} GB free of {3:N1} GB" -f $when, $_.DeviceID, ($_.FreeSpace / 1GB), ($_.Size / 1GB)
-            }
+          "workspace: $env:GITHUB_WORKSPACE"
+          Get-CimInstance Win32_LogicalDisk -Filter 'DriveType = 3' | Sort-Object DeviceID | ForEach-Object {
+            "{0} {1:N1} GB free of {2:N1} GB" -f $_.DeviceID, ($_.FreeSpace / 1GB), ($_.Size / 1GB)
           }
-          Show-Free "before"
-          # Nothing here is used by the MSVC + Ninja + CUDA + Python toolchain.
-          # hostedtoolcache Python is NOT in this list: setup-python needs it.
-          $paths = @(
-            "C:\Android",
-            "C:\Program Files (x86)\Android",
-            "C:\ghcup",
-            "C:\hostedtoolcache\windows\CodeQL",
-            "C:\hostedtoolcache\windows\Java_Temurin-Hotspot_jdk",
-            "C:\hostedtoolcache\windows\Ruby",
-            "C:\hostedtoolcache\windows\go",
-            "C:\Program Files\Microsoft SDKs\Azure\CLI2",
-            "C:\Program Files\MongoDB",
-            "C:\Program Files\PostgreSQL",
-            "C:\Program Files\MySQL"
-          )
-          foreach ($p in $paths) {
-            if (Test-Path $p) {
-              Write-Host "removing $p"
-              Remove-Item -Recurse -Force $p -ErrorAction SilentlyContinue
-            }
-          }
-          Show-Free "after"
 
       - name: Checkout build tooling (this repo)
         uses: actions/checkout@v6


### PR DESCRIPTION
The CUDA Windows legs had no disk visibility at all. When `x64/cuda12-portable` died after 87 minutes with `The hosted runner lost communication with the server`, there was nothing recorded to say whether disk had anything to do with it.

This adds that visibility. It does not free anything, and the reason why is the useful part of the change.

## What the measurement said

This PR originally removed ~33 GB of preinstalled SDKs, on the premise that these are the only build legs with no disk management while the Linux CUDA legs run `jlumbroso/free-disk-space` first. Measured on a live `windows-2022` runner, that premise does not hold:

| volume | at job start | holds |
| --- | --- | --- |
| **D:** | 147.0 GB free of 150.0 | `GITHUB_WORKSPACE`: source tree, CMake build tree, ccache |
| **C:** | 84.3 GB free of 255.4 | CUDA toolkit, hostedtoolcache, Program Files |

The CUDA 12.8 toolkit is 4.79 GB, so C: never drops below about 106 GB free. The build writes to the workspace on **D:**, which was never close to full.

So the cleanup would have reclaimed space on the volume that was not under pressure, on each of the seven legs, on every release, forever. It has been dropped.

**Disk exhaustion did not cause that failure.** It was infrastructure loss, and `unsloth-prebuilt-retry.yml` already covers that class.

## What is left

Two report steps, printing both fixed volumes and the workspace path:

- at job start, for a baseline
- after the toolkit install, for headroom going into the build

Both volumes are printed each time on purpose. A leg that dies mid-build can only be read against the volume it was writing to, and the split across C: and D: is exactly the detail that made the original diagnosis wrong.
