### PR TITLE
CI: move the orchestration jobs off the retiring ubuntu-22.04 image

### DIFF
--- a/.github/workflows/unsloth-pin-preflight.yml
+++ b/.github/workflows/unsloth-pin-preflight.yml
@@ -38,7 +38,7 @@ concurrency:
 jobs:
   preflight:
     name: Dry-run the pin merges
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       GH_TOKEN: ${{ github.token }}
       REPIN_TOKEN: ${{ secrets.REPIN_TOKEN }}

--- a/.github/workflows/unsloth-pr-set-lint.yml
+++ b/.github/workflows/unsloth-pr-set-lint.yml
@@ -25,7 +25,7 @@ permissions:
 jobs:
   lint:
     name: Validate pr-set.json
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       GH_TOKEN: ${{ github.token }}
     steps:

--- a/.github/workflows/unsloth-prebuilt-deadman.yml
+++ b/.github/workflows/unsloth-prebuilt-deadman.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   deadman:
     name: Check publish freshness
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout (for the composite action)
         uses: actions/checkout@v6

--- a/.github/workflows/unsloth-prebuilt-retry.yml
+++ b/.github/workflows/unsloth-prebuilt-retry.yml
@@ -46,7 +46,7 @@ jobs:
         || github.event.workflow_run.conclusion == 'failure')
       && github.event.workflow_run.run_attempt == 1
       && github.event.workflow_run.event != 'workflow_dispatch'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Rerun the run when nothing about the build actually failed
         env:

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -89,7 +89,7 @@ concurrency:
 jobs:
   resolve:
     name: Resolve tag
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     # Read-only: resolve merges third-party PR content but pushes nothing;
     # only assemble needs the workflow-level contents:write (publish).
     permissions:
@@ -557,7 +557,7 @@ jobs:
     # exits non-zero unless all of them succeeded, so a failed leg still
     # publishes nothing. The installer needs the full bundle set or it'll fail.
     if: ${{ needs.resolve.outputs.exists != 'true' || github.event_name == 'workflow_dispatch' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     # The waiter holds this job open for the whole build. GitHub's 6h job cap
     # would kill it with no useful message; stop short of that deliberately,
     # leaving room for the download/verify/publish steps that follow.
@@ -900,7 +900,7 @@ jobs:
     name: Report pipeline health
     needs: [resolve, build-cuda, build-windows-cuda, build-rocm, build-macos, build-cpu, build-vulkan, assemble]
     if: ${{ always() && (github.event_name == 'schedule' || inputs.publish) }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/unsloth-repin-bot.yml
+++ b/.github/workflows/unsloth-repin-bot.yml
@@ -36,7 +36,7 @@ jobs:
     name: Repin against the current base tag
     # A preflight that passed has nothing to fix.
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'failure' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       # Without this, checkout leaves a github.com extraheader carrying
       # GITHUB_TOKEN, which would win over the REPIN_TOKEN in our push URLs.


### PR DESCRIPTION
`ubuntu-22.04` and `ubuntu-22.04-arm` deprecate from **2026-09-17** and retire **2027-04-17**, with brownout windows in between ([actions/runner-images#14254](https://github.com/actions/runner-images/issues/14254)).

These seven jobs run `git`, `gh`, `jq` and `python` and produce no compiled artifact, so the runner label carries no compatibility contract for them. Plain label swap.

| workflow | jobs |
| --- | --- |
| `unsloth-prebuilt.yml` | `resolve`, `assemble`, `alert` |
| `unsloth-prebuilt-retry.yml` | `retry` |
| `unsloth-prebuilt-deadman.yml` | `deadman` |
| `unsloth-pin-preflight.yml` | `preflight` |
| `unsloth-pr-set-lint.yml` | `lint` |
| `unsloth-repin-bot.yml` | `repin` |

`resolve` is worth moving first regardless of the deadline: every build child needs it, so a brownout there fails the whole pipeline rather than one leg.

`resolve` does build the stamped source tree, but it compiles nothing. The build children extract that tarball and compile on their own runners, so the floor is set there and is unaffected by this.

## Every build leg is deliberately untouched

The Linux build legs pin `ubuntu-22.04` to hold a glibc 2.35 / GLIBCXX <= 3.4.30 floor, so the bundles load on Ubuntu 22.04 and Debian 12. A 24.04 build needs `GLIBC_2.38` and fails there. That is a real compatibility contract and it cannot be moved by swapping a label.

Unchanged here: `unsloth-prebuilt-cpu.yml`, `unsloth-prebuilt-vulkan.yml`, `unsloth-prebuilt-rocm.yml`, and the seven x64 CUDA profiles in the matrix.

A separate prototype covers that half.