### PR TITLE
Prebuilt: pin the penalties sampler fix (#95)

### DIFF
--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -21,6 +21,7 @@
     "https://github.com/ggml-org/llama.cpp/pull/24423/commits/daca8075d871483545dd85d58ce11970b304b541",
     "https://github.com/ggml-org/llama.cpp/pull/25731/commits/0a9841fa63edce1cd252ed6efea713715abb0cf2",
     "https://github.com/unslothai/llama.cpp/pull/70/commits/06d2326acbf515b10f8d6abeada09123d361acde",
-    "https://github.com/unslothai/llama.cpp/pull/91/commits/c86ed269986f2dced6325c5c58bda966a2e2ead1"
+    "https://github.com/unslothai/llama.cpp/pull/91/commits/c86ed269986f2dced6325c5c58bda966a2e2ead1",
+    "https://github.com/unslothai/llama.cpp/pull/95/commits/c26185ba22df3e2b3b0f486e80d3274733bd0582"
   ]
 }


### PR DESCRIPTION
Pins [c26185b](https://github.com/unslothai/llama.cpp/pull/95/commits/c26185ba22df3e2b3b0f486e80d3274733bd0582) from #95 into the nightly prebuild set.

#95 stops `llama_sampler_penalties_apply` from probing the frequency map once per candidate. It now walks `token_count` (at most `penalty_last_n` entries) and indexes `cur_p` directly, with a guard that falls back to the old scan when an earlier sampler has reordered or dropped candidates.

This matters for the prebuilds because our own Studio presets enable it: the `qwen3.5` and `qwen3.6` family profiles set `presence_penalty: 1.5`, and on a 248320 token vocab the old scan cost about 11% of generation throughput.

Qwen3.6-27B-UD-Q4_K_XL, 400 tokens, `temperature 0`, median of 4, throughput from llama.cpp's own `/metrics`:

| presence_penalty | build | server t/s |
| --- | --- | ---: |
| 1.5 | stock | 130.29 |
| 1.5 | patched | 146.66 |

Output is unchanged: 16 stock vs patched comparisons across 4 prompts, both penalty settings, greedy and `temperature 0.8` with a fixed seed, all byte identical. `tests/test-sampling` passes.

Per the notes in `pr-set.json` the entry stays listed until the change lands upstream, since merging it into fork master alone would drop it from the mix.
