### PR TITLE
prebuilt: make the ROCm ccache usable, and hold one ROCm alpha per week

### DIFF
--- a/.github/workflows/unsloth-prebuilt-rocm.yml
+++ b/.github/workflows/unsloth-prebuilt-rocm.yml
@@ -217,9 +217,9 @@ jobs:
               try   { $tz = [System.TimeZoneInfo]::FindSystemTimeZoneById("Pacific Standard Time") }
               catch { $tz = [System.TimeZoneInfo]::FindSystemTimeZoneById("America/Los_Angeles") }
               $sf = [System.TimeZoneInfo]::ConvertTimeFromUtc([DateTime]::UtcNow, $tz)
-              $cutoff = $sf.Date.AddDays(-[int]$sf.DayOfWeek).ToString("yyyyMMdd")
+              $cutoff = $sf.Date.AddDays(-([int]$sf.DayOfWeek + 1)).ToString("yyyyMMdd")
             }
-            Write-Host "Weekly pin: newest build dated on or before $cutoff (SF Sunday)"
+            Write-Host "Weekly pin: newest build dated on or before $cutoff (week of the last SF Sunday)"
           } else {
             Write-Host "Auto-detecting latest ROCm version for target: $currentTarget"
           }
@@ -573,13 +573,14 @@ jobs:
         # static HTML page embeds a JSON `files` array with names and mtimes.
         base_url="https://rocm.nightlies.amd.com/tarball-multi-arch"
         if [ "$rocm_version" = "latest" ] || [ "$rocm_version" = "weekly" ]; then
-          # weekly: take the newest alpha up to the last SF Sunday, so a whole week uses one toolchain and the ccache hits.
+          # weekly: take the newest alpha up to the Saturday before the last SF Sunday, so a whole week uses one toolchain and the ccache hits.
+          # The cutoff day must be settled before the first run that uses it: TheRock names a build for the next day and usually publishes the evening before, but it has landed as late as 18:33 PT on the named day, which would split the week.
           # The parent sends one cutoff for the run, so every leg agrees; the fallback is for a standalone call.
           cutoff=99999999
           if [ "$rocm_version" = "weekly" ]; then
             cutoff="${{ inputs.rocm_cutoff }}"
-            [ -n "$cutoff" ] || cutoff="$(TZ=America/Los_Angeles date -d "-$(TZ=America/Los_Angeles date +%w) days" +%Y%m%d)"
-            echo "Weekly pin: newest build dated on or before $cutoff (SF Sunday)"
+            [ -n "$cutoff" ] || cutoff="$(TZ=America/Los_Angeles date -d "-$(( $(TZ=America/Los_Angeles date +%w) + 1 )) days" +%Y%m%d)"
+            echo "Weekly pin: newest build dated on or before $cutoff (week of the last SF Sunday)"
           else
             echo "Auto-detecting latest ROCm version for target: $current_target"
           fi

--- a/.github/workflows/unsloth-prebuilt-rocm.yml
+++ b/.github/workflows/unsloth-prebuilt-rocm.yml
@@ -49,9 +49,9 @@ on:
         default: 'windows,ubuntu'
         type: string
       rocm_version:
-        description: 'TheRock ROCm version (e.g., 10.1.0a20260807) or "latest"'
+        description: 'TheRock ROCm version (e.g., 10.1.0a20260807), "weekly" or "latest"'
         required: false
-        default: 'latest'
+        default: 'weekly'
         type: string
 
 permissions:
@@ -202,8 +202,21 @@ jobs:
         # TheRock publishes nightlies to the multi-arch tarball index. The
         # static HTML page embeds a JSON `files` array with names and mtimes.
         $baseUrl = "https://rocm.nightlies.amd.com/tarball-multi-arch"
-        if ($rocmVersion -eq "latest") {
-          Write-Host "Auto-detecting latest ROCm version for target: $currentTarget"
+        if ($rocmVersion -eq "latest" -or $rocmVersion -eq "weekly") {
+          # weekly: see the Linux job. Cutoff is the most recent Sunday in SF
+          # time, so the whole week resolves to one build and the ccache hits.
+          $cutoff = "99999999"
+          if ($rocmVersion -eq "weekly") {
+            # Windows uses its own zone ids; fall back to the IANA name so this
+            # keeps working if the step ever moves off a Windows runner.
+            try   { $tz = [System.TimeZoneInfo]::FindSystemTimeZoneById("Pacific Standard Time") }
+            catch { $tz = [System.TimeZoneInfo]::FindSystemTimeZoneById("America/Los_Angeles") }
+            $sf = [System.TimeZoneInfo]::ConvertTimeFromUtc([DateTime]::UtcNow, $tz)
+            $cutoff = $sf.Date.AddDays(-[int]$sf.DayOfWeek).ToString("yyyyMMdd")
+            Write-Host "Weekly pin: newest build dated on or before $cutoff (SF Sunday)"
+          } else {
+            Write-Host "Auto-detecting latest ROCm version for target: $currentTarget"
+          }
           $indexHtml = (Invoke-WebRequest "$baseUrl/" -UseBasicParsing).Content
           $filesMatch = [regex]::Match($indexHtml, 'const files = (\[.*?\]);', [System.Text.RegularExpressions.RegexOptions]::Singleline)
           if (-not $filesMatch.Success) {
@@ -217,10 +230,11 @@ jobs:
           $versionPattern = "^$([regex]::Escape($prefix))\d+\.\d+\.\d+(a|rc)\d+\.tar\.gz$"
           $latest = $allFiles |
             Where-Object { $_.name -match $versionPattern } |
+            Where-Object { [regex]::Match($_.name, '(\d{8})\.tar\.gz$').Groups[1].Value -le $cutoff } |
             Sort-Object { [regex]::Match($_.name, '(\d{8})\.tar\.gz$').Groups[1].Value } |
             Select-Object -Last 1
           if (-not $latest) {
-            Write-Error "No tarball found for prefix '$prefix' at $baseUrl/"
+            Write-Error "No tarball found for prefix '$prefix' at or before $cutoff at $baseUrl/"
             exit 1
           }
           $latestFile = $latest.name
@@ -555,8 +569,19 @@ jobs:
         # TheRock publishes nightlies to the multi-arch tarball index. The
         # static HTML page embeds a JSON `files` array with names and mtimes.
         base_url="https://rocm.nightlies.amd.com/tarball-multi-arch"
-        if [ "$rocm_version" = "latest" ]; then
-          echo "Auto-detecting latest ROCm version for target: $current_target"
+        if [ "$rocm_version" = "latest" ] || [ "$rocm_version" = "weekly" ]; then
+          # weekly: hold one alpha for the whole week instead of taking a new
+          # toolchain every night. The cutoff is the most recent Sunday in SF
+          # time, so every run Sun-Sat resolves the same build and the ccache
+          # (keyed on this version) hits all week. TheRock never backfills a
+          # skipped day, so a later publish cannot change an earlier pick.
+          cutoff=99999999
+          if [ "$rocm_version" = "weekly" ]; then
+            cutoff="$(TZ=America/Los_Angeles date -d "-$(TZ=America/Los_Angeles date +%w) days" +%Y%m%d)"
+            echo "Weekly pin: newest build dated on or before $cutoff (SF Sunday)"
+          else
+            echo "Auto-detecting latest ROCm version for target: $current_target"
+          fi
           prefix="therock-dist-linux-${archive_target}-"
           files_json=$(curl -s "$base_url/" | tr '\n' ' ' | grep -oP 'const files = \K\[.*?\](?=\s*;)')
           if [ -z "$files_json" ]; then
@@ -565,10 +590,10 @@ jobs:
           fi
 
           # Pick the newest build date and exclude sibling test archives.
-          latest_file=$(echo "$files_json" | jq -r --arg p "$prefix" \
-            '[.[] | select(.name | test("^" + $p + "[0-9]+\\.[0-9]+\\.[0-9]+(a|rc)[0-9]+\\.tar\\.gz$"))] | sort_by(.name | capture("(?<d>[0-9]{8})\\.tar\\.gz$").d) | last | .name // empty')
+          latest_file=$(echo "$files_json" | jq -r --arg p "$prefix" --arg c "$cutoff" \
+            '[.[] | select(.name | test("^" + $p + "[0-9]+\\.[0-9]+\\.[0-9]+(a|rc)[0-9]+\\.tar\\.gz$")) | select((.name | capture("(?<d>[0-9]{8})\\.tar\\.gz$").d) <= $c)] | sort_by(.name | capture("(?<d>[0-9]{8})\\.tar\\.gz$").d) | last | .name // empty')
           if [ -z "$latest_file" ]; then
-            echo "No tarball found for prefix '$prefix' at $base_url/"
+            echo "No tarball found for prefix '$prefix' at or before $cutoff at $base_url/"
             exit 1
           fi
           echo "Found latest file: $latest_file"

--- a/.github/workflows/unsloth-prebuilt-rocm.yml
+++ b/.github/workflows/unsloth-prebuilt-rocm.yml
@@ -574,7 +574,7 @@ jobs:
         base_url="https://rocm.nightlies.amd.com/tarball-multi-arch"
         if [ "$rocm_version" = "latest" ] || [ "$rocm_version" = "weekly" ]; then
           # weekly: take the newest alpha up to the Saturday before the last SF Sunday, so a whole week uses one toolchain and the ccache hits.
-          # The cutoff day must be settled before the first run that uses it: TheRock names a build for the next day and usually publishes the evening before, but it has landed as late as 18:33 PT on the named day, which would split the week.
+          # The cutoff day must be settled before the first run reads it: TheRock usually publishes the evening before, but has landed as late as 18:33 PT on the named day, which splits the week.
           # The parent sends one cutoff for the run, so every leg agrees; the fallback is for a standalone call.
           cutoff=99999999
           if [ "$rocm_version" = "weekly" ]; then

--- a/.github/workflows/unsloth-prebuilt-rocm.yml
+++ b/.github/workflows/unsloth-prebuilt-rocm.yml
@@ -53,6 +53,11 @@ on:
         required: false
         default: 'weekly'
         type: string
+      rocm_cutoff:
+        description: 'For "weekly": YYYYMMDD cutoff resolved once by the parent. Blank means each leg computes its own.'
+        required: false
+        default: ''
+        type: string
 
 permissions:
   contents: read
@@ -203,16 +208,17 @@ jobs:
         # static HTML page embeds a JSON `files` array with names and mtimes.
         $baseUrl = "https://rocm.nightlies.amd.com/tarball-multi-arch"
         if ($rocmVersion -eq "latest" -or $rocmVersion -eq "weekly") {
-          # weekly: see the Linux job. Cutoff is the most recent Sunday in SF
-          # time, so the whole week resolves to one build and the ccache hits.
+          # weekly: see the Linux job. Cutoff is the most recent Sunday in SF time, so the whole week resolves to one build and the ccache hits.
           $cutoff = "99999999"
           if ($rocmVersion -eq "weekly") {
-            # Windows uses its own zone ids; fall back to the IANA name so this
-            # keeps working if the step ever moves off a Windows runner.
-            try   { $tz = [System.TimeZoneInfo]::FindSystemTimeZoneById("Pacific Standard Time") }
-            catch { $tz = [System.TimeZoneInfo]::FindSystemTimeZoneById("America/Los_Angeles") }
-            $sf = [System.TimeZoneInfo]::ConvertTimeFromUtc([DateTime]::UtcNow, $tz)
-            $cutoff = $sf.Date.AddDays(-[int]$sf.DayOfWeek).ToString("yyyyMMdd")
+            $cutoff = "${{ inputs.rocm_cutoff }}"
+            if (-not $cutoff) {
+              # Windows uses its own zone ids; fall back to the IANA name so this keeps working if the step ever moves off a Windows runner.
+              try   { $tz = [System.TimeZoneInfo]::FindSystemTimeZoneById("Pacific Standard Time") }
+              catch { $tz = [System.TimeZoneInfo]::FindSystemTimeZoneById("America/Los_Angeles") }
+              $sf = [System.TimeZoneInfo]::ConvertTimeFromUtc([DateTime]::UtcNow, $tz)
+              $cutoff = $sf.Date.AddDays(-[int]$sf.DayOfWeek).ToString("yyyyMMdd")
+            }
             Write-Host "Weekly pin: newest build dated on or before $cutoff (SF Sunday)"
           } else {
             Write-Host "Auto-detecting latest ROCm version for target: $currentTarget"
@@ -275,10 +281,8 @@ jobs:
     # runs after packaging, so a failed package step does not persist a cache
     # for a bundle that never shipped (same pattern as the CPU/CUDA children).
     #
-    # The ROCm version is in the key because ccache hashes compiler identity
-    # into every entry: a cache written by a different nightly can never hit,
-    # so restoring one only costs a download and a re-save. The restore-key
-    # prefix stops at the version for the same reason.
+    # The ROCm version is in the key because ccache hashes compiler identity into every entry: a cache written by a different nightly can never hit, so restoring one only costs a download and a re-save.
+    # The restore-key prefix stops at the version for the same reason.
     - name: ccache
       uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03  # v1.2.23
       with:
@@ -570,14 +574,14 @@ jobs:
         # static HTML page embeds a JSON `files` array with names and mtimes.
         base_url="https://rocm.nightlies.amd.com/tarball-multi-arch"
         if [ "$rocm_version" = "latest" ] || [ "$rocm_version" = "weekly" ]; then
-          # weekly: hold one alpha for the whole week instead of taking a new
-          # toolchain every night. The cutoff is the most recent Sunday in SF
-          # time, so every run Sun-Sat resolves the same build and the ccache
-          # (keyed on this version) hits all week. TheRock never backfills a
-          # skipped day, so a later publish cannot change an earlier pick.
+          # weekly: hold one alpha for the whole week instead of taking a new toolchain every night.
+          # The cutoff is the most recent Sunday in SF time, so every run Sun-Sat resolves the same build and the ccache (keyed on this version) hits all week.
+          # TheRock never backfills a skipped day, so a later publish cannot change an earlier pick.
+          # The parent resolves the cutoff once and passes it in, so all legs of one run agree even if the run crosses midnight; the fallback is for a standalone call.
           cutoff=99999999
           if [ "$rocm_version" = "weekly" ]; then
-            cutoff="$(TZ=America/Los_Angeles date -d "-$(TZ=America/Los_Angeles date +%w) days" +%Y%m%d)"
+            cutoff="${{ inputs.rocm_cutoff }}"
+            [ -n "$cutoff" ] || cutoff="$(TZ=America/Los_Angeles date -d "-$(TZ=America/Los_Angeles date +%w) days" +%Y%m%d)"
             echo "Weekly pin: newest build dated on or before $cutoff (SF Sunday)"
           else
             echo "Auto-detecting latest ROCm version for target: $current_target"
@@ -648,8 +652,7 @@ jobs:
 
         echo "ROCm environment variables set successfully"
 
-    # See the Windows job for why the key is per gfx target and ROCm version,
-    # and why save: false.
+    # See the Windows job for why the key is per gfx target and ROCm version, and why save: false.
     - name: ccache
       uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03  # v1.2.23
       with:
@@ -661,9 +664,8 @@ jobs:
         max-size: 2G
         save: false
 
-    # The action already sets this on Windows and macOS but leaves Linux on the
-    # default mtime check. ROCm is re-extracted from the nightly tarball every
-    # run, so metadata alone is not a reliable compiler identity here.
+    # The action already sets this on Windows and macOS but leaves Linux on the default mtime check.
+    # ROCm is re-extracted from the nightly tarball every run, so metadata alone is not a reliable compiler identity here.
     - name: Hash the compiler by content, not mtime
       run: ccache --set-config=compiler_check=content
 

--- a/.github/workflows/unsloth-prebuilt-rocm.yml
+++ b/.github/workflows/unsloth-prebuilt-rocm.yml
@@ -260,12 +260,17 @@ jobs:
     # save: false -- the explicit actions/cache/save step at the end of the job
     # runs after packaging, so a failed package step does not persist a cache
     # for a bundle that never shipped (same pattern as the CPU/CUDA children).
+    #
+    # The ROCm version is in the key because ccache hashes compiler identity
+    # into every entry: a cache written by a different nightly can never hit,
+    # so restoring one only costs a download and a re-save. The restore-key
+    # prefix stops at the version for the same reason.
     - name: ccache
       uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03  # v1.2.23
       with:
-        key: rocm-windows-${{ matrix.gfx_target }}-${{ inputs.tag }}
+        key: rocm-windows-${{ matrix.gfx_target }}-${{ env.DETECTED_ROCM_VERSION }}-${{ inputs.tag }}
         restore-keys: |
-          rocm-windows-${{ matrix.gfx_target }}
+          rocm-windows-${{ matrix.gfx_target }}-${{ env.DETECTED_ROCM_VERSION }}
         append-timestamp: false
         variant: ccache
         max-size: 2G
@@ -485,7 +490,7 @@ jobs:
       uses: actions/cache/save@v6
       with:
         path: ${{ github.workspace }}\.ccache
-        key: ccache-rocm-windows-${{ matrix.gfx_target }}-${{ inputs.tag }}-
+        key: ccache-rocm-windows-${{ matrix.gfx_target }}-${{ env.DETECTED_ROCM_VERSION }}-${{ inputs.tag }}-
 
   build-ubuntu:
     name: linux/${{ matrix.gfx_target }}
@@ -618,17 +623,24 @@ jobs:
 
         echo "ROCm environment variables set successfully"
 
-    # See the Windows job for why the key is per gfx target and why save: false.
+    # See the Windows job for why the key is per gfx target and ROCm version,
+    # and why save: false.
     - name: ccache
       uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03  # v1.2.23
       with:
-        key: rocm-linux-${{ matrix.gfx_target }}-${{ inputs.tag }}
+        key: rocm-linux-${{ matrix.gfx_target }}-${{ env.DETECTED_ROCM_VERSION }}-${{ inputs.tag }}
         restore-keys: |
-          rocm-linux-${{ matrix.gfx_target }}
+          rocm-linux-${{ matrix.gfx_target }}-${{ env.DETECTED_ROCM_VERSION }}
         append-timestamp: false
         variant: ccache
         max-size: 2G
         save: false
+
+    # The action already sets this on Windows and macOS but leaves Linux on the
+    # default mtime check. ROCm is re-extracted from the nightly tarball every
+    # run, so metadata alone is not a reliable compiler identity here.
+    - name: Hash the compiler by content, not mtime
+      run: ccache --set-config=compiler_check=content
 
     # The parent's resolve job built the source tree (upstream base + any mix
     # PRs, with the build number/commit and Unsloth fingerprint baked
@@ -839,4 +851,4 @@ jobs:
       uses: actions/cache/save@v6
       with:
         path: ${{ github.workspace }}/.ccache
-        key: ccache-rocm-linux-${{ matrix.gfx_target }}-${{ inputs.tag }}-
+        key: ccache-rocm-linux-${{ matrix.gfx_target }}-${{ env.DETECTED_ROCM_VERSION }}-${{ inputs.tag }}-

--- a/.github/workflows/unsloth-prebuilt-rocm.yml
+++ b/.github/workflows/unsloth-prebuilt-rocm.yml
@@ -208,12 +208,12 @@ jobs:
         # static HTML page embeds a JSON `files` array with names and mtimes.
         $baseUrl = "https://rocm.nightlies.amd.com/tarball-multi-arch"
         if ($rocmVersion -eq "latest" -or $rocmVersion -eq "weekly") {
-          # weekly: see the Linux job. Cutoff is the most recent Sunday in SF time, so the whole week resolves to one build and the ccache hits.
+          # weekly: see the Linux job.
           $cutoff = "99999999"
           if ($rocmVersion -eq "weekly") {
             $cutoff = "${{ inputs.rocm_cutoff }}"
             if (-not $cutoff) {
-              # Windows uses its own zone ids; fall back to the IANA name so this keeps working if the step ever moves off a Windows runner.
+              # Windows uses its own zone ids; the IANA name is the fallback.
               try   { $tz = [System.TimeZoneInfo]::FindSystemTimeZoneById("Pacific Standard Time") }
               catch { $tz = [System.TimeZoneInfo]::FindSystemTimeZoneById("America/Los_Angeles") }
               $sf = [System.TimeZoneInfo]::ConvertTimeFromUtc([DateTime]::UtcNow, $tz)
@@ -281,8 +281,7 @@ jobs:
     # runs after packaging, so a failed package step does not persist a cache
     # for a bundle that never shipped (same pattern as the CPU/CUDA children).
     #
-    # The ROCm version is in the key because ccache hashes compiler identity into every entry: a cache written by a different nightly can never hit, so restoring one only costs a download and a re-save.
-    # The restore-key prefix stops at the version for the same reason.
+    # The ROCm version is in the key, and in the restore prefix, because ccache hashes the compiler into every entry: a cache from another nightly can never hit.
     - name: ccache
       uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03  # v1.2.23
       with:
@@ -574,10 +573,8 @@ jobs:
         # static HTML page embeds a JSON `files` array with names and mtimes.
         base_url="https://rocm.nightlies.amd.com/tarball-multi-arch"
         if [ "$rocm_version" = "latest" ] || [ "$rocm_version" = "weekly" ]; then
-          # weekly: hold one alpha for the whole week instead of taking a new toolchain every night.
-          # The cutoff is the most recent Sunday in SF time, so every run Sun-Sat resolves the same build and the ccache (keyed on this version) hits all week.
-          # TheRock never backfills a skipped day, so a later publish cannot change an earlier pick.
-          # The parent resolves the cutoff once and passes it in, so all legs of one run agree even if the run crosses midnight; the fallback is for a standalone call.
+          # weekly: take the newest alpha up to the last SF Sunday, so a whole week uses one toolchain and the ccache hits.
+          # The parent sends one cutoff for the run, so every leg agrees; the fallback is for a standalone call.
           cutoff=99999999
           if [ "$rocm_version" = "weekly" ]; then
             cutoff="${{ inputs.rocm_cutoff }}"
@@ -664,8 +661,7 @@ jobs:
         max-size: 2G
         save: false
 
-    # The action already sets this on Windows and macOS but leaves Linux on the default mtime check.
-    # ROCm is re-extracted from the nightly tarball every run, so metadata alone is not a reliable compiler identity here.
+    # The action sets this on Windows and macOS but leaves Linux on mtime, and ROCm is re-extracted every run, so mtime is not a reliable compiler identity.
     - name: Hash the compiler by content, not mtime
       run: ccache --set-config=compiler_check=content
 

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -107,6 +107,7 @@ jobs:
       cuda_matrix: ${{ steps.r.outputs.cuda_matrix }}
       win_cuda_matrix: ${{ steps.r.outputs.win_cuda_matrix }}
       rocm_matrix: ${{ steps.r.outputs.rocm_matrix }}
+      rocm_cutoff: ${{ steps.r.outputs.rocm_cutoff }}
       macos_matrix: ${{ steps.r.outputs.macos_matrix }}
     env:
       GH_TOKEN: ${{ github.token }}
@@ -389,6 +390,10 @@ jobs:
           [ -n "$GFX" ] || { echo "refusing empty gfx_target (would publish a CUDA-only release labeled CUDA + ROCm)" >&2; exit 1; }
           ROCM_MATRIX="$(jq -cn --arg g "$GFX" '{gfx_target: ($g | split(",") | map(gsub("^\\s+|\\s+$"; "")))}')"
 
+          # One weekly cutoff for the whole run, resolved here before fan-out.
+          # Each ROCm leg reads its own clock otherwise, so a run that crosses the SF Saturday-to-Sunday boundary would ship some bundles from last week's toolchain and some from this week's.
+          ROCM_CUTOFF="$(TZ=America/Los_Angeles date -d "-$(TZ=America/Los_Angeles date +%w) days" +%Y%m%d)"
+
           # macOS slices are static: two fixed runners with per-slice deployment
           # targets. arm64 builds on macos-26 (newest Metal SDK; avoids the
           # M5/A19 "error compiling source" the macos-14 SDK emits) while both
@@ -412,6 +417,7 @@ jobs:
             echo "cuda_matrix={\"include\":$CUDA_INCLUDE}"
             echo "win_cuda_matrix={\"include\":$WIN_CUDA_INCLUDE}"
             echo "rocm_matrix=$ROCM_MATRIX"
+            echo "rocm_cutoff=$ROCM_CUTOFF"
             echo "macos_matrix={\"include\":$MACOS_INCLUDE}"
           } >> "$GITHUB_OUTPUT"
           echo "Resolved $REQ -> $TAG ($COMMIT); prs=$PRS; source_artifact=${SRC_ARTIFACT:-none}; release exists=$EXISTS; only=$ONLY; gfx=$GFX"
@@ -508,6 +514,7 @@ jobs:
       matrix: ${{ needs.resolve.outputs.rocm_matrix }}
       operating_systems: ${{ github.event.inputs.operating_systems || 'windows,ubuntu' }}
       rocm_version: ${{ github.event.inputs.rocm_version || 'weekly' }}
+      rocm_cutoff: ${{ needs.resolve.outputs.rocm_cutoff }}
 
   build-macos:
     name: macOS
@@ -1084,10 +1091,11 @@ jobs:
 
           # Group by the restore-keys prefix: the key minus its -<tag>- suffix.
           # Newest first, so anything past $KEEP is unreachable by restore-keys.
+          # The ROCm version comes off too: it is part of the restore prefix, so leaving it on would make every weekly toolchain its own group and keep 2 caches per group forever, none of which can ever hit again.
           freed=0; deleted=0
           while IFS=$'\t' read -r id created size key; do
             [ -z "${id:-}" ] && continue
-            pre="$(printf '%s' "$key" | sed -E 's/-b[0-9]+-mix-[0-9a-f]+-?$//')"
+            pre="$(printf '%s' "$key" | sed -E 's/-b[0-9]+-mix-[0-9a-f]+-?$//; s/-[0-9]+\.[0-9]+\.[0-9]+(a|rc)[0-9]+$//')"
             printf '%s\t%s\t%s\t%s\n' "$pre" "$created" "$id" "$size"
           done < "$all" | sort -t"$(printf '\t')" -k1,1 -k2,2r > "$RUNNER_TEMP/grouped.tsv"
 

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -390,7 +390,7 @@ jobs:
           [ -n "$GFX" ] || { echo "refusing empty gfx_target (would publish a CUDA-only release labeled CUDA + ROCm)" >&2; exit 1; }
           ROCM_MATRIX="$(jq -cn --arg g "$GFX" '{gfx_target: ($g | split(",") | map(gsub("^\\s+|\\s+$"; "")))}')"
 
-          # One weekly cutoff for the whole run, before fan-out, set to the Saturday before the last SF Sunday so the day is already settled when the first run of the week reads it.
+          # One weekly cutoff for the whole run, before fan-out. See the ROCm child for why it is the Saturday before.
           # Each leg reads its own clock otherwise, so a run crossing the SF Sat-to-Sun boundary would mix two toolchains in one release.
           ROCM_CUTOFF="$(TZ=America/Los_Angeles date -d "-$(( $(TZ=America/Los_Angeles date +%w) + 1 )) days" +%Y%m%d)"
 

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -58,8 +58,8 @@ on:
         required: false
         type: string
       rocm_version:
-        description: 'ROCm version (or "latest")'
-        default: 'latest'
+        description: 'ROCm version, "weekly" (newest alpha as of the last SF Sunday) or "latest"'
+        default: 'weekly'
         required: false
         type: string
       publish:
@@ -507,7 +507,7 @@ jobs:
       source_artifact: ${{ needs.resolve.outputs.source_artifact }}
       matrix: ${{ needs.resolve.outputs.rocm_matrix }}
       operating_systems: ${{ github.event.inputs.operating_systems || 'windows,ubuntu' }}
-      rocm_version: ${{ github.event.inputs.rocm_version || 'latest' }}
+      rocm_version: ${{ github.event.inputs.rocm_version || 'weekly' }}
 
   build-macos:
     name: macOS

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -390,9 +390,9 @@ jobs:
           [ -n "$GFX" ] || { echo "refusing empty gfx_target (would publish a CUDA-only release labeled CUDA + ROCm)" >&2; exit 1; }
           ROCM_MATRIX="$(jq -cn --arg g "$GFX" '{gfx_target: ($g | split(",") | map(gsub("^\\s+|\\s+$"; "")))}')"
 
-          # One weekly cutoff for the whole run, before fan-out.
+          # One weekly cutoff for the whole run, before fan-out, set to the Saturday before the last SF Sunday so the day is already settled when the first run of the week reads it.
           # Each leg reads its own clock otherwise, so a run crossing the SF Sat-to-Sun boundary would mix two toolchains in one release.
-          ROCM_CUTOFF="$(TZ=America/Los_Angeles date -d "-$(TZ=America/Los_Angeles date +%w) days" +%Y%m%d)"
+          ROCM_CUTOFF="$(TZ=America/Los_Angeles date -d "-$(( $(TZ=America/Los_Angeles date +%w) + 1 )) days" +%Y%m%d)"
 
           # macOS slices are static: two fixed runners with per-slice deployment
           # targets. arm64 builds on macos-26 (newest Metal SDK; avoids the
@@ -1095,7 +1095,7 @@ jobs:
           freed=0; deleted=0
           while IFS=$'\t' read -r id created size key; do
             [ -z "${id:-}" ] && continue
-            pre="$(printf '%s' "$key" | sed -E 's/-b[0-9]+-mix-[0-9a-f]+-?$//; s/-[0-9]+\.[0-9]+\.[0-9]+(a|rc)[0-9]+$//')"
+            pre="$(printf '%s' "$key" | sed -E 's/-b[0-9]+(-mix-[0-9a-f]+)?-?$//; s/-[0-9]+\.[0-9]+\.[0-9]+(a|rc)[0-9]+$//')"
             printf '%s\t%s\t%s\t%s\n' "$pre" "$created" "$id" "$size"
           done < "$all" | sort -t"$(printf '\t')" -k1,1 -k2,2r > "$RUNNER_TEMP/grouped.tsv"
 

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -390,8 +390,8 @@ jobs:
           [ -n "$GFX" ] || { echo "refusing empty gfx_target (would publish a CUDA-only release labeled CUDA + ROCm)" >&2; exit 1; }
           ROCM_MATRIX="$(jq -cn --arg g "$GFX" '{gfx_target: ($g | split(",") | map(gsub("^\\s+|\\s+$"; "")))}')"
 
-          # One weekly cutoff for the whole run, resolved here before fan-out.
-          # Each ROCm leg reads its own clock otherwise, so a run that crosses the SF Saturday-to-Sunday boundary would ship some bundles from last week's toolchain and some from this week's.
+          # One weekly cutoff for the whole run, before fan-out.
+          # Each leg reads its own clock otherwise, so a run crossing the SF Sat-to-Sun boundary would mix two toolchains in one release.
           ROCM_CUTOFF="$(TZ=America/Los_Angeles date -d "-$(TZ=America/Los_Angeles date +%w) days" +%Y%m%d)"
 
           # macOS slices are static: two fixed runners with per-slice deployment
@@ -1091,7 +1091,7 @@ jobs:
 
           # Group by the restore-keys prefix: the key minus its -<tag>- suffix.
           # Newest first, so anything past $KEEP is unreachable by restore-keys.
-          # The ROCm version comes off too: it is part of the restore prefix, so leaving it on would make every weekly toolchain its own group and keep 2 caches per group forever, none of which can ever hit again.
+          # The ROCm version comes off too, else every weekly toolchain becomes its own group and keeps 2 caches that can never hit again.
           freed=0; deleted=0
           while IFS=$'\t' read -r id created size key; do
             [ -z "${id:-}" ] && continue


### PR DESCRIPTION
The ROCm legs were getting a 0% ccache hit rate while CUDA/CPU/Vulkan sit at 90-94%, which made
ROCm the whole critical path: `ROCm / windows/gfx110X` took 1h10m in run 31277751235 and gated
the 1h46m publish job.

Two things caused it, and this PR fixes both.

## 1. The cache key did not include the ROCm version

The ROCm legs install a rolling toolchain from TheRock, but the key carried only the gfx target
and the source tag. ccache hashes compiler identity into every entry, so a cache written by a
different build can never hit. Each job paid a 64-128 MB restore, missed all 787 objects, then
re-saved 128 MB. Every ROCm cache in the repo had `last_accessed_at == created_at`, so not one
had ever been read back.

Both jobs now key on the resolved `DETECTED_ROCM_VERSION`, which is already in the environment
by the time the ccache step runs. The restore-key prefix stops at the version, so a run no
longer downloads a cache that cannot hit. This is what ggml-org does upstream
(`release.yml`: `key: release-ubuntu-22.04-rocm-${{ matrix.ROCM_VERSION }}`).

Linux also now hashes the compiler by content. The pinned action already does this on Windows
and macOS but leaves Linux on the default mtime check, and ROCm is re-extracted from the tarball
every run. Not using `%compiler% --version` on purpose: ROCm's clang reports a generic version
string that can be identical across different builds, so it could serve an object built by
another compiler.

## 2. The toolchain moved every single night

TheRock publishes a dev alpha daily between about 03:00Z and 09:00Z; the cron fires at 20:13Z.
So every scheduled run picked up a new compiler and rebuilt ROCm from scratch, and no cache key
scheme could have helped.

The daily churn was not buying anything. Every GPU target we ship is covered by much older
builds: upstream builds the same set (including gfx1151 and gfx1200/1201) on pinned ROCm 7.2.1
and HIP SDK 26.Q1. The nightlies index is 100% `a` alpha builds, and the version churn
(7.15.0a to 10.1.0a in two weeks) is dev snapshot numbering, not releases. Over the last 20
pipeline runs the ROCm legs were 143 success, 10 skipped, 0 failures, so nothing points at a
nightly fix we depend on.

`rocm_version` now defaults to `weekly`: the newest alpha dated on or before the most recent
Sunday in SF time. That is a pure function of the date, so it needs no pin file, no bot and no
state, and every run from Sunday to Saturday resolves the same build. `latest` and explicit
versions still work.

Replaying the workflow's own jq expression over the last four weeks:

```
run 2026-08-09 (Sun) cutoff=20260809 -> 10.1.0a20260807   <- rolls
run 2026-08-08 (Sat) cutoff=20260802 -> 10.1.0a20260802
run 2026-08-07 (Fri) cutoff=20260802 -> 10.1.0a20260802
...
run 2026-08-02 (Sun) cutoff=20260802 -> 10.1.0a20260802   <- rolls
run 2026-08-01 (Sat) cutoff=20260726 -> 7.15.0a20260726
```

Constant inside each Sun-Sat window, rolls only on Sunday. The PowerShell path gives identical
results. Gaps are handled: today is Sunday 09 Aug but no 0808 or 0809 exists, so it picks 0807.

A stateless pin would only break if a build dated on or before Sunday showed up after Sunday's
run. Only 1 of the last 40 builds was published later than its build date, TheRock never
backfills a skipped day (the 13, 14 and 22 July holes are still holes), and publishes land
before the cron. Worst case is one extra rebuild, never a wrong binary.

## Measured

Both runs on this branch with `tag=b10327`, `gfx_target=gfx110X`, `operating_systems=ubuntu`,
`publish=false`, same toolchain `10.1.0a20260807`:

| run | ccache | ROCm linux/gfx110X |
| --- | --- | --- |
| 31297076947 (cold, no cache for the new key) | 0/787 | 30m32s |
| 31298717440 (warm) | 786/787, 99.87% | 4m38s |

Output is unchanged. Comparing the two bundles file by file, 1128 of 1129 files are
byte-identical. The one that differs is `libllama-common.so`, and that is a source difference,
not a caching artifact: `resolve` mints a new merge commit per run and bakes its short SHA into
build-info. ccache missed exactly one object out of 787, which is that translation unit.

As a control, the same single file is also the only difference between run 31297076947 and the
b10327-mix-b1e9972 release built last night, which was itself a full 0%-hit build. Two
independent uncached builds differ exactly as much as cold-vs-warm does, so caching adds no
variance.

Splitting host TUs onto a stable compiler was considered and dropped. Ninja timings from the
cold run: 145 device steps take 20.4m, 645 host steps take 4.6m, link and copy 0.3m. The device
TUs are 80% of the wall clock and are exactly what a toolchain bump invalidates, so the split
would buy little for real ABI risk.

Expected effect: 6 nightlies in 7 hit the cache, ROCm stops being the critical path except on
Sundays.