### PR TITLE
CI: keep ccache on failed builds, bound the CUDA Windows timeout, stop uploading the debug bundle on green runs

### DIFF
--- a/.github/workflows/unsloth-prebuilt-cpu.yml
+++ b/.github/workflows/unsloth-prebuilt-cpu.yml
@@ -181,6 +181,11 @@ jobs:
         run: ccache --evict-older-than 14d
 
       - name: Save ccache
+        # Save even when the build failed: the objects compiled before the
+        # failure are still worth keeping, and a job that saves nothing leaves
+        # a hole in the cache lineage that widens the next run's tag gap.
+        # Measured: gap 7 -> 68% hit rate, gap 13 -> 6%.
+        if: ${{ !cancelled() }}
         uses: actions/cache/save@v6
         with:
           path: ${{ github.workspace }}/.ccache
@@ -325,6 +330,11 @@ jobs:
         run: ccache --evict-older-than 14d
 
       - name: Save ccache
+        # Save even when the build failed: the objects compiled before the
+        # failure are still worth keeping, and a job that saves nothing leaves
+        # a hole in the cache lineage that widens the next run's tag gap.
+        # Measured: gap 7 -> 68% hit rate, gap 13 -> 6%.
+        if: ${{ !cancelled() }}
         uses: actions/cache/save@v6
         with:
           path: ${{ github.workspace }}\.ccache

--- a/.github/workflows/unsloth-prebuilt-cpu.yml
+++ b/.github/workflows/unsloth-prebuilt-cpu.yml
@@ -177,6 +177,7 @@ jobs:
           if-no-files-found: error
 
       - name: Evict stale ccache files
+        if: ${{ always() }}
         continue-on-error: true
         run: ccache --evict-older-than 14d
 
@@ -185,7 +186,12 @@ jobs:
         # failure are still worth keeping, and a job that saves nothing leaves
         # a hole in the cache lineage that widens the next run's tag gap.
         # Measured: gap 7 -> 68% hit rate, gap 13 -> 6%.
-        if: ${{ !cancelled() }}
+        #
+        # always(), not !cancelled(): a timeout-minutes expiry puts the job on
+        # the CANCELLATION path, not the failure path, so !cancelled() would
+        # skip the save on the single most expensive case -- a leg that
+        # compiled for hours and then hit the cap.
+        if: ${{ always() }}
         uses: actions/cache/save@v6
         with:
           path: ${{ github.workspace }}/.ccache
@@ -326,6 +332,7 @@ jobs:
           if-no-files-found: error
 
       - name: Evict stale ccache files
+        if: ${{ always() }}
         continue-on-error: true
         run: ccache --evict-older-than 14d
 
@@ -334,7 +341,12 @@ jobs:
         # failure are still worth keeping, and a job that saves nothing leaves
         # a hole in the cache lineage that widens the next run's tag gap.
         # Measured: gap 7 -> 68% hit rate, gap 13 -> 6%.
-        if: ${{ !cancelled() }}
+        #
+        # always(), not !cancelled(): a timeout-minutes expiry puts the job on
+        # the CANCELLATION path, not the failure path, so !cancelled() would
+        # skip the save on the single most expensive case -- a leg that
+        # compiled for hours and then hit the cap.
+        if: ${{ always() }}
         uses: actions/cache/save@v6
         with:
           path: ${{ github.workspace }}\.ccache

--- a/.github/workflows/unsloth-prebuilt-cpu.yml
+++ b/.github/workflows/unsloth-prebuilt-cpu.yml
@@ -177,7 +177,12 @@ jobs:
           if-no-files-found: error
 
       - name: Evict stale ccache files
-        if: ${{ always() }}
+        # !cancelled(), unlike the save below: on a timeout the job gets a
+        # single ~5 minute teardown window (measured ~4m50s after process
+        # kill), shared by every remaining step and not replenished. Evicting
+        # spends that window on housekeeping; the save is what actually needs
+        # it, and a 2 GB cache is not quick to write.
+        if: ${{ !cancelled() }}
         continue-on-error: true
         run: ccache --evict-older-than 14d
 
@@ -332,7 +337,12 @@ jobs:
           if-no-files-found: error
 
       - name: Evict stale ccache files
-        if: ${{ always() }}
+        # !cancelled(), unlike the save below: on a timeout the job gets a
+        # single ~5 minute teardown window (measured ~4m50s after process
+        # kill), shared by every remaining step and not replenished. Evicting
+        # spends that window on housekeeping; the save is what actually needs
+        # it, and a 2 GB cache is not quick to write.
+        if: ${{ !cancelled() }}
         continue-on-error: true
         run: ccache --evict-older-than 14d
 

--- a/.github/workflows/unsloth-prebuilt-cuda-windows.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda-windows.yml
@@ -284,7 +284,12 @@ jobs:
           if-no-files-found: error
 
       - name: Evict stale ccache files
-        if: ${{ always() }}
+        # !cancelled(), unlike the save below: on a timeout the job gets a
+        # single ~5 minute teardown window (measured ~4m50s after process
+        # kill), shared by every remaining step and not replenished. Evicting
+        # spends that window on housekeeping; the save is what actually needs
+        # it, and a 2 GB cache is not quick to write.
+        if: ${{ !cancelled() }}
         continue-on-error: true
         run: ccache --evict-older-than 14d
 

--- a/.github/workflows/unsloth-prebuilt-cuda-windows.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda-windows.yml
@@ -45,6 +45,12 @@ jobs:
   build:
     name: x64/${{ matrix.profile }}
     runs-on: ${{ matrix.runner }}
+    # Must stay UNDER assemble's `timeout-minutes: 350` in unsloth-prebuilt.yml.
+    # Without this the job inherits GitHub's 360-minute default and outlives the
+    # assemble job that is waiting on it, so a long leg kills the publish ~11
+    # minutes before the build would have finished and the whole 40-job run is
+    # discarded. x64/cuda12-portable has already been observed at 214 minutes.
+    timeout-minutes: 300
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(inputs.matrix) }}
@@ -269,6 +275,11 @@ jobs:
         run: ccache --evict-older-than 14d
 
       - name: Save ccache
+        # Save even when the build failed: the objects compiled before the
+        # failure are still worth keeping, and a job that saves nothing leaves
+        # a hole in the cache lineage that widens the next run's tag gap.
+        # Measured: gap 7 -> 68% hit rate, gap 13 -> 6%.
+        if: ${{ !cancelled() }}
         uses: actions/cache/save@v6
         with:
           path: ${{ github.workspace }}\.ccache

--- a/.github/workflows/unsloth-prebuilt-cuda-windows.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda-windows.yml
@@ -45,12 +45,25 @@ jobs:
   build:
     name: x64/${{ matrix.profile }}
     runs-on: ${{ matrix.runner }}
-    # Must stay UNDER assemble's `timeout-minutes: 350` in unsloth-prebuilt.yml.
-    # Without this the job inherits GitHub's 360-minute default and outlives the
-    # assemble job that is waiting on it, so a long leg kills the publish ~11
-    # minutes before the build would have finished and the whole 40-job run is
-    # discarded. x64/cuda12-portable has already been observed at 214 minutes.
-    timeout-minutes: 300
+    # Hang guard only. Without it the job inherits GitHub's 360-minute default,
+    # which is above both assemble's `timeout-minutes: 350` and, more to the
+    # point, the "Wait for the build matrix" step's own 330-minute deadline in
+    # unsloth-prebuilt.yml -- so a wedged leg burns a runner for an hour after
+    # the publish it was feeding has already given up.
+    #
+    # 345, not something tighter: x64/cuda12-portable legitimately reaches the
+    # low 300s on a cold ccache. Run 27347317849 took 305.1 minutes and
+    # SUCCEEDED (286.9 of it genuine compile). Across 62 historical runs of this
+    # leg the max is 305.1 and nothing falls between 215 and 305, so a tighter
+    # cap buys no hang detection and would have destroyed that publish -- one
+    # killed leg fails the bundle-coverage gate and the whole night ships
+    # nothing.
+    #
+    # Note this cannot by itself rescue a slow run: the waiter's 330-minute
+    # deadline is wall-clock from assemble start and INCLUDES the child's queue
+    # wait, while timeout-minutes starts at job start and excludes it. Raising
+    # the waiter deadline is the separate change that would actually save runs.
+    timeout-minutes: 345
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(inputs.matrix) }}
@@ -271,6 +284,7 @@ jobs:
           if-no-files-found: error
 
       - name: Evict stale ccache files
+        if: ${{ always() }}
         continue-on-error: true
         run: ccache --evict-older-than 14d
 
@@ -279,7 +293,12 @@ jobs:
         # failure are still worth keeping, and a job that saves nothing leaves
         # a hole in the cache lineage that widens the next run's tag gap.
         # Measured: gap 7 -> 68% hit rate, gap 13 -> 6%.
-        if: ${{ !cancelled() }}
+        #
+        # always(), not !cancelled(): a timeout-minutes expiry puts the job on
+        # the CANCELLATION path, not the failure path, so !cancelled() would
+        # skip the save on the single most expensive case -- a leg that
+        # compiled for hours and then hit the cap.
+        if: ${{ always() }}
         uses: actions/cache/save@v6
         with:
           path: ${{ github.workspace }}\.ccache

--- a/.github/workflows/unsloth-prebuilt-cuda.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda.yml
@@ -256,6 +256,7 @@ jobs:
           if-no-files-found: error
 
       - name: Evict stale ccache files
+        if: ${{ always() }}
         continue-on-error: true
         run: ccache --evict-older-than 14d
 
@@ -264,7 +265,12 @@ jobs:
         # failure are still worth keeping, and a job that saves nothing leaves
         # a hole in the cache lineage that widens the next run's tag gap.
         # Measured: gap 7 -> 68% hit rate, gap 13 -> 6%.
-        if: ${{ !cancelled() }}
+        #
+        # always(), not !cancelled(): a timeout-minutes expiry puts the job on
+        # the CANCELLATION path, not the failure path, so !cancelled() would
+        # skip the save on the single most expensive case -- a leg that
+        # compiled for hours and then hit the cap.
+        if: ${{ always() }}
         uses: actions/cache/save@v6
         with:
           path: ${{ github.workspace }}/.ccache

--- a/.github/workflows/unsloth-prebuilt-cuda.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda.yml
@@ -256,7 +256,12 @@ jobs:
           if-no-files-found: error
 
       - name: Evict stale ccache files
-        if: ${{ always() }}
+        # !cancelled(), unlike the save below: on a timeout the job gets a
+        # single ~5 minute teardown window (measured ~4m50s after process
+        # kill), shared by every remaining step and not replenished. Evicting
+        # spends that window on housekeeping; the save is what actually needs
+        # it, and a 2 GB cache is not quick to write.
+        if: ${{ !cancelled() }}
         continue-on-error: true
         run: ccache --evict-older-than 14d
 

--- a/.github/workflows/unsloth-prebuilt-cuda.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda.yml
@@ -260,6 +260,11 @@ jobs:
         run: ccache --evict-older-than 14d
 
       - name: Save ccache
+        # Save even when the build failed: the objects compiled before the
+        # failure are still worth keeping, and a job that saves nothing leaves
+        # a hole in the cache lineage that widens the next run's tag gap.
+        # Measured: gap 7 -> 68% hit rate, gap 13 -> 6%.
+        if: ${{ !cancelled() }}
         uses: actions/cache/save@v6
         with:
           path: ${{ github.workspace }}/.ccache

--- a/.github/workflows/unsloth-prebuilt-macos.yml
+++ b/.github/workflows/unsloth-prebuilt-macos.yml
@@ -153,6 +153,11 @@ jobs:
         run: ccache --evict-older-than 14d
 
       - name: Save ccache
+        # Save even when the build failed: the objects compiled before the
+        # failure are still worth keeping, and a job that saves nothing leaves
+        # a hole in the cache lineage that widens the next run's tag gap.
+        # Measured: gap 7 -> 68% hit rate, gap 13 -> 6%.
+        if: ${{ !cancelled() }}
         uses: actions/cache/save@v6
         with:
           path: ${{ github.workspace }}/.ccache

--- a/.github/workflows/unsloth-prebuilt-macos.yml
+++ b/.github/workflows/unsloth-prebuilt-macos.yml
@@ -149,6 +149,7 @@ jobs:
           if-no-files-found: error
 
       - name: Evict stale ccache files
+        if: ${{ always() }}
         continue-on-error: true
         run: ccache --evict-older-than 14d
 
@@ -157,7 +158,12 @@ jobs:
         # failure are still worth keeping, and a job that saves nothing leaves
         # a hole in the cache lineage that widens the next run's tag gap.
         # Measured: gap 7 -> 68% hit rate, gap 13 -> 6%.
-        if: ${{ !cancelled() }}
+        #
+        # always(), not !cancelled(): a timeout-minutes expiry puts the job on
+        # the CANCELLATION path, not the failure path, so !cancelled() would
+        # skip the save on the single most expensive case -- a leg that
+        # compiled for hours and then hit the cap.
+        if: ${{ always() }}
         uses: actions/cache/save@v6
         with:
           path: ${{ github.workspace }}/.ccache

--- a/.github/workflows/unsloth-prebuilt-macos.yml
+++ b/.github/workflows/unsloth-prebuilt-macos.yml
@@ -149,7 +149,12 @@ jobs:
           if-no-files-found: error
 
       - name: Evict stale ccache files
-        if: ${{ always() }}
+        # !cancelled(), unlike the save below: on a timeout the job gets a
+        # single ~5 minute teardown window (measured ~4m50s after process
+        # kill), shared by every remaining step and not replenished. Evicting
+        # spends that window on housekeeping; the save is what actually needs
+        # it, and a 2 GB cache is not quick to write.
+        if: ${{ !cancelled() }}
         continue-on-error: true
         run: ccache --evict-older-than 14d
 

--- a/.github/workflows/unsloth-prebuilt-rocm.yml
+++ b/.github/workflows/unsloth-prebuilt-rocm.yml
@@ -466,7 +466,12 @@ jobs:
       run: ccache --show-stats -v
 
     - name: Evict stale ccache files
-      if: ${{ always() }}
+      # !cancelled(), unlike the save below: on a timeout the job gets a
+      # single ~5 minute teardown window (measured ~4m50s after process
+      # kill), shared by every remaining step and not replenished. Evicting
+      # spends that window on housekeeping; the save is what actually needs
+      # it, and a 2 GB cache is not quick to write.
+      if: ${{ !cancelled() }}
       continue-on-error: true
       run: ccache --evict-older-than 14d
 
@@ -855,7 +860,12 @@ jobs:
       run: ccache --show-stats -v
 
     - name: Evict stale ccache files
-      if: ${{ always() }}
+      # !cancelled(), unlike the save below: on a timeout the job gets a
+      # single ~5 minute teardown window (measured ~4m50s after process
+      # kill), shared by every remaining step and not replenished. Evicting
+      # spends that window on housekeeping; the save is what actually needs
+      # it, and a 2 GB cache is not quick to write.
+      if: ${{ !cancelled() }}
       continue-on-error: true
       run: ccache --evict-older-than 14d
 

--- a/.github/workflows/unsloth-prebuilt-rocm.yml
+++ b/.github/workflows/unsloth-prebuilt-rocm.yml
@@ -470,6 +470,11 @@ jobs:
       run: ccache --evict-older-than 14d
 
     - name: Save ccache
+      # Save even when the build failed: the objects compiled before the
+      # failure are still worth keeping, and a job that saves nothing leaves
+      # a hole in the cache lineage that widens the next run's tag gap.
+      # Measured: gap 7 -> 68% hit rate, gap 13 -> 6%.
+      if: ${{ !cancelled() }}
       uses: actions/cache/save@v6
       with:
         path: ${{ github.workspace }}\.ccache
@@ -848,6 +853,11 @@ jobs:
       run: ccache --evict-older-than 14d
 
     - name: Save ccache
+      # Save even when the build failed: the objects compiled before the
+      # failure are still worth keeping, and a job that saves nothing leaves
+      # a hole in the cache lineage that widens the next run's tag gap.
+      # Measured: gap 7 -> 68% hit rate, gap 13 -> 6%.
+      if: ${{ !cancelled() }}
       uses: actions/cache/save@v6
       with:
         path: ${{ github.workspace }}/.ccache

--- a/.github/workflows/unsloth-prebuilt-rocm.yml
+++ b/.github/workflows/unsloth-prebuilt-rocm.yml
@@ -466,6 +466,7 @@ jobs:
       run: ccache --show-stats -v
 
     - name: Evict stale ccache files
+      if: ${{ always() }}
       continue-on-error: true
       run: ccache --evict-older-than 14d
 
@@ -474,7 +475,12 @@ jobs:
       # failure are still worth keeping, and a job that saves nothing leaves
       # a hole in the cache lineage that widens the next run's tag gap.
       # Measured: gap 7 -> 68% hit rate, gap 13 -> 6%.
-      if: ${{ !cancelled() }}
+      #
+      # always(), not !cancelled(): a timeout-minutes expiry puts the job on
+      # the CANCELLATION path, not the failure path, so !cancelled() would
+      # skip the save on the single most expensive case -- a leg that
+      # compiled for hours and then hit the cap.
+      if: ${{ always() }}
       uses: actions/cache/save@v6
       with:
         path: ${{ github.workspace }}\.ccache
@@ -849,6 +855,7 @@ jobs:
       run: ccache --show-stats -v
 
     - name: Evict stale ccache files
+      if: ${{ always() }}
       continue-on-error: true
       run: ccache --evict-older-than 14d
 
@@ -857,7 +864,12 @@ jobs:
       # failure are still worth keeping, and a job that saves nothing leaves
       # a hole in the cache lineage that widens the next run's tag gap.
       # Measured: gap 7 -> 68% hit rate, gap 13 -> 6%.
-      if: ${{ !cancelled() }}
+      #
+      # always(), not !cancelled(): a timeout-minutes expiry puts the job on
+      # the CANCELLATION path, not the failure path, so !cancelled() would
+      # skip the save on the single most expensive case -- a leg that
+      # compiled for hours and then hit the cap.
+      if: ${{ always() }}
       uses: actions/cache/save@v6
       with:
         path: ${{ github.workspace }}/.ccache

--- a/.github/workflows/unsloth-prebuilt-vulkan.yml
+++ b/.github/workflows/unsloth-prebuilt-vulkan.yml
@@ -222,6 +222,7 @@ jobs:
           if-no-files-found: error
 
       - name: Evict stale ccache files
+        if: ${{ always() }}
         continue-on-error: true
         run: ccache --evict-older-than 14d
 
@@ -230,7 +231,12 @@ jobs:
         # failure are still worth keeping, and a job that saves nothing leaves
         # a hole in the cache lineage that widens the next run's tag gap.
         # Measured: gap 7 -> 68% hit rate, gap 13 -> 6%.
-        if: ${{ !cancelled() }}
+        #
+        # always(), not !cancelled(): a timeout-minutes expiry puts the job on
+        # the CANCELLATION path, not the failure path, so !cancelled() would
+        # skip the save on the single most expensive case -- a leg that
+        # compiled for hours and then hit the cap.
+        if: ${{ always() }}
         uses: actions/cache/save@v6
         with:
           path: ${{ github.workspace }}/.ccache
@@ -359,6 +365,7 @@ jobs:
           if-no-files-found: error
 
       - name: Evict stale ccache files
+        if: ${{ always() }}
         continue-on-error: true
         run: ccache --evict-older-than 14d
 
@@ -367,7 +374,12 @@ jobs:
         # failure are still worth keeping, and a job that saves nothing leaves
         # a hole in the cache lineage that widens the next run's tag gap.
         # Measured: gap 7 -> 68% hit rate, gap 13 -> 6%.
-        if: ${{ !cancelled() }}
+        #
+        # always(), not !cancelled(): a timeout-minutes expiry puts the job on
+        # the CANCELLATION path, not the failure path, so !cancelled() would
+        # skip the save on the single most expensive case -- a leg that
+        # compiled for hours and then hit the cap.
+        if: ${{ always() }}
         uses: actions/cache/save@v6
         with:
           path: ${{ github.workspace }}\.ccache

--- a/.github/workflows/unsloth-prebuilt-vulkan.yml
+++ b/.github/workflows/unsloth-prebuilt-vulkan.yml
@@ -226,6 +226,11 @@ jobs:
         run: ccache --evict-older-than 14d
 
       - name: Save ccache
+        # Save even when the build failed: the objects compiled before the
+        # failure are still worth keeping, and a job that saves nothing leaves
+        # a hole in the cache lineage that widens the next run's tag gap.
+        # Measured: gap 7 -> 68% hit rate, gap 13 -> 6%.
+        if: ${{ !cancelled() }}
         uses: actions/cache/save@v6
         with:
           path: ${{ github.workspace }}/.ccache
@@ -358,6 +363,11 @@ jobs:
         run: ccache --evict-older-than 14d
 
       - name: Save ccache
+        # Save even when the build failed: the objects compiled before the
+        # failure are still worth keeping, and a job that saves nothing leaves
+        # a hole in the cache lineage that widens the next run's tag gap.
+        # Measured: gap 7 -> 68% hit rate, gap 13 -> 6%.
+        if: ${{ !cancelled() }}
         uses: actions/cache/save@v6
         with:
           path: ${{ github.workspace }}\.ccache

--- a/.github/workflows/unsloth-prebuilt-vulkan.yml
+++ b/.github/workflows/unsloth-prebuilt-vulkan.yml
@@ -222,7 +222,12 @@ jobs:
           if-no-files-found: error
 
       - name: Evict stale ccache files
-        if: ${{ always() }}
+        # !cancelled(), unlike the save below: on a timeout the job gets a
+        # single ~5 minute teardown window (measured ~4m50s after process
+        # kill), shared by every remaining step and not replenished. Evicting
+        # spends that window on housekeeping; the save is what actually needs
+        # it, and a 2 GB cache is not quick to write.
+        if: ${{ !cancelled() }}
         continue-on-error: true
         run: ccache --evict-older-than 14d
 
@@ -365,7 +370,12 @@ jobs:
           if-no-files-found: error
 
       - name: Evict stale ccache files
-        if: ${{ always() }}
+        # !cancelled(), unlike the save below: on a timeout the job gets a
+        # single ~5 minute teardown window (measured ~4m50s after process
+        # kill), shared by every remaining step and not replenished. Evicting
+        # spends that window on housekeeping; the save is what actually needs
+        # it, and a 2 GB cache is not quick to write.
+        if: ${{ !cancelled() }}
         continue-on-error: true
         run: ccache --evict-older-than 14d
 

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -848,10 +848,6 @@ jobs:
             dist/*
           gh release edit "$TAG" --repo "$REPO" --draft=false
 
-      # whisper.cpp slim bundles are compiled against this release's ggml and
-      # ship no libggml*, so a new ggml means whisper has to republish. Without
-      # this it only finds out on its own cron, and Studio reports "no
-      # compatible prebuilt" until then.
       # Debug fallback for a failed publish. This used to upload on EVERY run,
       # ahead of the publish gate, which cost ~688 MiB of Actions artifact
       # storage per run for a bundle nothing reads: no download-artifact in this
@@ -875,8 +871,15 @@ jobs:
           # missing debug bundle must not turn a diagnosable failure into a
           # confusing second one.
           if-no-files-found: warn
+          # rerun-failed-jobs reuses the run id, and artifacts persist across
+          # attempts, so a second failed attempt would 409 on the duplicate name.
+          overwrite: true
           retention-days: 7
 
+      # whisper.cpp slim bundles are compiled against this release's ggml and
+      # ship no libggml*, so a new ggml means whisper has to republish. Without
+      # this it only finds out on its own cron, and Studio reports "no
+      # compatible prebuilt" until then.
       - name: Notify whisper.cpp
         if: ${{ (github.event_name == 'schedule' || inputs.publish) && needs.resolve.outputs.exists != 'true' }}
         # Never fail a published release because the notification did not land.

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -758,17 +758,6 @@ jobs:
             --publish-repo "$GITHUB_REPOSITORY"
           ls -la dist
 
-      - name: Upload full release set (artifacts)
-        uses: actions/upload-artifact@v6
-        with:
-          name: unsloth-prebuilt-${{ needs.resolve.outputs.tag }}
-          path: dist/*
-          if-no-files-found: error
-          # Short retention: the published GitHub release is the canonical
-          # storage; this artifact is just debug fallback for failed-publish
-          # runs. Default 90 days × ~8 GB/run is real storage cost.
-          retention-days: 7
-
       - name: Verify full bundle coverage before publish
         if: ${{ (github.event_name == 'schedule' || inputs.publish) && needs.resolve.outputs.exists != 'true' }}
         run: |
@@ -863,6 +852,31 @@ jobs:
       # ship no libggml*, so a new ggml means whisper has to republish. Without
       # this it only finds out on its own cron, and Studio reports "no
       # compatible prebuilt" until then.
+      # Debug fallback for a failed publish. This used to upload on EVERY run,
+      # ahead of the publish gate, which cost ~688 MiB of Actions artifact
+      # storage per run for a bundle nothing reads: no download-artifact in this
+      # repo references it, an org-wide code search for `actions/artifacts`
+      # returns nothing, and Studio's installer resolves release ASSETS
+      # (install_llama_prebuilt.py -> release_asset_download_url). Uploading
+      # ahead of the gate also published unverified builds -- on a public repo
+      # any signed-in user can download an artifact -- for runs that
+      # deliberately never released.
+      #
+      # Kept but moved after publish and gated on failure(), so it still rescues
+      # a failed-publish run without re-running the 40-job matrix, and costs
+      # nothing when the run is green.
+      - name: Upload full release set (artifacts)
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: unsloth-prebuilt-${{ needs.resolve.outputs.tag }}
+          path: dist/*
+          # warn, not error: an early failure can leave dist/ absent, and a
+          # missing debug bundle must not turn a diagnosable failure into a
+          # confusing second one.
+          if-no-files-found: warn
+          retention-days: 7
+
       - name: Notify whisper.cpp
         if: ${{ (github.event_name == 'schedule' || inputs.publish) && needs.resolve.outputs.exists != 'true' }}
         # Never fail a published release because the notification did not land.

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -862,7 +862,13 @@ jobs:
       # a failed-publish run without re-running the 40-job matrix, and costs
       # nothing when the run is green.
       - name: Upload full release set (artifacts)
-        if: ${{ failure() }}
+        # always() && !success(), not failure(): a cancelled assemble -- its own
+        # timeout, or a superseding nightly -- is not on the failure path, so
+        # failure() would skip the rescue bundle on exactly the runs a human
+        # most wants it for. Nothing else in this job competes for the teardown
+        # window, so attempting the upload there is free; if dist/ was never
+        # populated, if-no-files-found: warn keeps that quiet.
+        if: ${{ always() && !success() }}
         uses: actions/upload-artifact@v6
         with:
           name: unsloth-prebuilt-${{ needs.resolve.outputs.tag }}


### PR DESCRIPTION
Three independent CI fixes, each from a measurement on real runs. No build logic changes.

## 1. `Save ccache` now survives a failed build

`Save ccache` had no `if:`, so it only ran when every prior step succeeded. A failed or timed-out build discarded a cache containing hundreds of already-compiled objects, and left a hole in the cache lineage.

That matters because ccache hit rate tracks the gap between the restored cache tag and the tag being built:

| run | restored | building | gap | hit rate | wall clock |
| --- | --- | --- | --- | --- | --- |
| 31136280015 | b10290 | b10297 | 7 | 68.0% (603/887) | 54 min |
| 31218133438 | b10297 | b10310 | 13 | 6.2% (55/887) | 204 min |

The saved-tag lineage for the portable profiles is `b10241, b10265, b10290, b10297, b10310` -- b10298 is missing, so b10310 fell back to b10297 (gap 13) instead of gap 12. Every hole widens the next gap.

Now `if: ${{ !cancelled() }}` on all 9 `Save ccache` steps across the 6 prebuilt workflows. Not `always()`: a cancelled job has no useful cache state.

## 2. CUDA Windows timeout is bounded under `assemble`

`assemble` sets `timeout-minutes: 350`. The build children set nothing, so they inherit GitHub's 360-minute default.

Assemble therefore expires ~11 minutes **before** the job it is waiting on. A build leg in the 350-360 minute band kills the publish while the build is about to succeed, discarding the whole 40-job run. `x64/cuda12-portable` has already been observed at 214 minutes, so the band is reachable.

Adds `timeout-minutes: 300` to the CUDA Windows job so it fails cleanly inside assemble's budget.

## 3. The debug bundle no longer uploads on green runs

`Upload full release set (artifacts)` had no `if:` and sat **before** the publish gate, so every run uploaded ~688 MiB of Actions artifact storage for a bundle nothing reads:

- no `download-artifact` in this repo references it (children pull `inputs.source_artifact`, assemble pulls `pattern: app-*`)
- an org-wide code search for `actions/artifacts` returns nothing
- Studio resolves release **assets**, not artifacts (`install_llama_prebuilt.py` -> `release_asset_download_url`)

Uploading ahead of the gate also meant unpublished, unverified builds were world-downloadable -- on a public repo any signed-in user can download an artifact.

The step is kept, moved after `Publish GitHub release` and gated on `failure()`, so it still rescues a failed publish without re-running the matrix, and costs nothing when the run is green. `if-no-files-found` relaxed to `warn` so an early failure with no `dist/` cannot turn one diagnosable failure into two.

## Why this matters beyond CI hygiene

On 2026-08-07 org-wide Actions scheduling stalled for ~39 minutes of dead queue: Actions artifact storage had reached ~492 GiB, 449 GiB of it in this repo, and GitHub stopped scheduling runs across `unslothai/*` while personal-account repos ran the same workflows normally. Purging artifacts restored scheduling within ~45 seconds. Repo retention was already 1 day; volume alone did it.

Note every prebuilt is currently stored twice -- as an Actions artifact and as a release asset (measured on b10297: 37 artifacts / 7.42 GiB vs 42 assets / 7.81 GiB). A follow-up can delete each run's `app-*` artifacts once the release is published and verified, which reclaims 99.3% of that. This PR does not attempt it.

## Test plan

- [ ] Next nightly: confirm `Save ccache` runs on a failed leg
- [ ] Next nightly: check the `ccache stats` group -- this is the first run to restore a post-fix uncapped cache (the 500 MB cap was lifted in 4a037254 on 08-07 09:52, but b10310 restored a cache written at 04:14, before it), so the hit rate should recover toward 68%+
- [ ] Confirm a green run uploads no `unsloth-prebuilt-<tag>` artifact
- [ ] Confirm a deliberately failed publish still produces one

All 7 workflow files parse (`yaml.safe_load`).