### PR TITLE
fix(qwen): resolve GGUF export failure when MTP config is nested under text_config

### DIFF
--- a/conversion/qwen.py
+++ b/conversion/qwen.py
@@ -289,12 +289,21 @@ class _QwenMtpMixin:
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.block_count = self.hparams["num_hidden_layers"]
+        hparams = {**self.hparams, **self.hparams.get("text_config", {})}
+        self.block_count = hparams["num_hidden_layers"]
         if not self.no_mtp:
-            n_mtp = self.hparams.get("mtp_num_hidden_layers", 0)
+            n_mtp = hparams.get("mtp_num_hidden_layers", 0)
             # Qwen-3-Next doesn't include `mtp_num_hidden_layers` in config.
+            # Qwen3.5/3.6 nests it under text_config — handled by the merge above.
             if n_mtp == 0:
-                assert self.opt_num_mtp_layers != 0
+                # opt_num_mtp_layers is recovered from tensor names in
+                # filter_tensors, which runs later during index_tensors.
+                if self.opt_num_mtp_layers == 0:
+                    raise ValueError(
+                        "MTP layer count not found in config (checked top level and "
+                        "text_config) and not yet recovered from tensor names. "
+                        "Re-export with --no-mtp, or add mtp_num_hidden_layers to config."
+                    )
                 n_mtp = self.opt_num_mtp_layers
             self.block_count += n_mtp
         self.tensor_map = gguf.get_tensor_name_map(self.model_arch, self.block_count)


### PR DESCRIPTION
Closes https://github.com/unslothai/unsloth/issues/8443

## Problem

`_QwenMtpMixin.__init__` reads `num_hidden_layers` and `mtp_num_hidden_layers`
from the **top level** of `self.hparams` only. For Qwen3.5/3.6 models these keys
are nested under `text_config`, so `__init__` always read 0 MTP layers. It then
hit `assert self.opt_num_mtp_layers != 0`, but `opt_num_mtp_layers` is only
recovered from tensor names during `filter_tensors`/`index_tensors`, which run
**after** `__init__`. The first GGUF conversion in a fresh process always
crashed with a cryptic `AssertionError`:

    assert self.opt_num_mtp_layers != 0

## Fix

1. **Flatten config** — merge `text_config` into `hparams` the same way
   `index_tensors` already does, so nested `mtp_num_hidden_layers` /
   `num_hidden_layers` are found.
2. **Replace the bare assert** with an actionable `ValueError` explaining the
   MTP count could not be found and how to work around it
   (`--no-mtp`, or add `mtp_num_hidden_layers` to `config.json`).

## Verification

Reproduced against the three relevant config shapes (MTP nested under
`text_config`, flat top-level config, and a config missing MTP entirely):

| Scenario | Before | After |
|----------|--------|-------|
| `mtp_num_hidden_layers` under `text_config` | `AssertionError` | 25 blocks |
| flat top-level config | 25 blocks | 25 blocks |
| no MTP info anywhere | `AssertionError` | actionable `ValueError` |

## Files changed

- `conversion/qwen.py` — `_QwenMtpMixin.__init__`