### PR TITLE
Prototype: pin the CPU legs' glibc floor with a container, not the runner

### DIFF
--- a/.github/workflows/unsloth-prebuilt-cpu.yml
+++ b/.github/workflows/unsloth-prebuilt-cpu.yml
@@ -48,12 +48,13 @@ jobs:
   build-linux:
     name: linux/${{ matrix.arch }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { arch: x64,   runner: ubuntu-22.04 }
-          - { arch: arm64, runner: ubuntu-22.04-arm }
+          - { arch: x64,   runner: ubuntu-24.04,     container: 'ubuntu:22.04' }
+          - { arch: arm64, runner: ubuntu-24.04-arm, container: 'ubuntu:22.04' }
     steps:
       # The parent's resolve job built the source tree (upstream base + any mix
       # PRs, with the build number/commit and Unsloth fingerprint baked
@@ -71,11 +72,17 @@ jobs:
           mkdir -p src
           tar -xzf "srcpkg/llama.cpp-source-${{ inputs.tag }}.tar.gz" -C src --strip-components=1
 
+      # The container runs as root and the base image ships no sudo, so the
+      # privilege prefix is dropped. ca-certificates, wget, gnupg and lsb-release
+      # are present on the host runner image but not in ubuntu:22.04, and
+      # llvm.sh below needs all four.
       - name: Install build dependencies
         run: |
           set -eux
-          sudo apt-get update
-          sudo apt-get install -y build-essential libssl-dev ninja-build
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            build-essential libssl-dev ninja-build cmake \
+            ca-certificates wget gnupg lsb-release xz-utils
 
       # arm64 builds on ubuntu-22.04-arm so the bundle keeps the x64 leg's
       # loader floor (a 24.04 build needs GLIBC_2.38 and fails to load on
@@ -88,7 +95,7 @@ jobs:
           set -eux
           wget -q https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh 19
+          ./llvm.sh 19
           {
             echo "CC=clang-19"
             echo "CXX=clang++-19"
@@ -159,6 +166,32 @@ jobs:
             echo "warning: DiffusionGemma binaries failed to build; bundle will omit them"
           fi
           exit 0
+
+      # The whole point of the container is this number, so assert it rather
+      # than trusting that the image did its job. objdump reports the highest
+      # GLIBC_x.y any binary asks the loader for; on a 22.04 userspace that is
+      # 2.35, and a 24.04 build would show 2.38 or higher and fail here.
+      #
+      # This is the check the runner label was silently standing in for. It was
+      # never asserted while the floor came from the runner image, which is why
+      # nothing would have caught the label drifting.
+      - name: Assert the glibc floor
+        run: |
+          set -euo pipefail
+          MAX=0.0
+          for b in src/build/bin/*; do
+            [ -f "$b" ] && [ -x "$b" ] || continue
+            v="$(objdump -T "$b" 2>/dev/null \
+                 | sed -n 's/.*GLIBC_\([0-9][0-9.]*\).*/\1/p' \
+                 | sort -V | tail -1)" || true
+            [ -n "$v" ] || continue
+            if [ "$(printf '%s\n%s\n' "$MAX" "$v" | sort -V | tail -1)" = "$v" ]; then MAX="$v"; fi
+          done
+          echo "highest GLIBC requirement across bin/: ${MAX}"
+          if [ "$(printf '2.35\n%s\n' "$MAX" | sort -V | tail -1)" != "2.35" ]; then
+            echo "::error::binaries require GLIBC_${MAX}, above the 2.35 floor: they will not load on Ubuntu 22.04 or Debian 12"
+            exit 1
+          fi
 
       - name: Package bundle (tar.gz)
         run: |


### PR DESCRIPTION
**Draft. Untested against a real runner.** Opened for review of the approach, not to merge.

## The problem the label swap cannot solve

`ubuntu-22.04` and `ubuntu-22.04-arm` retire **2027-04-17**. Today those labels are what holds the bundles at glibc 2.35 / GLIBCXX <= 3.4.30 so they load on Ubuntu 22.04 and Debian 12. A 24.04 build needs `GLIBC_2.38`, so the label cannot simply be swapped the way it can for the orchestration jobs.

Moving the userspace into a container decouples the floor from the runner image: the build keeps 2.35 on a 24.04 host, and the same shape survives the 24.04 retirement after it.

## Why the CPU legs

They are the only Linux build legs with no vendor SDK to install, and they take their source from `download-artifact` rather than `checkout`, so the container needs no git.

## What the bare image forces

- No privilege prefix. The container runs as root and `ubuntu:22.04` ships none.
- `ca-certificates`, `wget`, `gnupg`, `lsb-release`. Present on the host runner image, absent from the base, and `llvm.sh` needs all four on arm64.

## The assertion the runner label was standing in for

Nothing has ever checked the produced floor. It was inherited from the runner image and trusted, which means nothing would have caught the label drifting either.

This adds a step that reads the highest `GLIBC_x.y` any binary in `bin/` asks the loader for and fails above 2.35. That makes the container's effect checkable rather than assumed, and it is arguably worth having on the build legs regardless of which approach wins.

## What I could not verify

I have no container runtime available, so **none of this has run**. Specifically unproven:

- that the runner's injected node works against glibc 2.35 (node20 needs 2.28+, so it should, but "should" is not a test)
- that `ccache-action`, `download-artifact`, `upload-artifact` and `cache/save` behave inside the container
- that the arm64 `llvm.sh` path works with only the packages listed above
- the actual produced floor, which is exactly what the new assertion exists to answer

The first real run answers all four at once. Worth doing on a staging repo before this goes near a release.

## Not converted

CUDA, ROCm and Vulkan each install a vendor toolkit whose behaviour inside a container needs its own test. Note also that the arm64 CUDA leg already runs on `ubuntu-24.04-arm` at glibc 2.39, so its floor is a separate question from the x64 profiles rather than the same one.

## No upstream precedent

`ggml-org/llama.cpp` uses containers for toolchain provisioning, not floor management: their container base always matches or exceeds the runner, and their ROCm jobs still pin `ubuntu-22.04`. So they carry the same exposure and there is no working example of this to copy.