### PR TITLE
unsloth : repin PR #70 after its force-push

### DIFF
--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -20,7 +20,7 @@
   "prs": [
     "https://github.com/ggml-org/llama.cpp/pull/24423/commits/daca8075d871483545dd85d58ce11970b304b541",
     "https://github.com/ggml-org/llama.cpp/pull/25731/commits/0a9841fa63edce1cd252ed6efea713715abb0cf2",
-    "https://github.com/unslothai/llama.cpp/pull/70/commits/06d2326acbf515b10f8d6abeada09123d361acde",
+    "https://github.com/unslothai/llama.cpp/pull/70/commits/edfd4c1a3b7a653303a85257ddac2a1f3ce39a2f",
     "https://github.com/unslothai/llama.cpp/pull/91/commits/c86ed269986f2dced6325c5c58bda966a2e2ead1",
     "https://github.com/unslothai/llama.cpp/pull/95/commits/3db8cb5b2e9bf291057b9f19960e8601a162da81"
   ]


### PR DESCRIPTION
The nightly `Unsloth prebuilt (full release)` run has been failing at `Resolve tag` since PR #70 was force-pushed:

```
refusing unslothai/llama.cpp#70: pinned commit 06d2326acbf515b10f8d6abeada09123d361acde
is not a commit of that PR (wrong paste, or force-pushed away);
fix the pin in scripts/unsloth/pr-set.json
```

The guard is doing its job. #70 was rebased at 2026-08-17T13:44:57Z (`head_ref_force_pushed`), which orphaned `06d2326`; the first scheduled run afterwards aborted before fan-out, so CPU/macOS/CUDA/CUDA Windows/Vulkan/ROCm all reported 0s and no release was published.

This repins to the current head, `edfd4c1a3b7a653303a85257ddac2a1f3ce39a2f`.

### What actually changed in the rewrite

The force-push kept the same three commits and rebased them from `a614fab` onto `34af94cd`. Comparing the two patch sets against their own bases, the interdiff is 57 lines and almost all of it is base drift:

- `src/models/kimi-k3.cpp`, `LLM_KV_EXPERT_LATENT_LENGTH`: the old base already had this key required, so the old patch only added a comment. The new base has it as `, false`, so the new patch flips it back to required. Same end state.
- `src/models/kimi-k3.cpp`, `layer.ssm_a`: `TENSOR_NOT_REQUIRED` vs `0` tracks the same flag changing in the base. Both versions land on `LLM_TENSOR_SSM_A_NOSCAN`; the explanatory comment was shortened from six lines to four.

One real content change: the MXFP4 `0xff` E8M0 NaN-scale validation in `conversion/base.py` (5 lines, `invalid E8M0 scale byte 0xff in N MXFP4 block(s)`) was dropped. It is not in either base, so it is gone rather than upstreamed. That check was unrelated to #70's stated scope of the MoonViT-3d vision tower and full-size loading, so dropping it looks deliberate, but flagging it here since it is the only behavioural delta from the reviewed pin.

### Other pins

`Resolve tag` aborts on the first bad pin, so #91 and #95 were never reached. Both re-verified as still valid against their PRs: `c86ed26` is #91's head, `3db8cb5` is #95's head. The two upstream pins (`ggml-org/llama.cpp#24423`, `#25731`) resolved fine in the failing run.
