### PR TITLE
sampling: index penalties by token id instead of scanning every candidate

### DIFF
--- a/src/llama-sampler.cpp
+++ b/src/llama-sampler.cpp
@@ -2969,17 +2969,17 @@ static void llama_sampler_penalties_apply(struct llama_sampler * smpl, llama_tok
     };
 
     // token_count holds at most penalty_last_n entries, so walking it is much cheaper than probing it once per candidate.
-    // This needs a token id to be its own index in cur_p, which holds while no earlier sampler has dropped or reordered candidates.
+    // This needs cur_p to still be the untouched candidate array, where a token id is its own index and appears once.
+    // The check is a compare per candidate, against a map probe per candidate, and it stops at the first mismatch.
     bool by_index = cur_p->size == (size_t) ctx->n_vocab;
 
-    for (const auto & it : ctx->token_count) {
-        if (!by_index) {
-            break;
+    if (by_index) {
+        for (size_t i = 0; i < cur_p->size; ++i) {
+            if (cur_p->data[i].id != (llama_token) i) {
+                by_index = false;
+                break;
+            }
         }
-
-        const llama_token token = it.first;
-
-        by_index = token >= 0 && (size_t) token < cur_p->size && cur_p->data[token].id == token;
     }
 
     // Apply frequency and presence penalties to the cur_p

--- a/src/llama-sampler.cpp
+++ b/src/llama-sampler.cpp
@@ -2954,26 +2954,48 @@ static void llama_sampler_penalties_apply(struct llama_sampler * smpl, llama_tok
         return;
     }
 
-    // Apply frequency and presence penalties to the cur_p
-    for (size_t i = 0; i < cur_p->size; ++i) {
-        const auto token_iter = ctx->token_count.find(cur_p->data[i].id);
-        if (token_iter == ctx->token_count.end()) {
-            continue;
-        }
-
-        const int count = token_iter->second;
-
+    auto penalize = [ctx](llama_token_data & cand, int count) {
         assert(count > 0 && count <= ctx->penalty_last_n);
 
         // The academic publication that described this technique actually just only divided, but that would cause tokens with negative logits to become more likely, which is obviously wrong.
         // This is common fix for this problem, which is to multiply by the penalty instead of dividing.
-        if (cur_p->data[i].logit <= 0) {
-            cur_p->data[i].logit *= ctx->penalty_repeat;
+        if (cand.logit <= 0) {
+            cand.logit *= ctx->penalty_repeat;
         } else {
-            cur_p->data[i].logit /= ctx->penalty_repeat;
+            cand.logit /= ctx->penalty_repeat;
         }
 
-        cur_p->data[i].logit -= float(count) * ctx->penalty_freq + float(count > 0) * ctx->penalty_present;
+        cand.logit -= float(count) * ctx->penalty_freq + float(count > 0) * ctx->penalty_present;
+    };
+
+    // token_count holds at most penalty_last_n entries, so walking it is much cheaper than probing it once per candidate.
+    // This needs a token id to be its own index in cur_p, which holds while no earlier sampler has dropped or reordered candidates.
+    bool by_index = cur_p->size == (size_t) ctx->n_vocab;
+
+    for (const auto & it : ctx->token_count) {
+        if (!by_index) {
+            break;
+        }
+
+        const llama_token token = it.first;
+
+        by_index = token >= 0 && (size_t) token < cur_p->size && cur_p->data[token].id == token;
+    }
+
+    // Apply frequency and presence penalties to the cur_p
+    if (by_index) {
+        for (const auto & it : ctx->token_count) {
+            penalize(cur_p->data[it.first], it.second);
+        }
+    } else {
+        for (size_t i = 0; i < cur_p->size; ++i) {
+            const auto token_iter = ctx->token_count.find(cur_p->data[i].id);
+            if (token_iter == ctx->token_count.end()) {
+                continue;
+            }
+
+            penalize(cur_p->data[i], token_iter->second);
+        }
     }
 
     cur_p->sorted = false;

--- a/tests/test-sampling.cpp
+++ b/tests/test-sampling.cpp
@@ -187,6 +187,48 @@ static void test_penalties(
     tester.check();
 }
 
+// penalties indexes cur_p by token id when it can, so a reordered cur_p must still give the same logits
+static void test_penalties_reordered(
+    const std::vector<float> & probs, const std::vector<llama_token> & last_tokens,
+    float repeat_penalty, float alpha_frequency, float alpha_presence
+) {
+    auto run = [&](bool reversed) {
+        std::vector<llama_token_data> cur;
+        cur.reserve(probs.size());
+        for (llama_token token_id = 0; token_id < (llama_token) probs.size(); token_id++) {
+            cur.emplace_back(llama_token_data{token_id, logf(probs[token_id]), probs[token_id]});
+        }
+
+        if (reversed) {
+            std::reverse(cur.begin(), cur.end());
+        }
+
+        llama_token_data_array cur_p = { cur.data(), cur.size(), -1, false };
+
+        auto * sampler = llama_sampler_init_penalties((int32_t) probs.size(), (int32_t) last_tokens.size(), repeat_penalty, alpha_frequency, alpha_presence);
+        for (size_t i = 0; i < last_tokens.size(); i++) {
+            llama_sampler_accept(sampler, last_tokens[i]);
+        }
+
+        llama_sampler_apply(sampler, &cur_p);
+        llama_sampler_free(sampler);
+
+        std::vector<float> logits(probs.size());
+        for (size_t i = 0; i < cur_p.size; i++) {
+            logits[cur_p.data[i].id] = cur_p.data[i].logit;
+        }
+
+        return logits;
+    };
+
+    const std::vector<float> by_index = run(false);
+    const std::vector<float> by_lookup = run(true);
+
+    for (size_t i = 0; i < by_index.size(); i++) {
+        GGML_ASSERT(by_index[i] == by_lookup[i]);
+    }
+}
+
 static void test_dry(
     const std::vector<float> & probs, const std::vector<llama_token> & last_tokens,
     const std::vector<float> & expected_probs, float dry_multiplier, float dry_base,
@@ -383,6 +425,10 @@ int main(void) {
     test_penalties({0.2f, 0.2f, 0.2f, 0.2f, 0.2f}, {0},             {0.000011f, 0.249997f, 0.249997f, 0.249997f, 0.249997f}, 1.0f, 5.0f, 5.0f);
     test_penalties({0.2f, 0.2f, 0.2f, 0.2f, 0.2f}, {0, 1, 2},       {0.000023f, 0.000023f, 0.000023f, 0.499966f, 0.499966f}, 1.0f, 5.0f, 5.0f);
     test_penalties({0.2f, 0.2f, 0.2f, 0.2f, 0.2f}, {0, 1, 2, 0, 0}, {0.000000f, 0.000023f, 0.000023f, 0.499977f, 0.499977f}, 1.0f, 5.0f, 5.0f);
+
+    test_penalties_reordered({0.2f, 0.2f, 0.2f, 0.2f, 0.2f}, {0, 1, 2, 0, 0}, 50.0f, 0.0f, 0.0f);
+    test_penalties_reordered({0.2f, 0.2f, 0.2f, 0.2f, 0.2f}, {0, 1, 2, 0, 0}, 1.0f, 0.0f, 1.5f);
+    test_penalties_reordered({0.2f, 0.2f, 0.2f, 0.2f, 0.2f}, {0, 1, 2, 0, 0}, 1.1f, 5.0f, 5.0f);
 
 
     test_dry({0.25f, 0.25f, 0.25f, 0.25f}, {0, 1}, {0.25f, 0.25f, 0.25f, 0.25f}, 1.0f, 1.1f, 2, 4, {});

--- a/tests/test-sampling.cpp
+++ b/tests/test-sampling.cpp
@@ -229,6 +229,34 @@ static void test_penalties_reordered(
     }
 }
 
+// a cur_p that holds the same id twice must penalize both entries, so it cannot take the by-index path
+static void test_penalties_duplicate_ids(
+    const std::vector<float> & probs, const std::vector<llama_token> & last_tokens,
+    float repeat_penalty, float alpha_frequency, float alpha_presence
+) {
+    GGML_ASSERT(probs.size() > 1);
+
+    std::vector<llama_token_data> cur;
+    cur.reserve(probs.size());
+    for (llama_token token_id = 0; token_id < (llama_token) probs.size(); token_id++) {
+        cur.emplace_back(llama_token_data{token_id, logf(probs[token_id]), probs[token_id]});
+    }
+    cur.back() = cur.front();
+
+    llama_token_data_array cur_p = { cur.data(), cur.size(), -1, false };
+
+    auto * sampler = llama_sampler_init_penalties((int32_t) probs.size(), (int32_t) last_tokens.size(), repeat_penalty, alpha_frequency, alpha_presence);
+    for (size_t i = 0; i < last_tokens.size(); i++) {
+        llama_sampler_accept(sampler, last_tokens[i]);
+    }
+
+    llama_sampler_apply(sampler, &cur_p);
+    llama_sampler_free(sampler);
+
+    GGML_ASSERT(cur_p.data[0].id == cur_p.data[cur_p.size - 1].id);
+    GGML_ASSERT(cur_p.data[0].logit == cur_p.data[cur_p.size - 1].logit);
+}
+
 static void test_dry(
     const std::vector<float> & probs, const std::vector<llama_token> & last_tokens,
     const std::vector<float> & expected_probs, float dry_multiplier, float dry_base,
@@ -429,6 +457,9 @@ int main(void) {
     test_penalties_reordered({0.2f, 0.2f, 0.2f, 0.2f, 0.2f}, {0, 1, 2, 0, 0}, 50.0f, 0.0f, 0.0f);
     test_penalties_reordered({0.2f, 0.2f, 0.2f, 0.2f, 0.2f}, {0, 1, 2, 0, 0}, 1.0f, 0.0f, 1.5f);
     test_penalties_reordered({0.2f, 0.2f, 0.2f, 0.2f, 0.2f}, {0, 1, 2, 0, 0}, 1.1f, 5.0f, 5.0f);
+
+    test_penalties_duplicate_ids({0.2f, 0.2f, 0.2f, 0.2f, 0.2f}, {0, 1, 2, 0, 0}, 50.0f, 0.0f, 0.0f);
+    test_penalties_duplicate_ids({0.2f, 0.2f, 0.2f, 0.2f, 0.2f}, {0, 1, 2, 0, 0}, 1.0f, 0.0f, 1.5f);
 
 
     test_dry({0.25f, 0.25f, 0.25f, 0.25f}, {0, 1}, {0.25f, 0.25f, 0.25f, 0.25f}, 1.0f, 1.1f, 2, 4, {});


### PR DESCRIPTION
## The problem

`llama_sampler_penalties_apply` walks the whole candidate array and probes the frequency map once per candidate:

```cpp
for (size_t i = 0; i < cur_p->size; ++i) {
    const auto token_iter = ctx->token_count.find(cur_p->data[i].id);
```

`token_count` never holds more than `penalty_last_n` live entries (64 by default), so at most 64 of those probes can match. Everything else is a wasted hash lookup. The cost scales with the vocab, not with the penalty window, so it lands hardest on the recent large-vocab models: Qwen3.6-27B has 248320 tokens, which is 248320 lookups per token to penalize at most 64.

It only shows up when a penalty is actually enabled, so most default presets never see it. Ours do: the `qwen3.5` and `qwen3.6` family profiles in Unsloth Studio set `presence_penalty: 1.5`, and that alone was costing about 11% of generation throughput.

## The fix

Walk `token_count` and index `cur_p` directly. That turns the loop from `n_vocab` into `penalty_last_n`.

Indexing by id is only valid while `cur_p` is still the untouched candidate array, so the fast path is guarded on the array being the identity layout, `data[i].id == i` for every `i`. Anything else, a truncated, reordered or hand-built array, falls back to the original scan. The check is one compare per candidate against a map probe per candidate, and it stops at the first mismatch.

The identity layout also guarantees each id appears exactly once, which matters: the first version of this patch checked only that each penalized token sat at its own index, and an array holding the same id twice then got one of the two entries penalized instead of both. The fuzz below caught it.

The arithmetic itself is untouched and each token is still penalized exactly once, so the result does not depend on which path runs or on map iteration order.

## Measured

Both builds from `b10359`, single GPU, `--parallel 4 --kv-unified --flash-attn on`, 400 generated tokens, `temperature 0`, median of 5. Throughput is llama.cpp's own `/metrics` counters, not client wall clock.

Qwen3-0.6B-Q4_K_M, 151936 vocab:

| penalty | stock | patched | delta |
| --- | ---: | ---: | ---: |
| none | 610.69 | 603.32 | -1.2% |
| `presence_penalty 1.5` | 467.29 | 583.09 | +24.8% |
| `frequency_penalty 0.8` | 440.94 | 586.39 | +33.0% |
| `repeat_penalty 1.15` | 443.18 | 595.42 | +34.4% |

Qwen3.6-27B-UD-Q4_K_XL, 248320 vocab, `--spec-type draft-mtp`, `presence_penalty 1.5`: 130.29 to 144.59 t/s, up 11.0%, against 146.63 with the penalty switched off. So the penalty goes from costing 11% of the decode rate to costing about 1%.

The "none" row is noise. `is_disabled()` returns before any of this, so the patched path cannot execute there; over 9 runs each the medians were 600.60 and 598.80 with fully overlapping spreads.

The win grows with vocab size and shrinks with model size, which is why it has gone unnoticed: it is invisible on small-vocab models and largest exactly where it hurts, small fast models with modern tokenizers.

## Output is unchanged

60 comparisons, stock server against patched server, both built from `b10359`, 4 prompts x 5 penalty combinations x greedy and two seeded sampled settings:

| penalties | temperature 0 | temperature 0.8, seed 1234 | temperature 1.0, seed 7 |
| --- | --- | --- | --- |
| none | 4/4 identical | 4/4 identical | 4/4 identical |
| `presence 1.5` | 4/4 identical | 4/4 identical | 4/4 identical |
| `frequency 0.8` | 4/4 identical | 4/4 identical | 4/4 identical |
| `repeat 1.15` | 4/4 identical | 4/4 identical | 4/4 identical |
| all three | 4/4 identical | 4/4 identical | 4/4 identical |

60/60 byte identical. Repeating a generation five times on each build gave one distinct output per build, so both remain deterministic.

## Tests

`tests/test-sampling` passes. The existing `test_penalties` cases already pin the expected probabilities for repeat, frequency and presence penalties and are unchanged. Two cases are added:

- `test_penalties_reordered` applies the sampler to a normal candidate array and to a reversed one, which forces the fallback, and asserts the resulting logits match exactly.
- `test_penalties_duplicate_ids` builds an array holding one id twice and asserts both entries end up with the same logit, which is what the scan does and what the first version of this patch got wrong.

Beyond the suite, a differential fuzz compared the shipped sampler against a reference implementation of the old scan over 33600 cases: 10 vocab sizes from 1 to 151936, 6 values of `penalty_last_n` including 0, 5 repeat x 4 frequency x 4 presence settings including negative ones, and 7 candidate layouts (canonical, reversed, shuffled, truncated, duplicated id, sorted by logit, single entry), with logits including 0, -0, inf, -inf, nan, denormals and `FLT_MAX`. Comparison is on the float bit patterns, so a nan or a signed zero landing in the wrong place fails.

- against the first version of this patch: 209 mismatches, all on the duplicate-id layout
- against this version: 0 mismatches
- against the stock library, as a check that the reference is faithful: 0 mismatches

`g++ -std=c++17` and `-std=c++20`, both with `-Wall -Wextra -Werror`, are clean, and the file produces no warnings the stock file does not.
