### PR TITLE
Prebuilt: update ROCm and restore upstream build parity

### DIFF
--- a/.github/workflows/unsloth-prebuilt-cpu.yml
+++ b/.github/workflows/unsloth-prebuilt-cpu.yml
@@ -89,6 +89,7 @@ jobs:
           wget -q https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh 19
+          sudo apt-get install -y libomp-19-dev
           {
             echo "CC=clang-19"
             echo "CXX=clang++-19"
@@ -136,6 +137,10 @@ jobs:
           # bins. Backend modules (CPU variants, RPC) build as ggml deps.
           cmake --build build --config Release -j "$(nproc)"
           strip build/bin/llama-* || true
+
+      - name: Bundle OpenMP runtime (arm64)
+        if: matrix.arch == 'arm64'
+        run: cp /usr/lib/llvm-19/lib/libomp.so.5 src/build/bin/
 
       # DiffusionGemma binaries (example targets present only in #24423 mix
       # builds): best-effort, never fail the job. See the CUDA child for the

--- a/.github/workflows/unsloth-prebuilt-rocm.yml
+++ b/.github/workflows/unsloth-prebuilt-rocm.yml
@@ -192,11 +192,11 @@ jobs:
         $rocmVersion = "${{ inputs.rocm_version }}"
         $currentTarget = "${{ matrix.gfx_target }}"
 
-        # Add appropriate suffixes for different GPU targets
-        $s3Target = $currentTarget
+        # Map the build target to the matching TheRock archive family
+        $archiveTarget = $currentTarget
         if ($currentTarget -eq "gfx103X" -or $currentTarget -eq "gfx110X" -or $currentTarget -eq "gfx120X") {
-          $s3Target = "$currentTarget-all"
-          Write-Host "Using target with -all suffix: $s3Target"
+          $archiveTarget = "$currentTarget-all"
+          Write-Host "Using target with -all suffix: $archiveTarget"
         }
 
         # TheRock publishes nightlies to the multi-arch tarball index. The
@@ -213,7 +213,7 @@ jobs:
 
           # Pick the newest build date and exclude sibling test archives.
           $allFiles = $filesMatch.Groups[1].Value | ConvertFrom-Json
-          $prefix = "therock-dist-windows-$s3Target-"
+          $prefix = "therock-dist-windows-$archiveTarget-"
           $versionPattern = "^$([regex]::Escape($prefix))\d+\.\d+\.\d+(a|rc)\d+\.tar\.gz$"
           $latest = $allFiles |
             Where-Object { $_.name -match $versionPattern } |
@@ -227,18 +227,18 @@ jobs:
           Write-Host "Found latest file: $latestFile"
 
           # Extract version from the filename for environment variable
-          if ($latestFile -match "therock-dist-windows-$s3Target-(\d+\.\d+\.\d+(?:a|rc)\d+)\.tar\.gz") {
+          if ($latestFile -match "therock-dist-windows-$archiveTarget-(\d+\.\d+\.\d+(?:a|rc)\d+)\.tar\.gz") {
             $rocmVersion = $matches[1]
             Write-Host "Detected latest ROCm version: $rocmVersion"
           } else {
             Write-Error "Failed to extract ROCm version from latest file: $latestFile"
-            Write-Error "Expected pattern: therock-dist-windows-$s3Target-<version>.tar.gz"
+            Write-Error "Expected pattern: therock-dist-windows-$archiveTarget-<version>.tar.gz"
             exit 1
           }
 
           $rocmUrl = "$baseUrl/$latestFile"
         } else {
-          $rocmUrl = "$baseUrl/therock-dist-windows-$s3Target-$rocmVersion.tar.gz"
+          $rocmUrl = "$baseUrl/therock-dist-windows-$archiveTarget-$rocmVersion.tar.gz"
         }
 
         # Store the version for use in other steps
@@ -524,11 +524,11 @@ jobs:
         rocm_version="${{ inputs.rocm_version }}"
         current_target="${{ matrix.gfx_target }}"
 
-        # Add appropriate suffixes for different GPU targets
-        s3_target="$current_target"
+        # Map the build target to the matching TheRock archive family
+        archive_target="$current_target"
         if [[ "$current_target" = "gfx103X" || "$current_target" = "gfx110X" || "$current_target" = "gfx120X" ]]; then
-          s3_target="${current_target}-all"
-          echo "Using target with -all suffix: $s3_target"
+          archive_target="${current_target}-all"
+          echo "Using target with -all suffix: $archive_target"
         fi
 
         # TheRock publishes nightlies to the multi-arch tarball index. The
@@ -536,7 +536,7 @@ jobs:
         base_url="https://rocm.nightlies.amd.com/tarball-multi-arch"
         if [ "$rocm_version" = "latest" ]; then
           echo "Auto-detecting latest ROCm version for target: $current_target"
-          prefix="therock-dist-linux-${s3_target}-"
+          prefix="therock-dist-linux-${archive_target}-"
           files_json=$(curl -s "$base_url/" | tr '\n' ' ' | grep -oP 'const files = \K\[.*?\](?=\s*;)')
           if [ -z "$files_json" ]; then
             echo "Failed to parse file index from $base_url/"
@@ -553,18 +553,18 @@ jobs:
           echo "Found latest file: $latest_file"
 
           # Extract version from the filename for environment variable
-          if [[ "$latest_file" =~ therock-dist-linux-${s3_target}-([0-9]+\.[0-9]+\.[0-9]+(a|rc)[0-9]+)\.tar\.gz ]]; then
+          if [[ "$latest_file" =~ therock-dist-linux-${archive_target}-([0-9]+\.[0-9]+\.[0-9]+(a|rc)[0-9]+)\.tar\.gz ]]; then
             rocm_version="${BASH_REMATCH[1]}"
             echo "Detected latest ROCm version: $rocm_version"
           else
             echo "Failed to extract ROCm version from latest file: $latest_file"
-            echo "Expected pattern: therock-dist-linux-${s3_target}-<version>.tar.gz"
+            echo "Expected pattern: therock-dist-linux-${archive_target}-<version>.tar.gz"
             exit 1
           fi
 
           rocm_url="$base_url/$latest_file"
         else
-          rocm_url="$base_url/therock-dist-linux-${s3_target}-${rocm_version}.tar.gz"
+          rocm_url="$base_url/therock-dist-linux-${archive_target}-${rocm_version}.tar.gz"
         fi
 
         # Store the version for use in other steps

--- a/.github/workflows/unsloth-prebuilt-rocm.yml
+++ b/.github/workflows/unsloth-prebuilt-rocm.yml
@@ -9,9 +9,9 @@ name: "Unsloth prebuilt: ROCm"
 # Huge thanks to the lemonade-sdk team -- this is adapted from their workflow:
 #   https://github.com/lemonade-sdk/llamacpp-rocm/blob/main/.github/workflows/build-llamacpp-rocm.yml
 #
-# Build mechanics taken verbatim from that file: TheRock S3 nightly download
-# + version auto-detect, gfx target name mapping, HIP/clang cmake invocation,
-# the full hardcoded ROCm runtime lib copy list, patchelf RPATH.
+# Build mechanics taken from that file: TheRock multi-arch nightly download +
+# version auto-detect, gfx target name mapping, HIP/clang cmake invocation, the
+# full hardcoded ROCm runtime lib copy list, patchelf RPATH.
 #
 # Local adaptations:
 #   - tag is passed in (the parent resolves it against ggml-org upstream)
@@ -49,7 +49,7 @@ on:
         default: 'windows,ubuntu'
         type: string
       rocm_version:
-        description: 'TheRock ROCm version (e.g., 7.13.0a20260318) or "latest"'
+        description: 'TheRock ROCm version (e.g., 10.1.0a20260807) or "latest"'
         required: false
         default: 'latest'
         type: string
@@ -194,56 +194,51 @@ jobs:
 
         # Add appropriate suffixes for different GPU targets
         $s3Target = $currentTarget
-        if ($currentTarget -eq "gfx103X") {
-          $s3Target = "$currentTarget-dgpu"
-          Write-Host "Using S3 target with -dgpu suffix: $s3Target"
-        } elseif ($currentTarget -eq "gfx110X" -or $currentTarget -eq "gfx120X") {
+        if ($currentTarget -eq "gfx103X" -or $currentTarget -eq "gfx110X" -or $currentTarget -eq "gfx120X") {
           $s3Target = "$currentTarget-all"
-          Write-Host "Using S3 target with -all suffix: $s3Target"
+          Write-Host "Using target with -all suffix: $s3Target"
         }
 
+        # TheRock publishes nightlies to the multi-arch tarball index. The
+        # static HTML page embeds a JSON `files` array with names and mtimes.
+        $baseUrl = "https://rocm.nightlies.amd.com/tarball-multi-arch"
         if ($rocmVersion -eq "latest") {
           Write-Host "Auto-detecting latest ROCm version for target: $currentTarget"
-          $s3Response = (Invoke-WebRequest "https://therock-nightly-tarball.s3.amazonaws.com/?prefix=therock-dist-windows-$s3Target-7").Content
-          $files = $s3Response -split '<Key>' | Where-Object {$_ -match '</Key>'} | ForEach-Object { ($_ -split '</Key>')[0] }
-
-          # Extract versions and sort them properly using semantic versioning
-          $versionFiles = @()
-          foreach ($file in $files) {
-            if ($file -match "therock-dist-windows-$s3Target-.*?(\d+\.\d+\.\d+(?:a|rc)\d+)\.tar\.gz") {
-              $version = $matches[1]
-              $versionFiles += [PSCustomObject]@{
-                File = $file
-                Version = $version
-                Major = [int]($version -split '\.')[0]
-                Minor = [int]($version -split '\.')[1]
-                Patch = [int](($version -split '\.')[2] -replace '(?:a|rc).*', '')
-                RC = [int]($version -replace '.*(?:a|rc)', '')
-                IsAlpha = $version -match 'a'
-              }
-            }
+          $indexHtml = (Invoke-WebRequest "$baseUrl/" -UseBasicParsing).Content
+          $filesMatch = [regex]::Match($indexHtml, 'const files = (\[.*?\]);', [System.Text.RegularExpressions.RegexOptions]::Singleline)
+          if (-not $filesMatch.Success) {
+            Write-Error "Failed to parse file index from $baseUrl/"
+            exit 1
           }
 
-          # Sort by semantic version (major.minor.patch.rc, with alpha versions being newer than rc)
-          $latestFile = ($versionFiles | Sort-Object Major, Minor, Patch, @{Expression={if($_.IsAlpha){1}else{0}}}, RC | Select-Object -Last 1).File
-
+          # Pick the newest build date and exclude sibling test archives.
+          $allFiles = $filesMatch.Groups[1].Value | ConvertFrom-Json
+          $prefix = "therock-dist-windows-$s3Target-"
+          $versionPattern = "^$([regex]::Escape($prefix))\d+\.\d+\.\d+(a|rc)\d+\.tar\.gz$"
+          $latest = $allFiles |
+            Where-Object { $_.name -match $versionPattern } |
+            Sort-Object { [regex]::Match($_.name, '(\d{8})\.tar\.gz$').Groups[1].Value } |
+            Select-Object -Last 1
+          if (-not $latest) {
+            Write-Error "No tarball found for prefix '$prefix' at $baseUrl/"
+            exit 1
+          }
+          $latestFile = $latest.name
           Write-Host "Found latest file: $latestFile"
 
           # Extract version from the filename for environment variable
-          if ($latestFile -match "therock-dist-windows-$s3Target-.*?(\d+\.\d+\.\d+(?:a|rc)\d+)\.tar\.gz") {
+          if ($latestFile -match "therock-dist-windows-$s3Target-(\d+\.\d+\.\d+(?:a|rc)\d+)\.tar\.gz") {
             $rocmVersion = $matches[1]
             Write-Host "Detected latest ROCm version: $rocmVersion"
           } else {
             Write-Error "Failed to extract ROCm version from latest file: $latestFile"
-            Write-Error "Expected pattern: therock-dist-windows-$s3Target-*<version>.tar.gz"
+            Write-Error "Expected pattern: therock-dist-windows-$s3Target-<version>.tar.gz"
             exit 1
           }
 
-          # Use the exact filename from S3 instead of reconstructing
-          $rocmUrl = "https://therock-nightly-tarball.s3.amazonaws.com/$latestFile"
+          $rocmUrl = "$baseUrl/$latestFile"
         } else {
-          # For specific versions, construct the URL as before
-          $rocmUrl = "https://therock-nightly-tarball.s3.amazonaws.com/therock-dist-windows-$s3Target-$rocmVersion.tar.gz"
+          $rocmUrl = "$baseUrl/therock-dist-windows-$s3Target-$rocmVersion.tar.gz"
         }
 
         # Store the version for use in other steps
@@ -383,7 +378,8 @@ jobs:
             "rocsolver.dll",
             "hipblaslt.dll",
             "libhipblaslt.dll",
-            "hipblas.dll"
+            "hipblas.dll",
+            "origami.dll"
           )
 
           foreach ($pattern in $filesToCopy) {
@@ -530,86 +526,45 @@ jobs:
 
         # Add appropriate suffixes for different GPU targets
         s3_target="$current_target"
-        if [ "$current_target" = "gfx103X" ]; then
-          s3_target="${current_target}-dgpu"
-          echo "Using S3 target with -dgpu suffix: $s3_target"
-        elif [[ "$current_target" = "gfx110X" || "$current_target" = "gfx120X" ]]; then
+        if [[ "$current_target" = "gfx103X" || "$current_target" = "gfx110X" || "$current_target" = "gfx120X" ]]; then
           s3_target="${current_target}-all"
-          echo "Using S3 target with -all suffix: $s3_target"
+          echo "Using target with -all suffix: $s3_target"
         fi
 
+        # TheRock publishes nightlies to the multi-arch tarball index. The
+        # static HTML page embeds a JSON `files` array with names and mtimes.
+        base_url="https://rocm.nightlies.amd.com/tarball-multi-arch"
         if [ "$rocm_version" = "latest" ]; then
           echo "Auto-detecting latest ROCm version for target: $current_target"
-          s3_response=$(curl -s "https://therock-nightly-tarball.s3.amazonaws.com/?prefix=therock-dist-linux-${s3_target}-7")
+          prefix="therock-dist-linux-${s3_target}-"
+          files_json=$(curl -s "$base_url/" | tr '\n' ' ' | grep -oP 'const files = \K\[.*?\](?=\s*;)')
+          if [ -z "$files_json" ]; then
+            echo "Failed to parse file index from $base_url/"
+            exit 1
+          fi
 
-          # Extract all files and parse versions properly
-          files=$(echo "$s3_response" | grep -oP '(?<=<Key>)[^<]*' | grep "therock-dist-linux-${s3_target}-")
-
-          # Extract versions and sort them properly using semantic versioning
-          latest_file=""
-          latest_major=0
-          latest_minor=0
-          latest_patch=0
-          latest_rc=0
-          latest_is_alpha=false
-
-          while IFS= read -r file; do
-            if [[ "$file" =~ therock-dist-linux-${s3_target}-.*?([0-9]+\.[0-9]+\.[0-9]+(a|rc)[0-9]+)\.tar\.gz ]]; then
-              version="${BASH_REMATCH[1]}"
-              major=$(echo "$version" | cut -d. -f1)
-              minor=$(echo "$version" | cut -d. -f2)
-              patch=$(echo "$version" | cut -d. -f3 | sed 's/\(a\|rc\).*//')
-              rc=$(echo "$version" | sed 's/.*\(a\|rc\)//')
-              is_alpha=false
-              if [[ "$version" =~ a ]]; then
-                is_alpha=true
-              fi
-
-              # Compare versions (alpha versions are newer than rc versions)
-              is_newer=false
-              if [ "$major" -gt "$latest_major" ]; then
-                is_newer=true
-              elif [ "$major" -eq "$latest_major" ] && [ "$minor" -gt "$latest_minor" ]; then
-                is_newer=true
-              elif [ "$major" -eq "$latest_major" ] && [ "$minor" -eq "$latest_minor" ] && [ "$patch" -gt "$latest_patch" ]; then
-                is_newer=true
-              elif [ "$major" -eq "$latest_major" ] && [ "$minor" -eq "$latest_minor" ] && [ "$patch" -eq "$latest_patch" ]; then
-                # Same major.minor.patch, compare alpha vs rc
-                if [ "$is_alpha" = true ] && [ "$latest_is_alpha" = false ]; then
-                  is_newer=true
-                elif [ "$is_alpha" = "$latest_is_alpha" ] && [ "$rc" -gt "$latest_rc" ]; then
-                  is_newer=true
-                fi
-              fi
-
-              if [ "$is_newer" = true ]; then
-                latest_file="$file"
-                latest_major="$major"
-                latest_minor="$minor"
-                latest_patch="$patch"
-                latest_rc="$rc"
-                latest_is_alpha="$is_alpha"
-              fi
-            fi
-          done <<< "$files"
-
+          # Pick the newest build date and exclude sibling test archives.
+          latest_file=$(echo "$files_json" | jq -r --arg p "$prefix" \
+            '[.[] | select(.name | test("^" + $p + "[0-9]+\\.[0-9]+\\.[0-9]+(a|rc)[0-9]+\\.tar\\.gz$"))] | sort_by(.name | capture("(?<d>[0-9]{8})\\.tar\\.gz$").d) | last | .name // empty')
+          if [ -z "$latest_file" ]; then
+            echo "No tarball found for prefix '$prefix' at $base_url/"
+            exit 1
+          fi
           echo "Found latest file: $latest_file"
 
           # Extract version from the filename for environment variable
-          if [[ "$latest_file" =~ therock-dist-linux-${s3_target}-.*?([0-9]+\.[0-9]+\.[0-9]+(a|rc)[0-9]+)\.tar\.gz ]]; then
+          if [[ "$latest_file" =~ therock-dist-linux-${s3_target}-([0-9]+\.[0-9]+\.[0-9]+(a|rc)[0-9]+)\.tar\.gz ]]; then
             rocm_version="${BASH_REMATCH[1]}"
             echo "Detected latest ROCm version: $rocm_version"
           else
             echo "Failed to extract ROCm version from latest file: $latest_file"
-            echo "Expected pattern: therock-dist-linux-${s3_target}-*<version>.tar.gz"
+            echo "Expected pattern: therock-dist-linux-${s3_target}-<version>.tar.gz"
             exit 1
           fi
 
-          # Use the exact filename from S3 instead of reconstructing
-          rocm_url="https://therock-nightly-tarball.s3.amazonaws.com/$latest_file"
+          rocm_url="$base_url/$latest_file"
         else
-          # For specific versions, construct the URL as before
-          rocm_url="https://therock-nightly-tarball.s3.amazonaws.com/therock-dist-linux-${s3_target}-${rocm_version}.tar.gz"
+          rocm_url="$base_url/therock-dist-linux-${s3_target}-${rocm_version}.tar.gz"
         fi
 
         # Store the version for use in other steps
@@ -786,6 +741,7 @@ jobs:
         cp -v /opt/rocm/lib/libhsa-runtime64.so* "$build_bin_path/" 2>/dev/null || echo "libhsa-runtime64.so* not found"
         cp -v /opt/rocm/lib/rocm_sysdeps/lib/librocm_sysdeps_numa.so* "$build_bin_path/" 2>/dev/null || echo "librocm_sysdeps_numa.so* not found"
         cp -v /opt/rocm/lib/librocroller.so* "$build_bin_path/" 2>/dev/null || echo "librocroller.so* not found"
+        cp -v /opt/rocm/lib/liborigami.so* "$build_bin_path/" 2>/dev/null || echo "liborigami.so* not found"
         cp -v /opt/rocm/lib/librocm_kpack.so* "$build_bin_path/" 2>/dev/null || echo "librocm_kpack.so* not found"
         cp -v /opt/rocm/lib/rocm_sysdeps/lib/librocm_sysdeps_z.so* "$build_bin_path/" 2>/dev/null || echo "librocm_sysdeps_z.so* not found"
         cp -v /opt/rocm/lib/rocm_sysdeps/lib/librocm_sysdeps_zstd.so* "$build_bin_path/" 2>/dev/null || echo "librocm_sysdeps_zstd.so* not found"

--- a/.github/workflows/unsloth-prebuilt-vulkan.yml
+++ b/.github/workflows/unsloth-prebuilt-vulkan.yml
@@ -42,8 +42,8 @@ permissions:
   contents: read
 
 env:
-  # LunarG SDK version, matching llama-cpp-binaries' build-wheels-vulkan.yml.
-  VULKAN_VERSION: 1.4.313.2
+  # LunarG SDK version used by ggml-org's Windows release build.
+  VULKAN_VERSION: 1.4.357.0
 
 jobs:
   build-linux:
@@ -94,6 +94,7 @@ jobs:
           wget -q https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh 19
+          sudo apt-get install -y libomp-19-dev
           {
             echo "CC=clang-19"
             echo "CXX=clang++-19"
@@ -181,6 +182,10 @@ jobs:
           # dependencies, so every tool pulls them in.
           cmake --build build --config Release -j "$(nproc)"
           strip build/bin/llama-* || true
+
+      - name: Bundle OpenMP runtime (arm64)
+        if: matrix.arch == 'arm64'
+        run: cp /usr/lib/llvm-19/lib/libomp.so.5 src/build/bin/
 
       # DiffusionGemma binaries (example targets present only in #24423 mix
       # builds): best-effort, never fail the job. See the CUDA child for the

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -391,12 +391,10 @@ jobs:
 
           # macOS slices are static: two fixed runners with per-slice deployment
           # targets. arm64 builds on macos-26 (newest Metal SDK; avoids the
-          # M5/A19 "error compiling source" the macos-14 SDK emits) yet pins
-          # minos 14.0 via deploy_target, so it still loads on macOS 14+. x64
-          # pins 13.3 (matches upstream's Intel leg, covers 2017 Intel Macs
-          # capped at Ventura).
+          # M5/A19 "error compiling source" the macos-14 SDK emits) while both
+          # slices pin 13.3 to match upstream's Ventura compatibility floor.
           MACOS_INCLUDE='[
-            {"build":"arm64","runner":"macos-26",      "expect_arch":"arm64", "deploy_target":"14.0","defines":"-DGGML_METAL_EMBED_LIBRARY=ON"},
+            {"build":"arm64","runner":"macos-26",      "expect_arch":"arm64", "deploy_target":"13.3","defines":"-DGGML_METAL_EMBED_LIBRARY=ON"},
             {"build":"x64",  "runner":"macos-15-intel","expect_arch":"x86_64","deploy_target":"13.3","defines":"-DGGML_METAL=OFF"}
           ]'
           MACOS_INCLUDE="$(echo "$MACOS_INCLUDE" | jq -c .)"


### PR DESCRIPTION
## Summary

Unsloth publishes prebuilt llama.cpp bundles for Studio across ROCm, Vulkan, CPU, and macOS. The builds were green, but their logs and resolved dependencies showed four places where the produced binaries no longer matched current upstream build expectations.

This updates those toolchain inputs without changing the llama.cpp source, target matrix, artifact names, or Studio selection logic.

## Problems

### ROCm resolved months-old builds

The workflow queried TheRock's retired S3 index. In the latest Unsloth release it selected a June 12 ROCm build for `gfx1151` and an April 21 build for `gfx103X`. AMD's active index provided August 7 builds for every target in our matrix.

The active index names the gfx103X package `gfx103X-all`, so retaining `gfx103X-dgpu` would make that download fail. Current ROCm nightlies also load origami through hipBLASLt. Omitting it allows compilation to succeed but leaves the published runtime incomplete.

### Windows Vulkan omitted supported acceleration paths

The Windows bundle used Vulkan SDK 1.4.313.2. Its build log showed llama.cpp disabling these shaders because `glslc` did not support their extensions:

- cooperative matrix decode
- E2M1 low-precision formats
- E4M3 low-precision formats

Upstream Windows releases use SDK 1.4.357.0, which can compile those paths. This does not change results on unsupported hardware. It restores optimized shaders on GPUs and drivers that expose the corresponding extensions.

### Linux ARM64 disabled OpenMP

The CPU and Vulkan ARM64 logs reported that OpenMP could not be found, then completed with it disabled. The x64 bundles and upstream ARM64 build enable it.

Installing `libomp-19-dev` restores the expected clang OpenMP path for CPU work and CPU fallback inside the Vulkan bundle. `libomp.so.5` is included beside the binaries, preserving the self-contained bundle contract.

This change restores feature parity. It does not claim a measured end-to-end speedup for every model or ARM64 processor.

### Apple Silicon excluded Ventura

The Apple Silicon binaries carried a macOS 14.0 minimum while upstream now targets 13.3. That excludes Ventura even though the Studio configuration does not declare a macOS 14 requirement.

The build remains on the macOS 26 runner for the newer Metal SDK and M5 support. Only the deployment target moves to 13.3, matching upstream and restoring Ventura compatibility.

## What changed

- Resolve ROCm from AMD's active multi-arch index for Windows and Linux.
- Use `gfx103X-all`, exclude similarly named test archives, and bundle origami.
- Update the Windows Vulkan SDK from 1.4.313.2 to 1.4.357.0.
- Install and bundle OpenMP for Linux ARM64 CPU and Vulkan builds.
- Lower the Apple Silicon deployment target from macOS 14.0 to 13.3 while retaining the macOS 26 runner.

## Verification

- `actionlint` passed on all four changed workflows.
- YAML parsing and `git diff --check` passed.
- Live ROCm resolution selected the August 7 non-test archive for every published Windows and Linux target.
- Verified the Vulkan SDK download and ARM64 OpenMP package and runtime paths.
