### PR TITLE
Start the publish job with the build matrix instead of behind it

### DIFF
--- a/.github/workflows/unsloth-prebuilt-retry.yml
+++ b/.github/workflows/unsloth-prebuilt-retry.yml
@@ -70,6 +70,15 @@ jobs:
 
           FAILED="$(awk -F'\t' '$2 == "failure"' <<<"$JOBS")"
 
+          # assemble waits on the build matrix from inside the job, so a leg
+          # that dies fails assemble too. Alongside another failure that is a
+          # consequence, not a cause; read it only when it failed alone.
+          # The name tracks assemble's `name:` in unsloth-prebuilt.yml.
+          INDEPENDENT="$(awk -F'\t' 'NF && $3 != "Assemble metadata + publish"' <<<"$FAILED")"
+          if [ -n "$INDEPENDENT" ]; then
+            FAILED="$INDEPENDENT"
+          fi
+
           # A cancellation that follows a real failure is a build problem to
           # read, not to repeat.
           if [ "$CONCLUSION" = cancelled ] && [ -n "$FAILED" ]; then

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -502,16 +502,127 @@ jobs:
 
   assemble:
     name: Assemble metadata + publish
-    needs: [resolve, build-cuda, build-windows-cuda, build-rocm, build-macos, build-cpu, build-vulkan]
-    # No `if: always()`. Atomicity: if any matrix entry in any child
-    # workflow failed, the corresponding `build-*` job reports failure, the
-    # default `needs` success check skips this assemble job, and nothing is
-    # published. The installer needs the full bundle set or it'll fail.
+    # Only `resolve`, so this job starts alongside the build matrix instead of
+    # after it. It used to `needs:` every build child, which meant it began
+    # queueing for a runner only once the last leg went green: on the reference
+    # run that queue wait was 109 minutes to then run a 10-second job. Starting
+    # early overlaps the wait with the build. The cost is one runner slot held
+    # for the length of the run.
+    needs: [resolve]
+    # No `if: always()`. Atomicity is unchanged in effect, but it is now
+    # enforced by the "Wait for the build matrix" step below rather than by
+    # `needs:`: that step blocks until every sibling build job is finished and
+    # exits non-zero unless all of them succeeded, so a failed leg still
+    # publishes nothing. The installer needs the full bundle set or it'll fail.
     if: ${{ needs.resolve.outputs.exists != 'true' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-22.04
+    # The waiter holds this job open for the whole build. GitHub's 6h job cap
+    # would kill it with no useful message; stop short of that deliberately,
+    # leaving room for the download/verify/publish steps that follow.
+    timeout-minutes: 350
+    # A job-level block replaces the workflow-level one, so contents:write has
+    # to be repeated here; actions:read is what lets the waiter read the run's
+    # job list (the `alert` job already needs it for the same reason).
+    permissions:
+      contents: write
+      actions: read
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
+      # Reimplements the `needs:` success check that the trimmed-down `needs:`
+      # above gave away. It has to be at least as strict as `needs:` was --
+      # publishing a partial release is far worse than publishing late.
+      - name: Wait for the build matrix
+        env:
+          # Same expression that gates the verify/publish steps below.
+          PUBLISH_INTENT: ${{ github.event_name == 'schedule' || inputs.publish }}
+        run: |
+          set -euo pipefail
+
+          # Build jobs live in called workflows, so they appear in this run's
+          # job list as "<caller job name> / <called job name>", e.g.
+          # "CUDA / x64/cuda12-legacy". One prefix per build child; every one of
+          # them must be represented or we are not looking at a complete run.
+          PREFIXES=('CUDA / ' 'CUDA Windows / ' 'ROCm / ' 'macOS / ' 'CPU / ' 'Vulkan / ')
+          SELF='Assemble metadata + publish'
+          ALERT='Report pipeline health'
+
+          POLL=60
+          DEADLINE=$(( $(date +%s) + 330 * 60 ))
+          # Called-workflow job records do not all exist the moment the run
+          # starts, so a missing prefix is only fatal once this has passed.
+          STARTUP_DEADLINE=$(( $(date +%s) + 45 * 60 ))
+          API_FAILS=0
+
+          while :; do
+            if ! JOBS="$(gh api --paginate \
+                  "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs?per_page=100" \
+                  --jq '.jobs[] | [.name, .status, (.conclusion // "none")] | @tsv' 2>/dev/null)"; then
+              # A blip in the jobs API must not throw away a finished build.
+              API_FAILS=$(( API_FAILS + 1 ))
+              if [ "$API_FAILS" -ge 10 ]; then
+                echo "ERROR: the jobs API failed 10 times running; cannot confirm the build matrix finished" >&2
+                exit 1
+              fi
+              echo "jobs API call failed (${API_FAILS}/10); retrying in ${POLL}s"
+              sleep "$POLL"
+              continue
+            fi
+            API_FAILS=0
+
+            # Everything in the run except this job and the alert job that
+            # reports on it. `resolve` stays in the set; it is already a
+            # `needs:`, so it is a free consistency check.
+            SIBS="$(printf '%s\n' "$JOBS" | awk -F'\t' -v self="$SELF" -v alert="$ALERT" 'NF && $1 != self && $1 != alert')"
+
+            MISSING=""
+            for p in "${PREFIXES[@]}"; do
+              printf '%s\n' "$SIBS" | awk -F'\t' -v p="$p" 'index($1, p) == 1 { found = 1 } END { exit !found }' \
+                || MISSING="${MISSING} '${p}'"
+            done
+            if [ -n "$MISSING" ]; then
+              if [ "$(date +%s)" -gt "$STARTUP_DEADLINE" ]; then
+                echo "ERROR: no job records for build child(ren):${MISSING}; refusing to publish without confirming they ran" >&2
+                exit 1
+              fi
+              echo "waiting for job records to appear for:${MISSING}"
+              sleep "$POLL"
+              continue
+            fi
+
+            # Fail on the first finished leg that did not succeed rather than
+            # sitting on a runner for another hour to reach the same answer.
+            # `skipped` is the one conclusion that needs a judgement call: a
+            # publish run is pinned by `resolve` to the full default matrix, so
+            # a skipped leg there means something is wrong and must block, but a
+            # publish=false subset dispatch (say operating_systems=ubuntu) skips
+            # legs on purpose and `needs:` tolerated that before.
+            BAD="$(printf '%s\n' "$SIBS" | awk -F'\t' -v strict="$PUBLISH_INTENT" '
+              !NF || $2 != "completed" { next }
+              $3 == "success" { next }
+              $3 == "skipped" && strict != "true" { next }
+              { printf "  %s (%s)\n", $1, $3 }
+            ')"
+            if [ -n "$BAD" ]; then
+              echo "ERROR: refusing to publish, these build jobs did not succeed:" >&2
+              printf '%s\n' "$BAD" >&2
+              exit 1
+            fi
+
+            TOTAL="$(printf '%s\n' "$SIBS" | grep -c . || true)"
+            PENDING="$(printf '%s\n' "$SIBS" | awk -F'\t' 'NF && $2 != "completed"' | grep -c . || true)"
+            if [ "$PENDING" -eq 0 ]; then
+              echo "all ${TOTAL} build jobs finished and succeeded"
+              break
+            fi
+            if [ "$(date +%s)" -gt "$DEADLINE" ]; then
+              echo "ERROR: timed out waiting for the build matrix; ${PENDING} of ${TOTAL} jobs still running" >&2
+              exit 1
+            fi
+            echo "${PENDING} of ${TOTAL} build jobs still running; polling again in ${POLL}s"
+            sleep "$POLL"
+          done
+
       - name: Checkout build tooling (this repo)
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## What

`assemble` drops to `needs: [resolve]` so it starts alongside the build matrix instead of behind it, and then waits for its siblings from inside the job by polling the run's job list.

This is the risky one of the batch, so it is on its own.

## Why

On the reference run the tail cost a 109-minute runner queue wait in order to run a 10-second job. That wait exists because `assemble` only began queueing for a runner once the last build leg went green. Starting it at the same time as the matrix moves the queue wait into the window where the build is running anyway.

## How the atomicity is preserved

This reimplements the `needs:` success check in a shell loop, which is exactly the part worth reviewing carefully. A publish that goes ahead after a failed leg is much worse than a slow publish, so the waiter is deliberately at least as strict as `needs:` was:

- Build jobs live in called workflows, so they appear in this run's job list as `<caller job name> / <called job name>`, for example `CUDA / x64/cuda12-legacy`. The waiter requires all six child prefixes to be present. If a whole child produced no job records, that is a hard failure rather than something to shrug at.
- `failure`, `cancelled`, `timed_out` and a null conclusion all stop the publish. It fails on the first finished leg that did not succeed rather than sitting on a runner for another hour to reach the same answer.
- `skipped` is the one conclusion that needed a judgement call. A publish run is already pinned by `resolve` to the full default matrix, so a skipped leg there means something is wrong and must block. A `publish=false` subset dispatch, say `operating_systems=ubuntu`, skips legs on purpose, and `needs:` tolerated that before, so it still does. Strict on publish runs, tolerant otherwise, which is stricter than today where it matters and identical everywhere else.
- A transient jobs-API error does not throw away a finished build: ten consecutive failures are tolerated before giving up.
- `assemble` still has no `if: always()`, and `alert` is still `always()`. Neither property is touched.
- `timeout-minutes: 350` is set explicitly, because the waiter now holds the job open for the length of the build and the 6-hour job cap would otherwise kill it with no useful message. The poll loop has its own 330-minute deadline inside that, plus a 45-minute grace period for called-workflow job records to appear.
- Job-level `permissions` had to be added: a job-level block replaces the workflow-level one, so `contents: write` is repeated and `actions: read` is added for the jobs API. `alert` already carries `actions: read` for the same reason.

The existing "Verify full bundle coverage before publish" step is untouched and is the second line of defence here. It enumerates every required bundle by name, including both OSes for all seven gfx targets, and it runs on exactly the publish-intent runs where the waiter is strict. I am relying on it: even if the waiter were somehow fooled into proceeding, a missing bundle still refuses the publish.

Failure messages are prefixed `ERROR:` so the `alert` job's log grep quotes the actual reason into the issue it opens.

## Trade-off, stated plainly

This holds one runner slot for the whole build rather than for ten seconds at the end. On a saturated pool that is not free, and in the worst case it is a wash: a slot spent waiting is a slot a build leg could have used. The reason I still think it is worth it is that the tail wait is pure serial latency on the critical path, whereas the extra occupied slot competes against a matrix that is already 38 jobs wide.

One behaviour change worth knowing: when a build leg fails, `alert` used to report `build-cuda (failure)` with `assemble` skipped and counted healthy. Now it reports both, since `assemble` fails rather than being skipped. Noisier, but arguably clearer.

## Measured vs projected

- **Measured:** the 109-minute queue wait for a 10-second job on the reference run. That the jobs API lists called-workflow jobs as `Parent / child`, confirmed against a real completed run of this workflow (39 job records, all six prefixes present).
- **Projected:** the actual saving on any given night, which is entirely a function of how congested the pool is when the matrix finishes.

## Verification

The decision logic was extracted verbatim into a standalone script and driven against fixtures covering 11 cases: all-success, one still running, `failure`, `cancelled`, `skipped` under both publish intents, a null conclusion, missing job records for a child, self and alert correctly excluded from the sibling set, a failure taking priority over still-pending jobs, and the `CUDA / ` prefix correctly not matching `CUDA Windows / `. All 11 behave as intended.

Beyond that: the workflow parses, `actionlint` and shellcheck are clean on the new step, and no step in `assemble` referenced a `needs.build-*` output, so dropping them from `needs` changes nothing else. `alert` keeps its full `needs` list.

I have also dispatched a `publish=false` subset run against this branch to exercise the waiter end to end. Nothing it does can publish. Run number in a comment below.
