### PR TITLE
Drop the inert unsloth capacity-sweeper dispatch

### DIFF
--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -455,48 +455,6 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-      # Ask unsloth to stand its scheduled CI down while this release builds.
-      # Fired here rather than at assemble time: the point is to free slots
-      # before the 39-job matrix queues, not after it has finished waiting.
-      # Guarded on the same condition as the build jobs, so a scheduled no-op
-      # never sweeps anything.
-      #
-      # workflow_dispatch, not repository_dispatch. Both would work, but
-      # POST /dispatches needs Contents: write on the target and this needs only
-      # Actions: write, so the token cannot push code to unsloth.
-      #
-      # unsloth decides what it is willing to cancel; this only asks. If the
-      # sweeper is not on unsloth's main yet, this 404s and warns, which is why
-      # the whole step is best-effort.
-      - name: Ask unsloth to free runner capacity
-        if: ${{ steps.r.outputs.exists != 'true' || github.event_name == 'workflow_dispatch' }}
-        # A release must never fail because the request did not land.
-        continue-on-error: true
-        env:
-          DISPATCH_TOKEN: ${{ secrets.UNSLOTH_DISPATCH_TOKEN }}
-          TAG: ${{ steps.r.outputs.tag }}
-        run: |
-          # No -x here: it would trace the token into the log.
-          set -eu
-          if [ -z "${DISPATCH_TOKEN:-}" ]; then
-            echo "::warning::UNSLOTH_DISPATCH_TOKEN is not set; not asking unsloth to free capacity"
-            exit 0
-          fi
-          PAYLOAD="$(jq -cn --arg r "llama.cpp ${TAG} run ${GITHUB_RUN_ID}" \
-            '{ref: "main", inputs: {mode: "sweep", events: "schedule", classes: "linux,windows", reason: $r}}')"
-          CODE="$(curl -sS -o /dev/null -w '%{http_code}' -X POST \
-            -H "Authorization: Bearer ${DISPATCH_TOKEN}" \
-            -H "Accept: application/vnd.github+json" \
-            https://api.github.com/repos/unslothai/unsloth/actions/workflows/ci-capacity.yml/dispatches \
-            -d "$PAYLOAD")"
-          # 204 is "request accepted", not "capacity freed". unsloth's sweeper
-          # ships inert, so until it is enabled there this is a no-op by design.
-          if [ "$CODE" = "204" ]; then
-            echo "asked unsloth to free linux/windows capacity for ${TAG}"
-          else
-            echo "::warning::unsloth ci-capacity dispatch returned HTTP ${CODE}; continuing without it"
-          fi
-
   build-cuda:
     name: CUDA
     needs: resolve


### PR DESCRIPTION
Removes the "Ask unsloth to free runner capacity" step from `unsloth-prebuilt.yml`.

## Why

The step asks `unslothai/unsloth` to run `ci-capacity.yml` and free linux/windows runners before this pipeline queues its build matrix. That sweeper is gated on the repo variable `CI_PREEMPT_ENABLED` being the exact string `true` on unsloth, and it is not set, so the sweeper ships inert: it resolves what it would have cancelled, prints it to the job summary, and touches nothing.

The step already documented this ("204 is request accepted, not capacity freed ... until it is enabled there this is a no-op by design"). It has never freed a runner. Queue clearing on unsloth is done manually now, so the dispatch is dead weight: it needs the `UNSLOTH_DISPATCH_TOKEN` secret, makes a cross-repo API call, and warns on failure, all to trigger a no-op.

## What changes

- Deletes the step and its comment block from the `resolve` job (42 lines).
- Nothing else references it. Job graph is unchanged: `resolve, build-cuda, build-windows-cuda, build-rocm, build-macos, build-cpu, build-vulkan, assemble, reclaim, alert`.
- The `reclaim` job (artifact storage) is untouched -- unrelated to this, and still wanted.
- `UNSLOTH_DISPATCH_TOKEN` now has no consumer in this workflow and can be retired if nothing else uses it.

## Test plan

- [ ] Dispatch with `publish:false` and confirm `resolve` completes without the step