### PR TITLE
Prebuilt: pin the IQ1_XS, IQ1_XXS and IQ1_XXXS quant types onto master

### DIFF
--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -20,6 +20,7 @@
   "prs": [
     "https://github.com/ggml-org/llama.cpp/pull/24423/commits/daca8075d871483545dd85d58ce11970b304b541",
     "https://github.com/ggml-org/llama.cpp/pull/25731/commits/0a9841fa63edce1cd252ed6efea713715abb0cf2",
-    "https://github.com/unslothai/llama.cpp/pull/70/commits/06d2326acbf515b10f8d6abeada09123d361acde"
+    "https://github.com/unslothai/llama.cpp/pull/70/commits/06d2326acbf515b10f8d6abeada09123d361acde",
+    "https://github.com/unslothai/llama.cpp/pull/91/commits/c86ed269986f2dced6325c5c58bda966a2e2ead1"
   ]
 }


### PR DESCRIPTION
#92 was merged into its stacked base branch `prset-drop-merged-26841` rather than into master, so the pin commit is sitting on that branch and never reached the `scripts/unsloth/pr-set.json` the nightly actually reads. Master today has only the #90 change:

```
$ git show origin/master:scripts/unsloth/pr-set.json | jq -r '.prs[]'
https://github.com/ggml-org/llama.cpp/pull/24423/commits/daca8075d871483545dd85d58ce11970b304b541
https://github.com/ggml-org/llama.cpp/pull/25731/commits/0a9841fa63edce1cd252ed6efea713715abb0cf2
https://github.com/unslothai/llama.cpp/pull/70/commits/06d2326acbf515b10f8d6abeada09123d361acde
```

This is the same one-line addition from #92, reapplied on top of master. Opened as a fresh branch rather than retargeting `prset-drop-merged-26841`, because that branch carries its own copy of the #90 commit and master took #90 as a squash, so pointing it at master would put a duplicate of #90 into the diff.

## The pin still works now that #91 is merged

#91 merged into `iq1-narrow-upstream-base`, not into master, so the tree `resolve` builds (upstream base tag plus pins) still does not contain the change. The pin is what puts it there.

The gate handles this: a required pin that is no longer open keeps being merged in and logs a warning, which is exactly the case the `_doc` describes. The membership check also still passes, `c86ed269` is a commit of #91. Once a base tag ever contains this work the entry should be deleted outright rather than left to no-op, per the note added in #90.

## Verification

Unchanged from #92, since the pinned commit and the rest of the set are the same. Resolve replay on `b10356` gives `MERGED OK` at tag `b10356-mix-1c79028`, with only #70 needing `additive_merge.py` and only for pure add/add hunks. The tree that comes out hashes to `cdc8f9490e4e33bc0dc87c94842455f6a8e5e189`, which is the tree that was built and tested:

- CUDA `sm_100` build completes clean
- `test-backend-ops -o MUL_MAT -b CUDA0` 1219/1219, `-o MUL_MAT_ID` 874/874
- 59 of 60 ctest pass, the 60th being `test-backend-ops` itself hitting the 1500s ctest timeout
- all three types quantize and generate on Llama-3.2-1B with an imatrix, sizes in bpw order
- IQ1_S, IQ2_XXS, Q4_K_M and Q8_0 come out byte-identical against a build without the change
- DiffusionGemma, Inkling, Kimi-K3 and Muse Glimmer all still land in the merged tree
