### PR TITLE
Prebuilt: move the #95 pin to the identity-guard commit

### DIFF
--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -22,6 +22,6 @@
     "https://github.com/ggml-org/llama.cpp/pull/25731/commits/0a9841fa63edce1cd252ed6efea713715abb0cf2",
     "https://github.com/unslothai/llama.cpp/pull/70/commits/06d2326acbf515b10f8d6abeada09123d361acde",
     "https://github.com/unslothai/llama.cpp/pull/91/commits/c86ed269986f2dced6325c5c58bda966a2e2ead1",
-    "https://github.com/unslothai/llama.cpp/pull/95/commits/e2e842a46990765f26cfb5b6c5f1f8e03c3601bc"
+    "https://github.com/unslothai/llama.cpp/pull/95/commits/3db8cb5b2e9bf291057b9f19960e8601a162da81"
   ]
 }


### PR DESCRIPTION
#95 gained a second commit, so the pin has to move with it.

The first version of the patch checked only that each penalized token sat at its own index in `cur_p`. An array holding the same id twice then took the by-index path and penalized one of the two entries, where the original scan penalized both. It now requires the full identity layout, `data[i].id == i` for every `i`, which also rules out duplicates.

A differential fuzz over 33600 cases found it: 209 mismatches against the first version, all on the duplicate-id layout, and 0 against this one. The same harness run against the stock library also reports 0, which is the check that the reference implementation is faithful.

Repins from `e2e842a` to [3db8cb5](https://github.com/unslothai/llama.cpp/pull/95/commits/3db8cb5b2e9bf291057b9f19960e8601a162da81) so the nightly builds the fixed version.

Throughput with the stricter guard, both builds from `b10359`, Qwen3-0.6B-Q4_K_M (151936 vocab), 400 tokens, `temperature 0`, median of 5:

| penalty | stock | patched | delta |
| --- | ---: | ---: | ---: |
| `presence_penalty 1.5` | 467.29 | 583.09 | +24.8% |
| `frequency_penalty 0.8` | 440.94 | 586.39 | +33.0% |
| `repeat_penalty 1.15` | 443.18 | 595.42 | +34.4% |

Output is unchanged: 60/60 byte identical across 4 prompts, 5 penalty combinations, greedy and two seeded sampled settings.
