### PR TITLE
CI: bound release asset uploads and verify the release before publishing

### DIFF
--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -815,6 +815,11 @@ jobs:
 
       - name: Publish GitHub release
         id: publish
+        # Last resort cap. The uploader has its own 90m phase deadline; if that
+        # ever fails to trip, this still fails the step with hours of job budget
+        # left instead of letting the 350m job cap kill it with no message, and
+        # it lets the rescue artifact step below run.
+        timeout-minutes: 120
         if: ${{ (github.event_name == 'schedule' || inputs.publish) && needs.resolve.outputs.exists != 'true' }}
         # prs carries PR titles (arbitrary text), so pass it through env
         # rather than inlining it: a title with a quote would otherwise break out
@@ -852,10 +857,29 @@ jobs:
           if [ "$(gh release view "$TAG" --repo "$REPO" --json isDraft --jq .isDraft 2>/dev/null || true)" = "true" ]; then
             gh release delete "$TAG" --repo "$REPO" --yes
           fi
-          gh release create "$TAG" --repo "$REPO" --draft \
-            --title "llama.cpp prebuilt $TAG" \
-            --notes "$NOTES" \
-            dist/*
+          # Create the draft empty, then upload through the uploader instead of
+          # passing dist/* here. `gh release create` uses a fixed 5-worker pool
+          # with no per-connection timeout, so a few wedged PUTs block the whole
+          # set: in run 31335302864 six large bundles stalled at ~0.03 MB/s and
+          # held the pool for 3h45m, while the other 25 assets took 37s total.
+          for attempt in 1 2 3; do
+            if gh release create "$TAG" --repo "$REPO" --draft \
+                 --title "llama.cpp prebuilt $TAG" \
+                 --notes "$NOTES"; then
+              break
+            fi
+            if [ "$attempt" = 3 ]; then
+              echo "ERROR: could not create draft release $TAG" >&2
+              exit 1
+            fi
+            sleep $(( attempt * 10 ))
+          done
+
+          bash tooling/scripts/unsloth/upload_release_assets.sh \
+            --tag "$TAG" --repo "$REPO" --dist dist
+
+          # Reached only after the uploader verified every asset is present,
+          # byte-identical and in state "uploaded".
           gh release edit "$TAG" --repo "$REPO" --draft=false
 
       # Debug fallback for a failed publish. This used to upload on EVERY run,

--- a/scripts/unsloth/test_upload_release_assets.sh
+++ b/scripts/unsloth/test_upload_release_assets.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+# Tests for upload_release_assets.sh. Run: bash scripts/unsloth/test_upload_release_assets.sh
+#
+# Every case runs the real uploader against a stub `gh` that reproduces the
+# failure modes seen against uploads.github.com: a PUT that wedges and never
+# returns, a transient 5xx, an asset committed at the wrong size, an asset left
+# in a non-uploaded state, and a `gh` that exits 0 without the asset landing.
+# Budgets are shrunk so a stall is killed in ~1s instead of ~500s.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HERE/upload_release_assets.sh"
+STUBDIR="$(mktemp -d)"
+trap 'rm -rf "$STUBDIR"' EXIT
+mkdir -p "$STUBDIR/bin"
+
+cat > "$STUBDIR/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+# Stub gh: serves `release upload` and `release view` off a file registry.
+set -uo pipefail
+REG="${STUB_REG:?}"; mkdir -p "$REG/assets" "$REG/attempts"
+
+in_list() { case " ${2:-} " in *" $1 "*) return 0 ;; *) return 1 ;; esac; }
+
+if [ "$1" = "release" ] && [ "$2" = "upload" ]; then
+  file="${*: -1}"; size="$(stat -c %s "$file")"
+  # GitHub sanitises the asset name server-side; mirror that here so the test
+  # exercises the same name mapping the uploader has to verify against.
+  name="$(printf '%s' "$(basename "$file")" | tr -c 'A-Za-z0-9._-' '.')"
+  c="$REG/attempts/$name"; n=$(( $(cat "$c" 2>/dev/null || echo 0) + 1 )); echo "$n" > "$c"
+
+  if in_list "$name" "${STUB_STALL_ALWAYS:-}"; then sleep 300; exit 0; fi
+  if in_list "$name" "${STUB_STALL_ONCE:-}" && [ "$n" -le 1 ]; then sleep 300; exit 0; fi
+  if in_list "$name" "${STUB_FAIL_ALWAYS:-}"; then echo "stub: HTTP 502" >&2; exit 1; fi
+  if in_list "$name" "${STUB_FAIL_ONCE:-}" && [ "$n" -le 1 ]; then echo "stub: HTTP 502" >&2; exit 1; fi
+  # Below: exits 0, but leaves the release in a state the caller must catch.
+  if in_list "$name" "${STUB_WRONGSIZE:-}" && [ "$n" -le 1 ]; then
+    printf '%s\t%s\tuploaded\n' "$name" "$(( size - 1 ))" > "$REG/assets/$name"; exit 0
+  fi
+  if in_list "$name" "${STUB_NOTUPLOADED:-}" && [ "$n" -le 1 ]; then
+    printf '%s\t%s\tstarter\n' "$name" "$size" > "$REG/assets/$name"; exit 0
+  fi
+  if in_list "$name" "${STUB_SILENT_DROP:-}"; then exit 0; fi
+  printf '%s\t%s\tuploaded\n' "$name" "$size" > "$REG/assets/$name"
+  exit 0
+fi
+
+if [ "$1" = "release" ] && [ "$2" = "view" ]; then
+  jqexpr=""
+  for ((i=1;i<=$#;i++)); do
+    if [ "${!i}" = "--jq" ]; then j=$((i+1)); jqexpr="${!j}"; fi
+  done
+  { echo '{"assets":['
+    first=1
+    for a in "$REG"/assets/*; do
+      [ -e "$a" ] || continue
+      IFS=$'\t' read -r n s st < "$a"
+      if [ "$first" = 1 ]; then first=0; else echo ','; fi
+      printf '{"name":"%s","size":%s,"state":"%s"}' "$n" "$s" "$st"
+    done
+    echo ']}'; } | jq -r "$jqexpr"
+  exit 0
+fi
+echo "stub: unhandled: $*" >&2; exit 64
+STUB
+chmod +x "$STUBDIR/bin/gh"
+export PATH="$STUBDIR/bin:$PATH"
+
+export UPLOAD_GRACE_SECONDS=1 UPLOAD_MIN_RATE_MB_S=1000 UPLOAD_HEARTBEAT_SECONDS=3
+export UPLOAD_JOBS=4 UPLOAD_ATTEMPTS=3
+
+FAILS=()
+
+run_case() { # name expected_rc [env ...]
+  local name="$1" want="$2"; shift 2
+  local d; d="$(mktemp -d)"; mkdir -p "$d/dist"
+  local i
+  for i in 01 02 03 04 05 06; do head -c 1000000 /dev/zero > "$d/dist/bundle-$i.tar.gz"; done
+  # A name GitHub will rewrite, so the verify path's name mapping is covered.
+  head -c 1000 /dev/zero > "$d/dist/has space.json"
+  local out rc
+  out="$(STUB_REG="$d/reg" env "$@" bash "$SCRIPT" --tag T --repo o/r --dist "$d/dist" 2>&1)"; rc=$?
+  if [ "$rc" = "$want" ]; then
+    printf 'PASS  %s\n' "$name"
+  else
+    printf 'FAIL  %s  :: rc=%s want=%s\n' "$name" "$rc" "$want"
+    printf '%s\n' "$out" | sed 's/^/      | /'
+    FAILS+=("$name")
+  fi
+  rm -rf "$d"
+}
+
+run_case "happy path"                    0 IGNORED=1
+run_case "stall, recovers on retry"      0 STUB_STALL_ONCE="bundle-02.tar.gz bundle-05.tar.gz"
+run_case "transient 502, recovers"       0 STUB_FAIL_ONCE="bundle-03.tar.gz"
+run_case "permanent stall aborts"        1 STUB_STALL_ALWAYS="bundle-04.tar.gz"
+run_case "permanent 502 aborts"          1 STUB_FAIL_ALWAYS="bundle-01.tar.gz"
+run_case "wrong size caught, re-uploaded" 0 STUB_WRONGSIZE="bundle-06.tar.gz"
+run_case "non-uploaded state re-uploaded" 0 STUB_NOTUPLOADED="bundle-02.tar.gz"
+run_case "gh exits 0, asset never lands"  1 STUB_SILENT_DROP="bundle-03.tar.gz"
+run_case "phase deadline aborts"          1 UPLOAD_DEADLINE_MINUTES=0 STUB_STALL_ALWAYS="bundle-01.tar.gz"
+
+echo
+echo "${#FAILS[@]} failure(s)${FAILS[*]:+: ${FAILS[*]}}"
+[ "${#FAILS[@]}" -eq 0 ]

--- a/scripts/unsloth/test_upload_release_assets.sh
+++ b/scripts/unsloth/test_upload_release_assets.sh
@@ -48,6 +48,7 @@ if [ "$1" = "release" ] && [ "$2" = "upload" ]; then
 fi
 
 if [ "$1" = "release" ] && [ "$2" = "view" ]; then
+  if [ "${STUB_VIEW_FAILS:-}" = 1 ]; then echo "stub: HTTP 503" >&2; exit 1; fi
   jqexpr=""
   for ((i=1;i<=$#;i++)); do
     if [ "${!i}" = "--jq" ]; then j=$((i+1)); jqexpr="${!j}"; fi
@@ -101,6 +102,9 @@ run_case "wrong size caught, re-uploaded" 0 STUB_WRONGSIZE="bundle-06.tar.gz"
 run_case "non-uploaded state re-uploaded" 0 STUB_NOTUPLOADED="bundle-02.tar.gz"
 run_case "gh exits 0, asset never lands"  1 STUB_SILENT_DROP="bundle-03.tar.gz"
 run_case "phase deadline aborts"          1 UPLOAD_DEADLINE_MINUTES=0 STUB_STALL_ALWAYS="bundle-01.tar.gz"
+# The verify read must fail the script, not just its subshell: a process
+# substitution would swallow this and report every asset as verified.
+run_case "verification API outage aborts" 1 STUB_VIEW_FAILS=1
 
 echo
 echo "${#FAILS[@]} failure(s)${FAILS[*]:+: ${FAILS[*]}}"

--- a/scripts/unsloth/upload_release_assets.sh
+++ b/scripts/unsloth/upload_release_assets.sh
@@ -134,24 +134,28 @@ upload_pass "${FILES[@]}" || pass_rc=$?
 
 # gh exiting 0 does not prove the asset is complete. Every local file must be
 # on the release with the same size and state "uploaded".
-missing_files() {
-  local remote
+# Sets BAD to the files the release does not hold. Reads the API in the current
+# shell: inside `< <(...)` a failed read exits only the subshell, so BAD would
+# come back empty and we would publish a release we never checked.
+verify() {
+  local remote f
   remote="$(gh release view "$TAG" --repo "$REPO" --json assets \
     --jq '.assets[] | select(.state=="uploaded") | "\(.name)\t\(.size)"')" \
     || die "could not read release assets for verification"
+  BAD=()
   for f in "${FILES[@]}"; do
     if ! grep -qxF "$(asset_name "$f")	$(file_size "$f")" <<<"$remote"; then
-      printf '%s\0' "$f"
+      BAD+=("$f")
     fi
   done
 }
 
-mapfile -d '' -t BAD < <(missing_files)
+verify
 if [ "${#BAD[@]}" -gt 0 ]; then
   log "verification found ${#BAD[@]} missing or mismatched assets; re-uploading"
   for f in "${BAD[@]}"; do log "  - $(asset_name "$f")"; done
   upload_pass "${BAD[@]}" || true
-  mapfile -d '' -t BAD < <(missing_files)
+  verify
 fi
 
 if [ "${#BAD[@]}" -gt 0 ]; then

--- a/scripts/unsloth/upload_release_assets.sh
+++ b/scripts/unsloth/upload_release_assets.sh
@@ -85,7 +85,7 @@ if [ "${1:-}" = "--upload-one" ]; then
   exit 1
 fi
 
-# ---------------------------------------------------------------- parent mode
+# Parent mode.
 TAG="" REPO="" DIST=""
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -132,11 +132,10 @@ pass_rc=0
 upload_pass "${FILES[@]}" || pass_rc=$?
 [ "$pass_rc" -eq 0 ] || log "upload pass reported failures (xargs exit ${pass_rc}); verification decides"
 
-# gh exiting 0 does not prove the asset is complete. Every local file must be
-# on the release with the same size and state "uploaded".
-# Sets BAD to the files the release does not hold. Reads the API in the current
-# shell: inside `< <(...)` a failed read exits only the subshell, so BAD would
-# come back empty and we would publish a release we never checked.
+# gh exiting 0 does not prove the asset is complete, so set BAD to every local
+# file the release does not hold at the same size and state "uploaded". Read the
+# API here, not inside `< <(...)`, where a failed read exits only the subshell
+# and leaves BAD empty, i.e. publishes a release we never checked.
 verify() {
   local remote f
   remote="$(gh release view "$TAG" --repo "$REPO" --json assets \

--- a/scripts/unsloth/upload_release_assets.sh
+++ b/scripts/unsloth/upload_release_assets.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+# Upload a directory of files to a draft release, then check the release really
+# holds them before the caller flips draft=false.
+# Run: upload_release_assets.sh --tag TAG --repo OWNER/REPO --dist DIR
+#
+# `gh release create ... dist/*` uploads with a fixed 5-worker pool and no
+# per-connection timeout, so a few wedged PUTs block everything behind them. In
+# run 31335302864 six large bundles stalled at ~0.03 MB/s and held the pool for
+# 3h45m, while the other 25 assets took 37s in total. The job finished 25
+# minutes short of its 350m cap.
+#
+# So: bound each attempt, bound the whole phase, and verify against the API
+# before we publish.
+set -euo pipefail
+
+# Defaults come from measured healthy throughput on the runners, 33-47 MB/s.
+JOBS="${UPLOAD_JOBS:-4}"
+ATTEMPTS="${UPLOAD_ATTEMPTS:-4}"
+# Slowest rate we still call "progressing". ~17x below healthy, so a bad day
+# retries nothing but a wedged PUT dies fast.
+MIN_RATE_MB_S="${UPLOAD_MIN_RATE_MB_S:-2}"
+# Per-attempt allowance for setup and server-side commit, which do not scale
+# with file size.
+GRACE_SECONDS="${UPLOAD_GRACE_SECONDS:-120}"
+# Healthy is ~4 minutes for 7.2 GB, so only a real pathology trips this.
+DEADLINE_MINUTES="${UPLOAD_DEADLINE_MINUTES:-90}"
+HEARTBEAT_SECONDS="${UPLOAD_HEARTBEAT_SECONDS:-60}"
+
+log() { printf '%s %s\n' "$(date -u +%H:%M:%S)" "$*"; }
+die() { printf '%s ERROR: %s\n' "$(date -u +%H:%M:%S)" "$*" >&2; exit 1; }
+
+file_size() { stat -c %s "$1"; }
+
+# GitHub rewrites characters outside [A-Za-z0-9._-] to '.', so verify against
+# the name the API will report. printf, not basename: basename's trailing
+# newline is also outside the set and would become a phantom '.' on every name.
+asset_name() { printf '%s' "${1##*/}" | tr -c 'A-Za-z0-9._-' '.'; }
+
+# Worker mode. The parent fans out with xargs by re-invoking this script, which
+# is safer than `export -f`: an unexported function fails per file at runtime.
+if [ "${1:-}" = "--upload-one" ]; then
+  f="$2"
+  : "${TAG:?}" "${REPO:?}" "${UPLOAD_DEADLINE_EPOCH:?}"
+  name="$(asset_name "$f")"
+  bytes="$(file_size "$f")"
+  mb=$(( bytes / 1000000 ))
+  budget=$(( GRACE_SECONDS + mb / MIN_RATE_MB_S ))
+
+  for attempt in $(seq 1 "$ATTEMPTS"); do
+    now="$(date +%s)"
+    if [ "$now" -ge "$UPLOAD_DEADLINE_EPOCH" ]; then
+      die "deadline reached before uploading $name"
+    fi
+    # Keep one file's budget inside the phase deadline. Floor at 1: `timeout 0`
+    # means no timeout, which brings back the hang this script prevents.
+    remaining=$(( UPLOAD_DEADLINE_EPOCH - now ))
+    this_budget="$budget"
+    if [ "$this_budget" -gt "$remaining" ]; then this_budget="$remaining"; fi
+    if [ "$this_budget" -lt 1 ]; then this_budget=1; fi
+
+    start="$now"
+    # --clobber keeps a retry after a killed upload idempotent, else GitHub
+    # 422s on the duplicate name. Take the status here, not from $? after an
+    # `if`: a false `if` with no else exits 0, so every stall would read clean.
+    rc=0
+    timeout -k 30 "$this_budget" gh release upload "$TAG" --repo "$REPO" --clobber "$f" || rc=$?
+    elapsed=$(( $(date +%s) - start ))
+    if [ "$rc" -eq 0 ]; then
+      if [ "$elapsed" -lt 1 ]; then elapsed=1; fi
+      log "uploaded $name (${mb} MB in ${elapsed}s, $(( mb / elapsed )) MB/s, attempt ${attempt})"
+      exit 0
+    fi
+    if [ "$rc" -ge 124 ]; then
+      log "STALLED $name: no completion in ${elapsed}s (budget ${this_budget}s, ${mb} MB); attempt ${attempt}/${ATTEMPTS}"
+    else
+      log "FAILED $name: gh exit ${rc} after ${elapsed}s; attempt ${attempt}/${ATTEMPTS}"
+    fi
+    if [ "$attempt" -eq "$ATTEMPTS" ]; then
+      die "gave up on $name after ${ATTEMPTS} attempts"
+    fi
+    sleep $(( attempt * 15 ))
+  done
+  exit 1
+fi
+
+# ---------------------------------------------------------------- parent mode
+TAG="" REPO="" DIST=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --tag)  TAG="$2";  shift 2 ;;
+    --repo) REPO="$2"; shift 2 ;;
+    --dist) DIST="$2"; shift 2 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+[ -n "$TAG" ]  || die "--tag is required"
+[ -n "$REPO" ] || die "--repo is required"
+[ -n "$DIST" ] || die "--dist is required"
+[ -d "$DIST" ] || die "dist directory not found: $DIST"
+
+# NUL-delimited: a name with a space would otherwise split into two bad paths.
+mapfile -d '' -t FILES < <(find "$DIST" -maxdepth 1 -type f -print0 | sort -z)
+[ "${#FILES[@]}" -gt 0 ] || die "no files to upload in $DIST"
+
+total_bytes=0
+for f in "${FILES[@]}"; do total_bytes=$(( total_bytes + $(file_size "$f") )); done
+log "uploading ${#FILES[@]} assets ($(( total_bytes / 1000000 )) MB) to draft $TAG with ${JOBS} workers"
+
+UPLOAD_DEADLINE_EPOCH=$(( $(date +%s) + DEADLINE_MINUTES * 60 ))
+export TAG REPO UPLOAD_DEADLINE_EPOCH JOBS ATTEMPTS MIN_RATE_MB_S GRACE_SECONDS
+
+self="$(readlink -f "$0")"
+
+# The incident was 4 hours of silence, so report what the API has accepted.
+heartbeat() {
+  while sleep "$HEARTBEAT_SECONDS"; do
+    n="$(gh release view "$TAG" --repo "$REPO" --json assets --jq '[.assets[]|select(.state=="uploaded")]|length' 2>/dev/null || echo '?')"
+    log "heartbeat: ${n}/${#FILES[@]} assets uploaded, $(( (UPLOAD_DEADLINE_EPOCH - $(date +%s)) / 60 ))m left in budget"
+  done
+}
+heartbeat & hb_pid=$!
+trap 'kill "$hb_pid" 2>/dev/null || true' EXIT
+
+upload_pass() {
+  # Run through `bash`, so a lost exec bit cannot break the publish.
+  printf '%s\0' "$@" | xargs -0 -P "$JOBS" -n 1 bash "$self" --upload-one
+}
+
+pass_rc=0
+upload_pass "${FILES[@]}" || pass_rc=$?
+[ "$pass_rc" -eq 0 ] || log "upload pass reported failures (xargs exit ${pass_rc}); verification decides"
+
+# gh exiting 0 does not prove the asset is complete. Every local file must be
+# on the release with the same size and state "uploaded".
+missing_files() {
+  local remote
+  remote="$(gh release view "$TAG" --repo "$REPO" --json assets \
+    --jq '.assets[] | select(.state=="uploaded") | "\(.name)\t\(.size)"')" \
+    || die "could not read release assets for verification"
+  for f in "${FILES[@]}"; do
+    if ! grep -qxF "$(asset_name "$f")	$(file_size "$f")" <<<"$remote"; then
+      printf '%s\0' "$f"
+    fi
+  done
+}
+
+mapfile -d '' -t BAD < <(missing_files)
+if [ "${#BAD[@]}" -gt 0 ]; then
+  log "verification found ${#BAD[@]} missing or mismatched assets; re-uploading"
+  for f in "${BAD[@]}"; do log "  - $(asset_name "$f")"; done
+  upload_pass "${BAD[@]}" || true
+  mapfile -d '' -t BAD < <(missing_files)
+fi
+
+if [ "${#BAD[@]}" -gt 0 ]; then
+  for f in "${BAD[@]}"; do printf 'ERROR: asset never landed: %s\n' "$(asset_name "$f")" >&2; done
+  die "refusing to publish: ${#BAD[@]}/${#FILES[@]} assets missing after re-upload"
+fi
+
+log "verified all ${#FILES[@]} assets present, sized and uploaded"


### PR DESCRIPTION
## Problem

[Run 31335302864](https://github.com/unslothai/llama.cpp/actions/runs/31335302864) took 5h40m instead of the usual ~2h. It went green in the end, but the `Assemble metadata + publish` job ran 5h25m against its `timeout-minutes: 350`, so it cleared the cap by 25 minutes.

All of that time was in one step. `Publish GitHub release` ran 22:34:33 to 02:25:57, 3h51m, with no output at all. Every other step in the job took seconds, and the same step on the previous nightly took 49s.

`gh release create ... dist/*` uploads with a fixed 5-worker pool and no per-connection timeout. Per-asset timestamps from the releases API:

- the first 10 assets went up at 33-47 MB/s and were done in 9 seconds
- 6 large bundles then wedged at 0.03-0.09 MB/s and took all 5 slots: `rocm-gfx103X` 13876s, `rocm-gfx110X` 13473s, `rocm-gfx1150` and `rocm-gfx1151` 13373s, `rocm-gfx120X` 8384s, `cuda13-portable` 5004s
- the queue drained at 02:19:12 and the remaining 25 assets uploaded in 37 seconds at 30-42 MB/s

Runner egress was fine throughout. A handful of PUTs to uploads.github.com went silent, nothing timed them out, and the pool starved. No githubstatus incident was posted for that window.

A slightly worse stall fails the job and costs a full 40-job matrix rebuild.

## Change

Create the draft empty and upload through `scripts/unsloth/upload_release_assets.sh`:

- per-attempt budget from the file size, `120s + MB/2`, so 495s for the 749 MB bundle and 127s for a 13 MB one. A wedged PUT gets killed and retried, a slow but progressing one does not. This is the part that fixes the failure above.
- a 90m deadline for the whole upload phase, plus `timeout-minutes: 120` on the step. The bad case now fails fast with a message and hours of job budget left, instead of being killed by the job cap with nothing in the log. Failing there also lets the existing rescue artifact step run, so `dist/` survives without rebuilding the matrix.
- verification before publishing. Every local file has to be on the release with a byte-identical size and state `uploaded`. Mismatches get one re-upload, a second failure is fatal. This is new: the old step flipped `draft=false` on the exit code of `gh` alone.
- per-asset and heartbeat logging, since the whole incident was four hours of silence.
- still 4 workers. With per-attempt timeouts the concurrency is no longer a liability, so the good path stays around a minute rather than dropping to a ~3.5 minute sequential upload.

Draft-then-flip atomicity is unchanged, and a hard failure still leaves a draft, which `resolve` already treats as "not exists".

## Tests

`scripts/unsloth/test_upload_release_assets.sh` runs the uploader against a stub `gh` backed by a fake asset registry. 9 cases, all passing, and shellcheck is clean at `-S style`.

| case | expected | result |
| --- | --- | --- |
| happy path | publish | pass |
| stall on 2 assets, recovers on retry | publish | pass |
| transient 502, recovers | publish | pass |
| permanent stall | abort, no publish | pass |
| permanent 502 | abort, no publish | pass |
| asset committed at the wrong size | caught, re-uploaded | pass |
| asset stuck in a non-uploaded state | caught, re-uploaded | pass |
| gh exits 0 but the asset never lands | abort, no publish | pass |
| phase deadline exceeded | abort, no publish | pass |

The stall cases run with shrunk budgets so a wedged upload dies in about a second instead of 500.

Three bugs turned up while writing those tests, all fixed here:

- `if cmd; then ...; fi` exits 0 when the condition is false, so reading `$?` after it reported every stall and every 5xx as a clean exit and mislabelled the retry
- `basename | tr -c 'A-Za-z0-9._-' '.'` rewrites basename's trailing newline into a `.`, which appends a phantom character to every asset name and fails verification for all of them
- `[ test ] && action` as a statement under `set -e` exits when the test is false, including one instance in the workflow itself

## Note

One assumption worth flagging: verification maps local filenames to the sanitized names GitHub reports, on the basis that GitHub rewrites anything outside `[A-Za-z0-9._-]` to `.`. Every current `dist/` filename is already inside that set, so the mapping is a no-op today and only matters as a safety net.
