### PR TITLE
Prebuilt: update ROCm and restore upstream build parity

### DIFF
--- a/.github/workflows/unsloth-prebuilt-cpu.yml
+++ b/.github/workflows/unsloth-prebuilt-cpu.yml
@@ -89,6 +89,7 @@ jobs:
           wget -q https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh 19
+          sudo apt-get install -y libomp-19-dev
           {
             echo "CC=clang-19"
             echo "CXX=clang++-19"
@@ -136,6 +137,10 @@ jobs:
           # bins. Backend modules (CPU variants, RPC) build as ggml deps.
           cmake --build build --config Release -j "$(nproc)"
           strip build/bin/llama-* || true
+
+      - name: Bundle OpenMP runtime (arm64)
+        if: matrix.arch == 'arm64'
+        run: cp /usr/lib/llvm-19/lib/libomp.so.5 src/build/bin/
 
       # DiffusionGemma binaries (example targets present only in #24423 mix
       # builds): best-effort, never fail the job. See the CUDA child for the

--- a/.github/workflows/unsloth-prebuilt-rocm.yml
+++ b/.github/workflows/unsloth-prebuilt-rocm.yml
@@ -192,11 +192,11 @@ jobs:
         $rocmVersion = "${{ inputs.rocm_version }}"
         $currentTarget = "${{ matrix.gfx_target }}"
 
-        # Add appropriate suffixes for different GPU targets
-        $s3Target = $currentTarget
+        # Map the build target to the matching TheRock archive family
+        $archiveTarget = $currentTarget
         if ($currentTarget -eq "gfx103X" -or $currentTarget -eq "gfx110X" -or $currentTarget -eq "gfx120X") {
-          $s3Target = "$currentTarget-all"
-          Write-Host "Using target with -all suffix: $s3Target"
+          $archiveTarget = "$currentTarget-all"
+          Write-Host "Using target with -all suffix: $archiveTarget"
         }
 
         # TheRock publishes nightlies to the multi-arch tarball index. The
@@ -213,7 +213,7 @@ jobs:
 
           # Pick the newest build date and exclude sibling test archives.
           $allFiles = $filesMatch.Groups[1].Value | ConvertFrom-Json
-          $prefix = "therock-dist-windows-$s3Target-"
+          $prefix = "therock-dist-windows-$archiveTarget-"
           $versionPattern = "^$([regex]::Escape($prefix))\d+\.\d+\.\d+(a|rc)\d+\.tar\.gz$"
           $latest = $allFiles |
             Where-Object { $_.name -match $versionPattern } |
@@ -227,18 +227,18 @@ jobs:
           Write-Host "Found latest file: $latestFile"
 
           # Extract version from the filename for environment variable
-          if ($latestFile -match "therock-dist-windows-$s3Target-(\d+\.\d+\.\d+(?:a|rc)\d+)\.tar\.gz") {
+          if ($latestFile -match "therock-dist-windows-$archiveTarget-(\d+\.\d+\.\d+(?:a|rc)\d+)\.tar\.gz") {
             $rocmVersion = $matches[1]
             Write-Host "Detected latest ROCm version: $rocmVersion"
           } else {
             Write-Error "Failed to extract ROCm version from latest file: $latestFile"
-            Write-Error "Expected pattern: therock-dist-windows-$s3Target-<version>.tar.gz"
+            Write-Error "Expected pattern: therock-dist-windows-$archiveTarget-<version>.tar.gz"
             exit 1
           }
 
           $rocmUrl = "$baseUrl/$latestFile"
         } else {
-          $rocmUrl = "$baseUrl/therock-dist-windows-$s3Target-$rocmVersion.tar.gz"
+          $rocmUrl = "$baseUrl/therock-dist-windows-$archiveTarget-$rocmVersion.tar.gz"
         }
 
         # Store the version for use in other steps
@@ -540,11 +540,11 @@ jobs:
         rocm_version="${{ inputs.rocm_version }}"
         current_target="${{ matrix.gfx_target }}"
 
-        # Add appropriate suffixes for different GPU targets
-        s3_target="$current_target"
+        # Map the build target to the matching TheRock archive family
+        archive_target="$current_target"
         if [[ "$current_target" = "gfx103X" || "$current_target" = "gfx110X" || "$current_target" = "gfx120X" ]]; then
-          s3_target="${current_target}-all"
-          echo "Using target with -all suffix: $s3_target"
+          archive_target="${current_target}-all"
+          echo "Using target with -all suffix: $archive_target"
         fi
 
         # TheRock publishes nightlies to the multi-arch tarball index. The
@@ -552,7 +552,7 @@ jobs:
         base_url="https://rocm.nightlies.amd.com/tarball-multi-arch"
         if [ "$rocm_version" = "latest" ]; then
           echo "Auto-detecting latest ROCm version for target: $current_target"
-          prefix="therock-dist-linux-${s3_target}-"
+          prefix="therock-dist-linux-${archive_target}-"
           files_json=$(curl -s "$base_url/" | tr '\n' ' ' | grep -oP 'const files = \K\[.*?\](?=\s*;)')
           if [ -z "$files_json" ]; then
             echo "Failed to parse file index from $base_url/"
@@ -569,18 +569,18 @@ jobs:
           echo "Found latest file: $latest_file"
 
           # Extract version from the filename for environment variable
-          if [[ "$latest_file" =~ therock-dist-linux-${s3_target}-([0-9]+\.[0-9]+\.[0-9]+(a|rc)[0-9]+)\.tar\.gz ]]; then
+          if [[ "$latest_file" =~ therock-dist-linux-${archive_target}-([0-9]+\.[0-9]+\.[0-9]+(a|rc)[0-9]+)\.tar\.gz ]]; then
             rocm_version="${BASH_REMATCH[1]}"
             echo "Detected latest ROCm version: $rocm_version"
           else
             echo "Failed to extract ROCm version from latest file: $latest_file"
-            echo "Expected pattern: therock-dist-linux-${s3_target}-<version>.tar.gz"
+            echo "Expected pattern: therock-dist-linux-${archive_target}-<version>.tar.gz"
             exit 1
           fi
 
           rocm_url="$base_url/$latest_file"
         else
-          rocm_url="$base_url/therock-dist-linux-${s3_target}-${rocm_version}.tar.gz"
+          rocm_url="$base_url/therock-dist-linux-${archive_target}-${rocm_version}.tar.gz"
         fi
 
         # Store the version for use in other steps

--- a/.github/workflows/unsloth-prebuilt-rocm.yml
+++ b/.github/workflows/unsloth-prebuilt-rocm.yml
@@ -9,9 +9,9 @@ name: "Unsloth prebuilt: ROCm"
 # Huge thanks to the lemonade-sdk team -- this is adapted from their workflow:
 #   https://github.com/lemonade-sdk/llamacpp-rocm/blob/main/.github/workflows/build-llamacpp-rocm.yml
 #
-# Build mechanics taken verbatim from that file: TheRock S3 nightly download
-# + version auto-detect, gfx target name mapping, HIP/clang cmake invocation,
-# the full hardcoded ROCm runtime lib copy list, patchelf RPATH.
+# Build mechanics taken from that file: TheRock multi-arch nightly download +
+# version auto-detect, gfx target name mapping, HIP/clang cmake invocation, the
+# full hardcoded ROCm runtime lib copy list, patchelf RPATH.
 #
 # Local adaptations:
 #   - tag is passed in (the parent resolves it against ggml-org upstream)
@@ -49,7 +49,7 @@ on:
         default: 'windows,ubuntu'
         type: string
       rocm_version:
-        description: 'TheRock ROCm version (e.g., 7.13.0a20260318) or "latest"'
+        description: 'TheRock ROCm version (e.g., 10.1.0a20260807) or "latest"'
         required: false
         default: 'latest'
         type: string
@@ -194,56 +194,51 @@ jobs:
 
         # Add appropriate suffixes for different GPU targets
         $s3Target = $currentTarget
-        if ($currentTarget -eq "gfx103X") {
-          $s3Target = "$currentTarget-dgpu"
-          Write-Host "Using S3 target with -dgpu suffix: $s3Target"
-        } elseif ($currentTarget -eq "gfx110X" -or $currentTarget -eq "gfx120X") {
+        if ($currentTarget -eq "gfx103X" -or $currentTarget -eq "gfx110X" -or $currentTarget -eq "gfx120X") {
           $s3Target = "$currentTarget-all"
-          Write-Host "Using S3 target with -all suffix: $s3Target"
+          Write-Host "Using target with -all suffix: $s3Target"
         }
 
+        # TheRock publishes nightlies to the multi-arch tarball index. The
+        # static HTML page embeds a JSON `files` array with names and mtimes.
+        $baseUrl = "https://rocm.nightlies.amd.com/tarball-multi-arch"
         if ($rocmVersion -eq "latest") {
           Write-Host "Auto-detecting latest ROCm version for target: $currentTarget"
-          $s3Response = (Invoke-WebRequest "https://therock-nightly-tarball.s3.amazonaws.com/?prefix=therock-dist-windows-$s3Target-7").Content
-          $files = $s3Response -split '<Key>' | Where-Object {$_ -match '</Key>'} | ForEach-Object { ($_ -split '</Key>')[0] }
-
-          # Extract versions and sort them properly using semantic versioning
-          $versionFiles = @()
-          foreach ($file in $files) {
-            if ($file -match "therock-dist-windows-$s3Target-.*?(\d+\.\d+\.\d+(?:a|rc)\d+)\.tar\.gz") {
-              $version = $matches[1]
-              $versionFiles += [PSCustomObject]@{
-                File = $file
-                Version = $version
-                Major = [int]($version -split '\.')[0]
-                Minor = [int]($version -split '\.')[1]
-                Patch = [int](($version -split '\.')[2] -replace '(?:a|rc).*', '')
-                RC = [int]($version -replace '.*(?:a|rc)', '')
-                IsAlpha = $version -match 'a'
-              }
-            }
+          $indexHtml = (Invoke-WebRequest "$baseUrl/" -UseBasicParsing).Content
+          $filesMatch = [regex]::Match($indexHtml, 'const files = (\[.*?\]);', [System.Text.RegularExpressions.RegexOptions]::Singleline)
+          if (-not $filesMatch.Success) {
+            Write-Error "Failed to parse file index from $baseUrl/"
+            exit 1
           }
 
-          # Sort by semantic version (major.minor.patch.rc, with alpha versions being newer than rc)
-          $latestFile = ($versionFiles | Sort-Object Major, Minor, Patch, @{Expression={if($_.IsAlpha){1}else{0}}}, RC | Select-Object -Last 1).File
-
+          # Pick the newest build date and exclude sibling test archives.
+          $allFiles = $filesMatch.Groups[1].Value | ConvertFrom-Json
+          $prefix = "therock-dist-windows-$s3Target-"
+          $versionPattern = "^$([regex]::Escape($prefix))\d+\.\d+\.\d+(a|rc)\d+\.tar\.gz$"
+          $latest = $allFiles |
+            Where-Object { $_.name -match $versionPattern } |
+            Sort-Object { [regex]::Match($_.name, '(\d{8})\.tar\.gz$').Groups[1].Value } |
+            Select-Object -Last 1
+          if (-not $latest) {
+            Write-Error "No tarball found for prefix '$prefix' at $baseUrl/"
+            exit 1
+          }
+          $latestFile = $latest.name
           Write-Host "Found latest file: $latestFile"
 
           # Extract version from the filename for environment variable
-          if ($latestFile -match "therock-dist-windows-$s3Target-.*?(\d+\.\d+\.\d+(?:a|rc)\d+)\.tar\.gz") {
+          if ($latestFile -match "therock-dist-windows-$s3Target-(\d+\.\d+\.\d+(?:a|rc)\d+)\.tar\.gz") {
             $rocmVersion = $matches[1]
             Write-Host "Detected latest ROCm version: $rocmVersion"
           } else {
             Write-Error "Failed to extract ROCm version from latest file: $latestFile"
-            Write-Error "Expected pattern: therock-dist-windows-$s3Target-*<version>.tar.gz"
+            Write-Error "Expected pattern: therock-dist-windows-$s3Target-<version>.tar.gz"
             exit 1
           }
 
-          # Use the exact filename from S3 instead of reconstructing
-          $rocmUrl = "https://therock-nightly-tarball.s3.amazonaws.com/$latestFile"
+          $rocmUrl = "$baseUrl/$latestFile"
         } else {
-          # For specific versions, construct the URL as before
-          $rocmUrl = "https://therock-nightly-tarball.s3.amazonaws.com/therock-dist-windows-$s3Target-$rocmVersion.tar.gz"
+          $rocmUrl = "$baseUrl/therock-dist-windows-$s3Target-$rocmVersion.tar.gz"
         }
 
         # Store the version for use in other steps
@@ -383,7 +378,8 @@ jobs:
             "rocsolver.dll",
             "hipblaslt.dll",
             "libhipblaslt.dll",
-            "hipblas.dll"
+            "hipblas.dll",
+            "origami.dll"
           )
 
           foreach ($pattern in $filesToCopy) {
@@ -546,86 +542,45 @@ jobs:
 
         # Add appropriate suffixes for different GPU targets
         s3_target="$current_target"
-        if [ "$current_target" = "gfx103X" ]; then
-          s3_target="${current_target}-dgpu"
-          echo "Using S3 target with -dgpu suffix: $s3_target"
-        elif [[ "$current_target" = "gfx110X" || "$current_target" = "gfx120X" ]]; then
+        if [[ "$current_target" = "gfx103X" || "$current_target" = "gfx110X" || "$current_target" = "gfx120X" ]]; then
           s3_target="${current_target}-all"
-          echo "Using S3 target with -all suffix: $s3_target"
+          echo "Using target with -all suffix: $s3_target"
         fi
 
+        # TheRock publishes nightlies to the multi-arch tarball index. The
+        # static HTML page embeds a JSON `files` array with names and mtimes.
+        base_url="https://rocm.nightlies.amd.com/tarball-multi-arch"
         if [ "$rocm_version" = "latest" ]; then
           echo "Auto-detecting latest ROCm version for target: $current_target"
-          s3_response=$(curl -s "https://therock-nightly-tarball.s3.amazonaws.com/?prefix=therock-dist-linux-${s3_target}-7")
+          prefix="therock-dist-linux-${s3_target}-"
+          files_json=$(curl -s "$base_url/" | tr '\n' ' ' | grep -oP 'const files = \K\[.*?\](?=\s*;)')
+          if [ -z "$files_json" ]; then
+            echo "Failed to parse file index from $base_url/"
+            exit 1
+          fi
 
-          # Extract all files and parse versions properly
-          files=$(echo "$s3_response" | grep -oP '(?<=<Key>)[^<]*' | grep "therock-dist-linux-${s3_target}-")
-
-          # Extract versions and sort them properly using semantic versioning
-          latest_file=""
-          latest_major=0
-          latest_minor=0
-          latest_patch=0
-          latest_rc=0
-          latest_is_alpha=false
-
-          while IFS= read -r file; do
-            if [[ "$file" =~ therock-dist-linux-${s3_target}-.*?([0-9]+\.[0-9]+\.[0-9]+(a|rc)[0-9]+)\.tar\.gz ]]; then
-              version="${BASH_REMATCH[1]}"
-              major=$(echo "$version" | cut -d. -f1)
-              minor=$(echo "$version" | cut -d. -f2)
-              patch=$(echo "$version" | cut -d. -f3 | sed 's/\(a\|rc\).*//')
-              rc=$(echo "$version" | sed 's/.*\(a\|rc\)//')
-              is_alpha=false
-              if [[ "$version" =~ a ]]; then
-                is_alpha=true
-              fi
-
-              # Compare versions (alpha versions are newer than rc versions)
-              is_newer=false
-              if [ "$major" -gt "$latest_major" ]; then
-                is_newer=true
-              elif [ "$major" -eq "$latest_major" ] && [ "$minor" -gt "$latest_minor" ]; then
-                is_newer=true
-              elif [ "$major" -eq "$latest_major" ] && [ "$minor" -eq "$latest_minor" ] && [ "$patch" -gt "$latest_patch" ]; then
-                is_newer=true
-              elif [ "$major" -eq "$latest_major" ] && [ "$minor" -eq "$latest_minor" ] && [ "$patch" -eq "$latest_patch" ]; then
-                # Same major.minor.patch, compare alpha vs rc
-                if [ "$is_alpha" = true ] && [ "$latest_is_alpha" = false ]; then
-                  is_newer=true
-                elif [ "$is_alpha" = "$latest_is_alpha" ] && [ "$rc" -gt "$latest_rc" ]; then
-                  is_newer=true
-                fi
-              fi
-
-              if [ "$is_newer" = true ]; then
-                latest_file="$file"
-                latest_major="$major"
-                latest_minor="$minor"
-                latest_patch="$patch"
-                latest_rc="$rc"
-                latest_is_alpha="$is_alpha"
-              fi
-            fi
-          done <<< "$files"
-
+          # Pick the newest build date and exclude sibling test archives.
+          latest_file=$(echo "$files_json" | jq -r --arg p "$prefix" \
+            '[.[] | select(.name | test("^" + $p + "[0-9]+\\.[0-9]+\\.[0-9]+(a|rc)[0-9]+\\.tar\\.gz$"))] | sort_by(.name | capture("(?<d>[0-9]{8})\\.tar\\.gz$").d) | last | .name // empty')
+          if [ -z "$latest_file" ]; then
+            echo "No tarball found for prefix '$prefix' at $base_url/"
+            exit 1
+          fi
           echo "Found latest file: $latest_file"
 
           # Extract version from the filename for environment variable
-          if [[ "$latest_file" =~ therock-dist-linux-${s3_target}-.*?([0-9]+\.[0-9]+\.[0-9]+(a|rc)[0-9]+)\.tar\.gz ]]; then
+          if [[ "$latest_file" =~ therock-dist-linux-${s3_target}-([0-9]+\.[0-9]+\.[0-9]+(a|rc)[0-9]+)\.tar\.gz ]]; then
             rocm_version="${BASH_REMATCH[1]}"
             echo "Detected latest ROCm version: $rocm_version"
           else
             echo "Failed to extract ROCm version from latest file: $latest_file"
-            echo "Expected pattern: therock-dist-linux-${s3_target}-*<version>.tar.gz"
+            echo "Expected pattern: therock-dist-linux-${s3_target}-<version>.tar.gz"
             exit 1
           fi
 
-          # Use the exact filename from S3 instead of reconstructing
-          rocm_url="https://therock-nightly-tarball.s3.amazonaws.com/$latest_file"
+          rocm_url="$base_url/$latest_file"
         else
-          # For specific versions, construct the URL as before
-          rocm_url="https://therock-nightly-tarball.s3.amazonaws.com/therock-dist-linux-${s3_target}-${rocm_version}.tar.gz"
+          rocm_url="$base_url/therock-dist-linux-${s3_target}-${rocm_version}.tar.gz"
         fi
 
         # Store the version for use in other steps
@@ -802,6 +757,7 @@ jobs:
         cp -v /opt/rocm/lib/libhsa-runtime64.so* "$build_bin_path/" 2>/dev/null || echo "libhsa-runtime64.so* not found"
         cp -v /opt/rocm/lib/rocm_sysdeps/lib/librocm_sysdeps_numa.so* "$build_bin_path/" 2>/dev/null || echo "librocm_sysdeps_numa.so* not found"
         cp -v /opt/rocm/lib/librocroller.so* "$build_bin_path/" 2>/dev/null || echo "librocroller.so* not found"
+        cp -v /opt/rocm/lib/liborigami.so* "$build_bin_path/" 2>/dev/null || echo "liborigami.so* not found"
         cp -v /opt/rocm/lib/librocm_kpack.so* "$build_bin_path/" 2>/dev/null || echo "librocm_kpack.so* not found"
         cp -v /opt/rocm/lib/rocm_sysdeps/lib/librocm_sysdeps_z.so* "$build_bin_path/" 2>/dev/null || echo "librocm_sysdeps_z.so* not found"
         cp -v /opt/rocm/lib/rocm_sysdeps/lib/librocm_sysdeps_zstd.so* "$build_bin_path/" 2>/dev/null || echo "librocm_sysdeps_zstd.so* not found"

--- a/.github/workflows/unsloth-prebuilt-vulkan.yml
+++ b/.github/workflows/unsloth-prebuilt-vulkan.yml
@@ -42,8 +42,8 @@ permissions:
   contents: read
 
 env:
-  # LunarG SDK version, matching llama-cpp-binaries' build-wheels-vulkan.yml.
-  VULKAN_VERSION: 1.4.313.2
+  # LunarG SDK version used by ggml-org's Windows release build.
+  VULKAN_VERSION: 1.4.357.0
 
 jobs:
   build-linux:
@@ -94,6 +94,7 @@ jobs:
           wget -q https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh 19
+          sudo apt-get install -y libomp-19-dev
           {
             echo "CC=clang-19"
             echo "CXX=clang++-19"
@@ -181,6 +182,10 @@ jobs:
           # dependencies, so every tool pulls them in.
           cmake --build build --config Release -j "$(nproc)"
           strip build/bin/llama-* || true
+
+      - name: Bundle OpenMP runtime (arm64)
+        if: matrix.arch == 'arm64'
+        run: cp /usr/lib/llvm-19/lib/libomp.so.5 src/build/bin/
 
       # DiffusionGemma binaries (example targets present only in #24423 mix
       # builds): best-effort, never fail the job. See the CUDA child for the

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -391,12 +391,10 @@ jobs:
 
           # macOS slices are static: two fixed runners with per-slice deployment
           # targets. arm64 builds on macos-26 (newest Metal SDK; avoids the
-          # M5/A19 "error compiling source" the macos-14 SDK emits) yet pins
-          # minos 14.0 via deploy_target, so it still loads on macOS 14+. x64
-          # pins 13.3 (matches upstream's Intel leg, covers 2017 Intel Macs
-          # capped at Ventura).
+          # M5/A19 "error compiling source" the macos-14 SDK emits) while both
+          # slices pin 13.3 to match upstream's Ventura compatibility floor.
           MACOS_INCLUDE='[
-            {"build":"arm64","runner":"macos-26",      "expect_arch":"arm64", "deploy_target":"14.0","defines":"-DGGML_METAL_EMBED_LIBRARY=ON"},
+            {"build":"arm64","runner":"macos-26",      "expect_arch":"arm64", "deploy_target":"13.3","defines":"-DGGML_METAL_EMBED_LIBRARY=ON"},
             {"build":"x64",  "runner":"macos-15-intel","expect_arch":"x86_64","deploy_target":"13.3","defines":"-DGGML_METAL=OFF"}
           ]'
           MACOS_INCLUDE="$(echo "$MACOS_INCLUDE" | jq -c .)"


### PR DESCRIPTION
Rebase of #85 by @oobabooga onto current master. Original commits and authorship preserved; opened here because the fork branch is not writable from this account despite `maintainer_can_modify`. **Supersedes #85** -- close that one in favour of this.

## Why the rebase was needed

#85 branched from `2bba58df` at 06:03, before #86 (SHA-pinning every third-party action) merged at 07:07. GitHub reported it `MERGEABLE / CLEAN` because the edits are in different regions of the same files, but squash-merging it as-is would have silently reverted `hendrikmuhs/ccache-action` to the mutable `@v1.2.23` tag in `unsloth-prebuilt-{cpu,vulkan,rocm}.yml`.

After the rebase: **0 unpinned third-party actions**, all 14 SHA pins intact, and the reclaim/prune jobs from #82/#84 plus the `timeout-minutes: 345` from #81 are all still present.

## Review of the original change

I verified every substantive claim against live data rather than the description.

**The ROCm index really is stale.** Queried both:

```
old S3   therock-dist-windows-gfx110X-all-7.14.0a20260612   <- stops 12 June
new AMD  therock-dist-windows-gfx110X-all-7.15.0a20260728   <- current
```

**The `-all` mapping is exactly right.** Checked all seven ROCm targets in our matrix against the live index:

| target | archive family | resolves |
| --- | --- | --- |
| gfx103X | gfx103X-all | 7.15.0a20260728 |
| gfx110X | gfx110X-all | 7.15.0a20260728 |
| gfx120X | gfx120X-all | 7.15.0a20260728 |
| gfx1150 | gfx1150 | 7.15.0a20260728 |
| gfx1151 | gfx1151 | 7.15.0a20260728 |
| gfx908 | gfx908 | 7.15.0a20260728 |
| gfx90a | gfx90a | 7.15.0a20260728 |

`gfx103X`, `gfx110X` and `gfx120X` exist **only** with the `-all` suffix; the other four exist **only** bare. The PR guards on exactly those three, on both the PowerShell and bash paths. Retaining the old `-dgpu` suffix would 404, as described.

**The macOS 13.3 claim is correct.** Upstream's `macos-latest-arm64` job uses `-DCMAKE_OSX_DEPLOYMENT_TARGET=13.3`. The `14.0` values elsewhere in that file belong to the iOS, tvOS and visionOS jobs, which are different platforms. Easy to misread; the PR read it correctly. This widens support to Ventura rather than narrowing anything.

**Security:** static and LLM scans both clean. The new host is `rocm.nightlies.amd.com`, an AMD domain. No credential access, no exfiltration, no unexpected command execution.

## This intentionally changes the shipped binaries

Unlike the CI-only changes merged today, this alters what users download, and that is the point -- it fixes real defects:

| change | effect on the bundle |
| --- | --- |
| ROCm June -> August build | different ROCm runtime |
| `origami.dll` / `liborigami.so*` added | new file; ROCm nightlies load it through hipBLASLt, so omitting it left the published runtime incomplete |
| Vulkan SDK 1.4.313.2 -> 1.4.357.0 | re-enables coopmat decode and E2M1/E4M3 shaders that `glslc` was silently refusing to compile. Windows x64 only: `VULKAN_VERSION` is referenced solely by the Windows leg, and the Linux legs stay on the 1.4.313 generation because LunarG stopped publishing apt packages in May 2025 |
| `libomp-19-dev` + `libomp.so.5` on ARM64 | OpenMP was silently disabled on ARM64; x64 and upstream ARM64 enable it |
| macOS arm64 deploy target 14.0 -> 13.3 | widens support to Ventura |

Shipping ROCm binaries built in June, and ARM64 bundles with OpenMP silently off, are genuine bugs worth fixing.

## Test plan

Because this changes released artifacts, it wants a full prebuild before merge, not just a green parse:

- [x] ROCm legs resolve an August build for every gfx target, and the bundle contains `origami`
- [x] Windows Vulkan build log no longer reports coopmat / E2M1 / E4M3 shaders being skipped
- [x] Linux ARM64 CPU and Vulkan logs no longer report OpenMP as not found, and `libomp.so.5` is beside the binaries
- [x] macOS arm64 binary reports `minos 13.3`
- [ ] Studio can still load a prebuilt from each affected family

This will also be the first full run of the `reclaim` and `Prune superseded ccache generations` jobs from #82 and #84.

All 23 workflow and composite-action files parse.
