### PR TITLE
Ask unsloth to free runner capacity when a release starts building

### DIFF
--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -432,6 +432,48 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+      # Ask unsloth to stand its scheduled CI down while this release builds.
+      # Fired here rather than at assemble time: the point is to free slots
+      # before the 39-job matrix queues, not after it has finished waiting.
+      # Guarded on the same condition as the build jobs, so a scheduled no-op
+      # never sweeps anything.
+      #
+      # workflow_dispatch, not repository_dispatch. Both would work, but
+      # POST /dispatches needs Contents: write on the target and this needs only
+      # Actions: write, so the token cannot push code to unsloth.
+      #
+      # unsloth decides what it is willing to cancel; this only asks. If the
+      # sweeper is not on unsloth's main yet, this 404s and warns, which is why
+      # the whole step is best-effort.
+      - name: Ask unsloth to free runner capacity
+        if: ${{ steps.r.outputs.exists != 'true' || github.event_name == 'workflow_dispatch' }}
+        # A release must never fail because the request did not land.
+        continue-on-error: true
+        env:
+          DISPATCH_TOKEN: ${{ secrets.UNSLOTH_DISPATCH_TOKEN }}
+          TAG: ${{ steps.r.outputs.tag }}
+        run: |
+          # No -x here: it would trace the token into the log.
+          set -eu
+          if [ -z "${DISPATCH_TOKEN:-}" ]; then
+            echo "::warning::UNSLOTH_DISPATCH_TOKEN is not set; not asking unsloth to free capacity"
+            exit 0
+          fi
+          PAYLOAD="$(jq -cn --arg r "llama.cpp ${TAG} run ${GITHUB_RUN_ID}" \
+            '{ref: "main", inputs: {mode: "sweep", events: "schedule", classes: "linux,windows", reason: $r}}')"
+          CODE="$(curl -sS -o /dev/null -w '%{http_code}' -X POST \
+            -H "Authorization: Bearer ${DISPATCH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/unslothai/unsloth/actions/workflows/ci-capacity.yml/dispatches \
+            -d "$PAYLOAD")"
+          # 204 is "request accepted", not "capacity freed". unsloth's sweeper
+          # ships inert, so until it is enabled there this is a no-op by design.
+          if [ "$CODE" = "204" ]; then
+            echo "asked unsloth to free linux/windows capacity for ${TAG}"
+          else
+            echo "::warning::unsloth ci-capacity dispatch returned HTTP ${CODE}; continuing without it"
+          fi
+
   build-cuda:
     name: CUDA
     needs: resolve


### PR DESCRIPTION
The 39-job matrix queues behind ordinary CI in `unslothai/unsloth`, which is 91.8% of running job-minutes org-wide against one shared 60-job cap. Measured on the 08-03 release run `30854854994`: Linux jobs accumulated 5h47m of queue and Windows 5h48m, against **6 seconds** for macOS.

This asks unsloth to stand its scheduled CI down while a release builds.

## Where it fires

From `resolve`, not `assemble`. The point is to free slots **before** the matrix queues, not after it has finished waiting. It carries the same guard as the build jobs (`exists != true || workflow_dispatch`), so a scheduled no-op never sweeps anything.

## Why workflow_dispatch and not repository_dispatch

Both would work. The difference is the permission the token needs:

| mechanism | permission |
| --- | --- |
| `repository_dispatch` | Contents: write |
| `workflow_dispatch` | Actions: write |

Contents: write would let the bearer push commits and create releases in unsloth. Actions: write cannot touch source. `UNSLOTH_DISPATCH_TOKEN` is a fine-grained PAT scoped to `unslothai/unsloth` alone with Actions: write only.

## Best-effort throughout

Mirrors the existing `Notify whisper.cpp` step, which got this shape right:

- `continue-on-error: true`, so a release never fails because the request did not land
- a missing secret emits a warning and exits 0
- non-204 warns and continues
- `set -eu` and deliberately not `-x`, which would trace the token into the log
- the token is in `env:`, not on the command line, where `ps` could see it

## It is a no-op today

unsloth's `ci-capacity.yml` ships inert behind `CI_PREEMPT_ENABLED`, and is not on unsloth main yet. Until both change this either 404s with a warning or resolves a dry run there. That is deliberate: landing the request first means the next release reports what a sweep would have freed before anyone decides to enable it.