### PR TITLE
CI: pin every third-party action to a commit SHA

### DIFF
--- a/.github/workflows/bench.yml.disabled
+++ b/.github/workflows/bench.yml.disabled
@@ -162,7 +162,7 @@ jobs:
             tools/server/bench/*.log
 
       - name: Commit status
-        uses: Sibz/github-status-action@v1
+        uses: Sibz/github-status-action@faaa4d96fecf273bd762985e0e7f9f933c774918  # v1
         with:
           authToken: ${{secrets.GITHUB_TOKEN}}
           sha: ${{ inputs.sha || github.event.pull_request.head.sha || github.sha }}
@@ -172,7 +172,7 @@ jobs:
           state: 'success'
 
       - name: Upload benchmark images
-        uses: devicons/public-upload-to-imgur@v2.2.2
+        uses: devicons/public-upload-to-imgur@352cf5f2805c692539a96cfe49a09669e6fca88e  # v2.2.2
         continue-on-error: true # Important as it looks unstable: 503
         id: imgur_step
         with:
@@ -221,7 +221,7 @@ jobs:
           echo "IMAGE_3=${{ fromJSON(steps.imgur_step.outputs.imgur_urls)[3] }}" >> $GITHUB_ENV
 
       - name: Comment PR
-        uses: mshick/add-pr-comment@v2
+        uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc  # v2
         id: comment_pr
         if: ${{ github.event.pull_request != '' && matrix.pr_comment_enabled == 'true' }}
         with:

--- a/.github/workflows/unsloth-prebuilt-cpu.yml
+++ b/.github/workflows/unsloth-prebuilt-cpu.yml
@@ -95,7 +95,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.23
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03  # v1.2.23
         with:
           key: cpu-linux-${{ matrix.arch }}-${{ inputs.tag }}
           restore-keys: |
@@ -236,7 +236,7 @@ jobs:
           tar -xzf "srcpkg/llama.cpp-source-${{ inputs.tag }}.tar.gz" -C src --strip-components=1
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.23
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03  # v1.2.23
         with:
           key: cpu-windows-${{ matrix.arch }}-${{ inputs.tag }}
           restore-keys: |

--- a/.github/workflows/unsloth-prebuilt-cuda-windows.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda-windows.yml
@@ -115,7 +115,7 @@ jobs:
           tar -xzf "srcpkg/llama.cpp-source-${{ inputs.tag }}.tar.gz" -C src --strip-components=1
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.23
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03  # v1.2.23
         with:
           key: cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-${{ inputs.tag }}
           restore-keys: |
@@ -133,7 +133,7 @@ jobs:
         run: choco install ninja --no-progress
 
       - name: Setup MSVC
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756  # v1
 
       # Jimver's action has no mapping for CUDA 13.3 yet, so for that version we
       # fall back to llama.cpp's own install method: curl the individual NVIDIA
@@ -172,7 +172,7 @@ jobs:
 
       - name: Install CUDA toolkit ${{ matrix.cuda }} (Jimver)
         if: matrix.cuda != '13.3'
-        uses: Jimver/cuda-toolkit@v0.2.35
+        uses: Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec76  # v0.2.35
         id: cuda-toolkit
         with:
           cuda: ${{ matrix.cuda }}

--- a/.github/workflows/unsloth-prebuilt-cuda.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda.yml
@@ -45,7 +45,7 @@ jobs:
       matrix: ${{ fromJSON(inputs.matrix) }}
     steps:
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@v1.3.1
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
         with:
           tool-cache: true
           android: true
@@ -93,7 +93,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.23
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03  # v1.2.23
         with:
           key: cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ inputs.tag }}
           restore-keys: |
@@ -142,7 +142,7 @@ jobs:
 
       - name: Install CUDA toolkit ${{ matrix.cuda }} (Jimver)
         if: matrix.cuda != '13.3'
-        uses: Jimver/cuda-toolkit@v0.2.35
+        uses: Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec76  # v0.2.35
         id: cuda-toolkit
         with:
           cuda: ${{ matrix.cuda }}

--- a/.github/workflows/unsloth-prebuilt-macos.yml
+++ b/.github/workflows/unsloth-prebuilt-macos.yml
@@ -74,7 +74,7 @@ jobs:
       # in a way they do not elsewhere. Setting a launcher for a language this
       # build never enables is inert, so both are set unconditionally.
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.23
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03  # v1.2.23
         with:
           key: macos-${{ matrix.build }}-${{ matrix.deploy_target }}-${{ inputs.tag }}
           restore-keys: |

--- a/.github/workflows/unsloth-prebuilt-rocm.yml
+++ b/.github/workflows/unsloth-prebuilt-rocm.yml
@@ -266,7 +266,7 @@ jobs:
     # runs after packaging, so a failed package step does not persist a cache
     # for a bundle that never shipped (same pattern as the CPU/CUDA children).
     - name: ccache
-      uses: hendrikmuhs/ccache-action@v1.2.23
+      uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03  # v1.2.23
       with:
         key: rocm-windows-${{ matrix.gfx_target }}-${{ inputs.tag }}
         restore-keys: |
@@ -665,7 +665,7 @@ jobs:
 
     # See the Windows job for why the key is per gfx target and why save: false.
     - name: ccache
-      uses: hendrikmuhs/ccache-action@v1.2.23
+      uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03  # v1.2.23
       with:
         key: rocm-linux-${{ matrix.gfx_target }}-${{ inputs.tag }}
         restore-keys: |

--- a/.github/workflows/unsloth-prebuilt-vulkan.yml
+++ b/.github/workflows/unsloth-prebuilt-vulkan.yml
@@ -100,7 +100,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.23
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03  # v1.2.23
         with:
           key: vulkan-linux-${{ matrix.arch }}-${{ inputs.tag }}
           restore-keys: |
@@ -271,7 +271,7 @@ jobs:
           tar -xzf "srcpkg/llama.cpp-source-${{ inputs.tag }}.tar.gz" -C src --strip-components=1
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.23
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03  # v1.2.23
         with:
           key: vulkan-windows-x64-${{ inputs.tag }}
           restore-keys: |
@@ -285,7 +285,7 @@ jobs:
         run: choco install ninja --no-progress
 
       - name: Setup MSVC
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756  # v1
 
       - name: Install Vulkan SDK
         run: |


### PR DESCRIPTION
Pins all 7 third-party actions to immutable commit SHAs, with the version kept as a trailing comment.

## Why

A git tag is a mutable pointer. `uses: Jimver/cuda-toolkit@v0.2.35` re-resolves on every run, so if that tag is ever moved -- by the maintainer, or by someone who has taken over the account -- the next prebuild silently executes different code, with full access to the runner that produces the release binaries Studio downloads.

Two of these were on bare major tags (`ilammy/msvc-dev-cmd@v1`, `mshick/add-pr-comment@v2`), which by convention move on every minor release, so they were already changing under us.

Worth being specific about the exposure rather than generic: `Jimver/cuda-toolkit` is a **personal user account** (210 stars, MIT, actively maintained, but one individual and no organisational backing), and it runs on the CUDA build legs. `hendrikmuhs/ccache-action` runs on all 9 build legs.

`actions/*` are GitHub-owned and left on tags, consistent with the rest of the repo.

## What changed

| action | pinned to | was |
| --- | --- | --- |
| `hendrikmuhs/ccache-action` | `d62db5f07c26379fc4b4e0916f098a92573c3b03` | v1.2.23 |
| `Jimver/cuda-toolkit` | `3d45d157f327c09c04b50ee6ccdea2d9d017ec76` | v0.2.35 |
| `ilammy/msvc-dev-cmd` | `0b201ec74fa43914dc39ae48a89fd1d8cb592756` | v1 |
| `jlumbroso/free-disk-space` | `54081f138730dfa15788a46383842cd2f914a1be` | v1.3.1 |
| `mshick/add-pr-comment` | `b8f338c590a895d50bcbfa6c5859251edc8952fc` | v2 |
| `devicons/public-upload-to-imgur` | `352cf5f2805c692539a96cfe49a09669e6fca88e` | v2.2.2 |
| `Sibz/github-status-action` | `faaa4d96fecf273bd762985e0e7f9f933c774918` | v1 |

17 references across 7 files. The last three are only in `bench.yml.disabled`, which GitHub does not execute; pinned anyway so it is safe if it is ever re-enabled.

## Prebuilt outputs are unaffected

Every SHA is the exact commit its tag pointed at when this PR was written, verified against each upstream repo via the API. Same action code, same inputs, same toolchain -- only the reference is now immutable. Nothing about what gets compiled or packaged changes.

## Verification

- Each SHA confirmed to exist in its repo and to match the named tag.
- Diff contains **0 non-`uses:` changed lines** (17 insertions, 17 deletions, all `uses:`). An earlier attempt at this used a regex whose trailing group swallowed adjacent blank lines and comments; it was discarded and redone with a line-scoped edit, and this check is what caught it.
- All 23 workflow and composite-action files parse.
- No unpinned third-party action remains anywhere under `.github/`.

## Follow-up

Renovate and Dependabot both understand the `@<sha>  # <tag>` convention and will keep these updated, if you want automated bumps rather than manual ones.