### PR TITLE
Prebuilt: repin #25731 and #70 onto post-squash heads

### DIFF
--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -19,8 +19,8 @@
   ],
   "prs": [
     "https://github.com/ggml-org/llama.cpp/pull/24423/commits/daca8075d871483545dd85d58ce11970b304b541",
-    "https://github.com/ggml-org/llama.cpp/pull/25731/commits/0a9841fa63edce1cd252ed6efea713715abb0cf2",
-    "https://github.com/unslothai/llama.cpp/pull/70/commits/06d2326acbf515b10f8d6abeada09123d361acde",
+    "https://github.com/ggml-org/llama.cpp/pull/25731/commits/c44c9a11a77cf47a24e69d79504bcbddf9f69017",
+    "https://github.com/unslothai/llama.cpp/pull/70/commits/edfd4c1a3b7a653303a85257ddac2a1f3ce39a2f",
     "https://github.com/unslothai/llama.cpp/pull/91/commits/c86ed269986f2dced6325c5c58bda966a2e2ead1",
     "https://github.com/unslothai/llama.cpp/pull/95/commits/3db8cb5b2e9bf291057b9f19960e8601a162da81"
   ]


### PR DESCRIPTION
The nightly has been failing in `Resolve tag` since upstream squash-merged Kimi K3, so no prebuilt has been produced. Two pins needed moving.

### What was failing

`ggml-org#25731` (TML Inkling) was pinned to `0a9841fa`, which no longer merges onto the base tag once `#24423` is applied before it. Two of its four conflicts were real:

```
refused tools/mtmd/clip-model.h: both sides add the same line(s), so this is one change made twice: };
refused tools/mtmd/clip.cpp: merge base is not empty, so at least one side edited existing text
```

`unslothai#70` (Kimi K3 vision) was pinned to `06d2326a`, whose history carries the pre-squash snapshot of `ggml-org#26185`. Upstream merged that PR on 2026-08-15 as squash `ad1de39e`, and a squash is not an ancestor of the pinned commit, so the merge re-applied the whole text side on top of a base that already had it:

```
refused src/llama-arch.cpp: both sides add the same line(s), so this is one change made twice: case LLM_ARCH_KIMI_K3:
```

This is exactly the case the `_doc` in this file warns about.

### What changed

Both PRs have been reconciled with current upstream, so this only moves the pins:

| PR | Old | New |
| --- | --- | --- |
| `ggml-org#25731` | `0a9841fa` | `c44c9a11` |
| `unslothai#70` | `06d2326a` | `edfd4c1a` |

`#25731` merged current master in. `#70` was rebased onto master, which drops the duplicated text-side work and leaves only our delta, +209/-3 across 9 files: the MoonViT-3d vision tower, the full-size loading fixes and the `SSM_A_NOSCAN` placement fix. `conversion/base.py` fell out of that delta because upstream took `repack_mxfp4_blocks` as a `ModelBase` static method.

`#91` and `#95` are unchanged. `#91` stays listed: it is merged upstream but its pin is still not an ancestor of the base tag, so it is contributing content.

### Verification

Replayed the `Resolve tag` merge loop locally against base `b10456` with the real `scripts/unsloth/additive_merge.py`:

```
base: b10456 (f275595dd)
CLEAN      ggml-org/llama.cpp#24423 @ daca8075d871
CLEAN      ggml-org/llama.cpp#25731 @ c44c9a11a77c
ADDITIVE   unslothai/llama.cpp#70   @ edfd4c1a3b7a  [resolved: tools/mtmd/CMakeLists.txt]
CLEAN      unslothai/llama.cpp#91   @ c86ed269986f
CLEAN      unslothai/llama.cpp#95   @ 3db8cb5b2e9b
RESULT: all pins stacked cleanly onto b10456
```

Both reconciled branches were built with CUDA on B200 and tested before pinning. `#25731`: `test-llama-archs`, `test-chat`, `test-flash-attn-bias`, `test-flash-attn-generic-hash` all pass, and `test-backend-ops -o FLASH_ATTN_EXT_BANDED` reports 13/13 on CUDA0. `#70`: `test-llama-archs` and `test-chat` pass.

One note for whoever touches this next: the new `#70` pin sits 14 commits past `b10456`, since it is rebased on master rather than on the tag. The mix therefore carries a little upstream code that has not been through the 6 hour aging window.
