### PR TITLE
Prebuilt: repin #95 onto an upstream base

### DIFF
--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -22,6 +22,6 @@
     "https://github.com/ggml-org/llama.cpp/pull/25731/commits/0a9841fa63edce1cd252ed6efea713715abb0cf2",
     "https://github.com/unslothai/llama.cpp/pull/70/commits/06d2326acbf515b10f8d6abeada09123d361acde",
     "https://github.com/unslothai/llama.cpp/pull/91/commits/c86ed269986f2dced6325c5c58bda966a2e2ead1",
-    "https://github.com/unslothai/llama.cpp/pull/95/commits/c26185ba22df3e2b3b0f486e80d3274733bd0582"
+    "https://github.com/unslothai/llama.cpp/pull/95/commits/e2e842a46990765f26cfb5b6c5f1f8e03c3601bc"
   ]
 }


### PR DESCRIPTION
The pin added in #96 pointed at `c26185b`, which was cut from fork master. Fork master's merge base with the current base tag (`b10359`) is from June 10, so merging that commit into the mix pulled in the whole fork/upstream divergence and conflicted across roughly 1600 files. The change itself was fine; the branch point was not.

Rebased the commit onto `b10359` and repinned to [e2e842a](https://github.com/unslothai/llama.cpp/pull/95/commits/e2e842a46990765f26cfb5b6c5f1f8e03c3601bc). #95 now targets `penalties-upstream-base`, which is the upstream base commit, matching how #70 (`kimi-k3-text-upstream`) and #91 (`iq1-narrow-upstream-base`) are carried. Its diff is back to the 2 files it should be.

Replayed the prebuilt merge loop locally against `b10359`, in `pr-set.json` order:

```
CLEAN         ggml-org/llama.cpp#24423   daca8075d871
CLEAN         ggml-org/llama.cpp#25731   0a9841fa63ed
ADDITIVE      unslothai/llama.cpp#70     06d2326acbf5
CLEAN         unslothai/llama.cpp#91     c86ed269986f
CLEAN         unslothai/llama.cpp#95     e2e842a46990
```

#70 still needs `additive_merge.py` and every conflict it saw was a pure add/add in `src/llama-arch.cpp`, `src/llama-context.cpp`, `src/llama-model.cpp`, `tests/test-llama-archs.cpp` and `tools/mtmd/CMakeLists.txt`, which is the same shape it has been resolving all along. Nothing else conflicts, and the mixed tree builds with `tests/test-sampling` passing.
