### PR TITLE
CI: prune superseded ccache generations so the repo stays under the cache limit

### DIFF
--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -1050,6 +1050,75 @@ jobs:
             echo "| delete failures | $failed |"
           } >> "$GITHUB_STEP_SUMMARY"
 
+      # ── Keep the ccache budget inside the repo limit ──
+      #
+      # ccache entries are immutable, so every run writes a NEW cache per
+      # (cuda, os, profile) and finds the previous one by restore-keys prefix.
+      # restore-keys returns only the MOST RECENT match, so older generations can
+      # never be selected again -- they are pure landfill. Measured 2026-08-08:
+      # 122 caches / 31.72 GiB, of which only 40 / 9.13 GiB were reachable.
+      #
+      # That matters for build time, not tidiness. The repo cache limit is 50 GB
+      # and there are ~40 prefixes; once the total hits the limit GitHub evicts by
+      # its own LRU, which can take a LIVE cache. A partial cache is far worse
+      # than none: measured locally over 513 real translation units, capping a
+      # cache to 30% of what the build needs drops the hit rate to 14.2% and
+      # flips hits from direct to preprocessed -- the exact 3-direct /
+      # 52-preprocessed signature seen in CI when the cap was 500 MB, which cost
+      # a 204-minute build instead of 54.
+      #
+      # Keeping 2 rather than 1: the second generation is the fallback when a job
+      # dies before saving, which is precisely the hole that forces a cold build.
+      - name: Prune superseded ccache generations
+        # Never fail a published release over cache housekeeping.
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          KEEP: 2
+        run: |
+          set -euo pipefail
+          repo="$GITHUB_REPOSITORY"
+          all="$RUNNER_TEMP/caches.tsv"
+          gh api --paginate "repos/$repo/actions/caches?per_page=100" \
+            -q '.actions_caches[] | "\(.id)\t\(.created_at)\t\(.size_in_bytes)\t\(.key)"' > "$all" || true
+          total=$(awk -F'\t' '{s+=$3} END {printf "%d", s+0}' "$all")
+          echo "$(grep -c . "$all" || true) caches, $(( total / 1073741824 )) GiB"
+
+          # Group by the restore-keys prefix: the key minus its -<tag>- suffix.
+          # Newest first, so anything past $KEEP is unreachable by restore-keys.
+          freed=0; deleted=0
+          while IFS=$'\t' read -r id created size key; do
+            [ -z "${id:-}" ] && continue
+            pre="$(printf '%s' "$key" | sed -E 's/-b[0-9]+-mix-[0-9a-f]+-?$//')"
+            printf '%s\t%s\t%s\t%s\n' "$pre" "$created" "$id" "$size"
+          done < "$all" | sort -t"$(printf '\t')" -k1,1 -k2,2r > "$RUNNER_TEMP/grouped.tsv"
+
+          prev=""; n=0
+          while IFS=$'\t' read -r pre created id size; do
+            [ -z "${pre:-}" ] && continue
+            if [ "$pre" != "$prev" ]; then prev="$pre"; n=1; else n=$(( n + 1 )); fi
+            [ "$n" -le "$KEEP" ] && continue
+            if gh api -X DELETE "repos/$repo/actions/caches/$id" --silent < /dev/null 2>/dev/null; then
+              freed=$(( freed + size )); deleted=$(( deleted + 1 ))
+            fi
+          done < "$RUNNER_TEMP/grouped.tsv"
+
+          after=$(( total - freed ))
+          echo "pruned $deleted superseded caches, freed $(( freed / 1073741824 )) GiB"
+          {
+            echo "### ccache budget"
+            echo ""
+            echo "| metric | value |"
+            echo "| --- | --- |"
+            echo "| kept per prefix | $KEEP |"
+            echo "| caches pruned | $deleted |"
+            echo "| freed | $(( freed / 1073741824 )) GiB |"
+            echo "| cache total after | $(( after / 1073741824 )) GiB of 50 GB |"
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ "$after" -gt 42949672960 ]; then
+            echo "::warning::ccache total is $(( after / 1073741824 )) GiB of the 50 GB repo limit; at the limit GitHub evicts by LRU and a partially evicted cache collapses the hit rate. Lower KEEP to 1, or raise the limit."
+          fi
+
   # Without this a failed scheduled run is silent: GitHub emails only whoever
   # last touched the cron file, which is how three nightlies failed unnoticed.
   # Runs on publish-intent runs only, so subset test dispatches stay quiet.


### PR DESCRIPTION
Adds a second step to the `reclaim` job that deletes ccache generations `restore-keys` can no longer select. This is a build-time change, not housekeeping.

## Why it affects compile time

ccache entries are immutable, so every run writes a new cache per `(cuda, os, profile)` and finds the previous one by `restore-keys` prefix. `restore-keys` returns only the **most recent** match, so older generations can never be selected again.

Measured on this repo before the change: **122 caches / 31.72 GiB, of which only 40 / 9.13 GiB were reachable.** 71% of the budget was unreachable.

That matters because the repo cache limit is 50 GB across ~40 prefixes. Once the total reaches the limit GitHub evicts by its own LRU, which can take a **live** cache, and a partial cache is far worse than a cold one.

Measured locally over 513 real translation units:

| cache size vs what the build needs | direct | preprocessed | hit rate |
| --- | --- | --- | --- |
| 100% | 513 | 0 | 100% |
| 60% | 201 | 104 | 59.5% |
| 30% | 13 | 60 | 14.2% |

A preprocessed-dominant split is the fingerprint of a truncated cache: manifests are evicted, some objects survive, and lookups fall through to the slow path. CI showed exactly that (3 direct / 52 preprocessed) while the cap was 500 MB, and that run took **204 minutes against 54** for the same job with a healthy cache.

Projection now that 4a037254 has stopped the truncation and caches can reach full size:

| CUDA cache size | keep 1 | keep 2 |
| --- | --- | --- |
| 0.8 GiB | 17.7 GB | 35.4 GB |
| 1.2 GiB | 23.3 GB | 46.6 GB |
| 1.5 GiB | 27.5 GB | **55.0 GB, over** |

So without pruning the repo grows into GitHub-side LRU eviction, which reintroduces the truncation that cost those 150 minutes.

## What it does

Groups caches by their `restore-keys` prefix (the key minus its `-<tag>-` suffix), sorts newest first, and deletes everything past `KEEP: 2`. Keeping 2 rather than 1 because the second generation is the fallback when a job dies before saving, precisely the hole that forces a cold build.

It also emits a job summary and raises a `::warning::` above 40 GiB, so the squeeze is visible before it bites.

## Safety

- Lives in the existing `reclaim` job, which already holds `actions: write` and only runs when this run published (`needs.assemble.outputs.published == true`).
- `continue-on-error: true`, so cache housekeeping can never fail a published release.
- Worst case if it were ever wrong is a slower build, never a wrong or missing artifact.

## Testing

The step was extracted from the YAML and run against the **real 122-cache list** from this repo with a stubbed `gh`: it selected exactly **60 caches / 16 GiB**, identical to the manual prune performed today, and left the newest 2 per prefix. `bash -n` clean, all workflows parse.

## Follow-up, not in this PR

`Install CUDA toolkit` costs **7.1-8.8 min** on every cuda12 leg via Jimver, against **0.8-1.1 min** on the cuda13 legs which use the NVIDIA redist method already present in this workflow. Moving cuda12 to redist looks worth about 7 min x 4 jobs per run, but it needs the 12.8 component list pinned and tested before it goes near the release path.