### PR TITLE
Pin all GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/unsloth-pin-preflight.yml
+++ b/.github/workflows/unsloth-pin-preflight.yml
@@ -43,7 +43,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       REPIN_TOKEN: ${{ secrets.REPIN_TOKEN }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
 
       - name: Resolve base and dry-run the merges
         id: p

--- a/.github/workflows/unsloth-pr-set-lint.yml
+++ b/.github/workflows/unsloth-pr-set-lint.yml
@@ -29,7 +29,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
       - run: |
           set -euo pipefail
           FILE=scripts/unsloth/pr-set.json

--- a/.github/workflows/unsloth-prebuilt-cpu.yml
+++ b/.github/workflows/unsloth-prebuilt-cpu.yml
@@ -60,7 +60,7 @@ jobs:
       # into cmake/build-info.cmake) and uploaded it as an artifact; extract it
       # instead of cloning -- no .git needed, the build number is already baked.
       - name: Download source @ ${{ inputs.tag }}
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6.0.0
         with:
           name: ${{ inputs.source_artifact }}
           path: srcpkg
@@ -175,7 +175,7 @@ jobs:
           ls -la dist
 
       - name: Upload bundle artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: app-${{ inputs.tag }}-linux-${{ matrix.arch }}-cpu
           path: dist/app-${{ inputs.tag }}-linux-${{ matrix.arch }}-cpu.tar.gz
@@ -202,7 +202,7 @@ jobs:
         # skip the save on the single most expensive case -- a leg that
         # compiled for hours and then hit the cap.
         if: ${{ always() }}
-        uses: actions/cache/save@v6
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ${{ github.workspace }}/.ccache
           key: ccache-cpu-linux-${{ matrix.arch }}-${{ inputs.tag }}-
@@ -229,7 +229,7 @@ jobs:
       # into cmake/build-info.cmake) and uploaded it as an artifact; extract it
       # instead of cloning -- no .git needed, the build number is already baked.
       - name: Download source @ ${{ inputs.tag }}
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6.0.0
         with:
           name: ${{ inputs.source_artifact }}
           path: srcpkg
@@ -335,7 +335,7 @@ jobs:
           if ($LASTEXITCODE -ne 0) { Write-Error "llama-server --version failed: $LASTEXITCODE"; exit 1 }
 
       - name: Upload bundle artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: app-${{ inputs.tag }}-windows-${{ matrix.arch }}-cpu
           path: dist/app-${{ inputs.tag }}-windows-${{ matrix.arch }}-cpu.zip
@@ -362,7 +362,7 @@ jobs:
         # skip the save on the single most expensive case -- a leg that
         # compiled for hours and then hit the cap.
         if: ${{ always() }}
-        uses: actions/cache/save@v6
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ${{ github.workspace }}\.ccache
           key: ccache-cpu-windows-${{ matrix.arch }}-${{ inputs.tag }}-

--- a/.github/workflows/unsloth-prebuilt-cuda-windows.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda-windows.yml
@@ -94,7 +94,7 @@ jobs:
           }
 
       - name: Checkout build tooling (this repo)
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
         with:
           path: tooling
 
@@ -103,7 +103,7 @@ jobs:
       # into cmake/build-info.cmake) and uploaded it as an artifact; extract it
       # instead of cloning -- no .git needed, the build number is already baked.
       - name: Download source @ ${{ inputs.tag }}
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6.0.0
         with:
           name: ${{ inputs.source_artifact }}
           path: srcpkg
@@ -125,7 +125,7 @@ jobs:
           max-size: 2G
           save: false
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: "3.11"
 
@@ -277,7 +277,7 @@ jobs:
         run: python tooling/scripts/unsloth/package_bundle.py
 
       - name: Upload bundle artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: app-${{ inputs.tag }}-windows-x64-${{ matrix.profile }}
           path: dist/app-${{ inputs.tag }}-windows-x64-${{ matrix.profile }}.zip
@@ -304,7 +304,7 @@ jobs:
         # skip the save on the single most expensive case -- a leg that
         # compiled for hours and then hit the cap.
         if: ${{ always() }}
-        uses: actions/cache/save@v6
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ${{ github.workspace }}\.ccache
           key: ccache-cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-${{ inputs.tag }}-

--- a/.github/workflows/unsloth-prebuilt-cuda.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda.yml
@@ -55,7 +55,7 @@ jobs:
           swap-storage: true
 
       - name: Checkout build tooling (this repo)
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
         with:
           path: tooling
 
@@ -64,7 +64,7 @@ jobs:
       # into cmake/build-info.cmake) and uploaded it as an artifact; extract it
       # instead of cloning -- no .git needed, the build number is already baked.
       - name: Download source @ ${{ inputs.tag }}
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6.0.0
         with:
           name: ${{ inputs.source_artifact }}
           path: srcpkg
@@ -249,7 +249,7 @@ jobs:
         run: python3 tooling/scripts/unsloth/package_bundle.py
 
       - name: Upload bundle artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: app-${{ inputs.tag }}-linux-${{ matrix.arch }}-${{ matrix.profile }}
           path: dist/app-${{ inputs.tag }}-linux-${{ matrix.arch }}-${{ matrix.profile }}.tar.gz
@@ -276,7 +276,7 @@ jobs:
         # skip the save on the single most expensive case -- a leg that
         # compiled for hours and then hit the cap.
         if: ${{ always() }}
-        uses: actions/cache/save@v6
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ${{ github.workspace }}/.ccache
           key: ccache-cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ inputs.tag }}-

--- a/.github/workflows/unsloth-prebuilt-deadman.yml
+++ b/.github/workflows/unsloth-prebuilt-deadman.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout (for the composite action)
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
         with: { persist-credentials: false }
 
       - name: Check newest published release

--- a/.github/workflows/unsloth-prebuilt-macos.yml
+++ b/.github/workflows/unsloth-prebuilt-macos.yml
@@ -47,7 +47,7 @@ jobs:
       matrix: ${{ fromJSON(inputs.matrix) }}
     steps:
       - name: Checkout build tooling (this repo)
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
         with:
           path: tooling
           persist-credentials: false
@@ -57,7 +57,7 @@ jobs:
       # into cmake/build-info.cmake) and uploaded it as an artifact; extract it
       # instead of cloning -- no .git needed, the build number is already baked.
       - name: Download source @ ${{ inputs.tag }}
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6.0.0
         with:
           name: ${{ inputs.source_artifact }}
           path: srcpkg
@@ -142,7 +142,7 @@ jobs:
             -s ",^\.,llama-${TAG}," -C build/bin .
 
       - name: Upload bundle artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: app-${{ inputs.tag }}-macos-${{ matrix.build }}
           path: dist/llama-${{ inputs.tag }}-bin-macos-${{ matrix.build }}.tar.gz
@@ -169,7 +169,7 @@ jobs:
         # skip the save on the single most expensive case -- a leg that
         # compiled for hours and then hit the cap.
         if: ${{ always() }}
-        uses: actions/cache/save@v6
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ${{ github.workspace }}/.ccache
           key: ccache-macos-${{ matrix.build }}-${{ matrix.deploy_target }}-${{ inputs.tag }}-

--- a/.github/workflows/unsloth-prebuilt-rocm.yml
+++ b/.github/workflows/unsloth-prebuilt-rocm.yml
@@ -298,7 +298,7 @@ jobs:
     # into cmake/build-info.cmake) and uploaded it as an artifact; extract it
     # instead of cloning -- no .git needed, the build number is already baked.
     - name: Download source @ ${{ inputs.tag }}
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6.0.0
       with:
         name: ${{ inputs.source_artifact }}
         path: srcpkg
@@ -470,7 +470,7 @@ jobs:
         ls -la dist
 
     - name: Upload bundle artifact
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
       with:
         name: app-${{ inputs.tag }}-windows-x64-rocm-${{ matrix.gfx_target }}
         path: dist/app-${{ inputs.tag }}-windows-x64-rocm-${{ matrix.gfx_target }}.zip
@@ -504,7 +504,7 @@ jobs:
       # skip the save on the single most expensive case -- a leg that
       # compiled for hours and then hit the cap.
       if: ${{ always() }}
-      uses: actions/cache/save@v6
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
       with:
         path: ${{ github.workspace }}\.ccache
         key: ccache-rocm-windows-${{ matrix.gfx_target }}-${{ env.DETECTED_ROCM_VERSION }}-${{ inputs.tag }}-
@@ -671,7 +671,7 @@ jobs:
     # into cmake/build-info.cmake) and uploaded it as an artifact; extract it
     # instead of cloning -- no .git needed, the build number is already baked.
     - name: Download source @ ${{ inputs.tag }}
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6.0.0
       with:
         name: ${{ inputs.source_artifact }}
         path: srcpkg
@@ -840,7 +840,7 @@ jobs:
         ls -la dist
 
     - name: Upload bundle artifact
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
       with:
         name: app-${{ inputs.tag }}-linux-x64-rocm-${{ matrix.gfx_target }}
         path: dist/app-${{ inputs.tag }}-linux-x64-rocm-${{ matrix.gfx_target }}.tar.gz
@@ -872,7 +872,7 @@ jobs:
       # skip the save on the single most expensive case -- a leg that
       # compiled for hours and then hit the cap.
       if: ${{ always() }}
-      uses: actions/cache/save@v6
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
       with:
         path: ${{ github.workspace }}/.ccache
         key: ccache-rocm-linux-${{ matrix.gfx_target }}-${{ env.DETECTED_ROCM_VERSION }}-${{ inputs.tag }}-

--- a/.github/workflows/unsloth-prebuilt-vulkan.yml
+++ b/.github/workflows/unsloth-prebuilt-vulkan.yml
@@ -61,7 +61,7 @@ jobs:
       # into cmake/build-info.cmake) and uploaded it as an artifact; extract it
       # instead of cloning -- no .git needed, the build number is already baked.
       - name: Download source @ ${{ inputs.tag }}
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6.0.0
         with:
           name: ${{ inputs.source_artifact }}
           path: srcpkg
@@ -220,7 +220,7 @@ jobs:
           ls -la dist
 
       - name: Upload bundle artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: app-${{ inputs.tag }}-linux-${{ matrix.arch }}-vulkan
           path: dist/app-${{ inputs.tag }}-linux-${{ matrix.arch }}-vulkan.tar.gz
@@ -247,7 +247,7 @@ jobs:
         # skip the save on the single most expensive case -- a leg that
         # compiled for hours and then hit the cap.
         if: ${{ always() }}
-        uses: actions/cache/save@v6
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ${{ github.workspace }}/.ccache
           key: ccache-vulkan-linux-${{ matrix.arch }}-${{ inputs.tag }}-
@@ -264,7 +264,7 @@ jobs:
       # into cmake/build-info.cmake) and uploaded it as an artifact; extract it
       # instead of cloning -- no .git needed, the build number is already baked.
       - name: Download source @ ${{ inputs.tag }}
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6.0.0
         with:
           name: ${{ inputs.source_artifact }}
           path: srcpkg
@@ -368,7 +368,7 @@ jobs:
           ls -la dist
 
       - name: Upload bundle artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: app-${{ inputs.tag }}-windows-x64-vulkan
           path: dist/app-${{ inputs.tag }}-windows-x64-vulkan.zip
@@ -395,7 +395,7 @@ jobs:
         # skip the save on the single most expensive case -- a leg that
         # compiled for hours and then hit the cap.
         if: ${{ always() }}
-        uses: actions/cache/save@v6
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ${{ github.workspace }}\.ccache
           key: ccache-vulkan-windows-x64-${{ inputs.tag }}-

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -120,7 +120,7 @@ jobs:
       # Shallow by default (only pr-set.json is needed); a mix build unshallows
       # in-place to merge the PRs.
       - name: Checkout (pr-set.json + mix merge workspace)
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
       - id: r
         run: |
           set -euo pipefail
@@ -448,7 +448,7 @@ jobs:
       # (resolve skips source prep on a scheduled no-op, leaving no tarball).
       - name: Upload source artifact
         if: ${{ steps.r.outputs.exists != 'true' || github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: ${{ steps.r.outputs.source_artifact }}
           path: ${{ runner.temp }}/llama.cpp-source-${{ steps.r.outputs.tag }}.tar.gz
@@ -652,7 +652,7 @@ jobs:
           done
 
       - name: Checkout build tooling (this repo)
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
         with:
           path: tooling
 
@@ -661,7 +661,7 @@ jobs:
       # re-running the whole hour-long build matrix.
       - name: Download built bundles
         id: download
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6.0.0
         continue-on-error: true
         with:
           path: dist
@@ -670,7 +670,7 @@ jobs:
 
       - name: Download built bundles (retry)
         if: steps.download.outcome == 'failure'
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6.0.0
         with:
           path: dist
           pattern: app-*
@@ -880,7 +880,7 @@ jobs:
         # window, so attempting the upload there is free; if dist/ was never
         # populated, if-no-files-found: warn keeps that quiet.
         if: ${{ always() && !success() }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: unsloth-prebuilt-${{ needs.resolve.outputs.tag }}
           path: dist/*
@@ -1208,7 +1208,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout (for the composite action)
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
         with: { persist-credentials: false }
 
       - name: Summarise run

--- a/.github/workflows/unsloth-repin-bot.yml
+++ b/.github/workflows/unsloth-repin-bot.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       # Without this, checkout leaves a github.com extraheader carrying
       # GITHUB_TOKEN, which would win over the REPIN_TOKEN in our push URLs.
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
         with: { persist-credentials: false }
 
       - name: Resolve base tag


### PR DESCRIPTION
The `unsloth-*` workflows were the last tag-pinned Actions we run: 42 of 56 references resolved through a moving major tag such as `actions/checkout@v6`. The other three repos (`unsloth`, `unsloth-zoo`, `notebooks`) are already SHA-pinned, so this closes the gap.

It matters more here than it would elsewhere. Every unpinned reference sat in a workflow that either holds a cross-repository PAT (`REPIN_TOKEN`, `WHISPER_DISPATCH_TOKEN`) or runs with `contents: write` and publishes the prebuilt binaries our users download. A moved tag on any of those actions would execute with push access to this repo and land in a release.

### Why this cannot change behaviour

Each SHA is the commit that the corresponding major tag points at **right now**, so the workflows run exactly the same code before and after. No version is bumped.

| action | tag | pinned commit | tags at that commit |
| --- | --- | --- | --- |
| `actions/checkout` | v6 | `d23441a` | v6.1.0, v6 |
| `actions/upload-artifact` | v6 | `b7c566a` | v6.0.0, v6 |
| `actions/download-artifact` | v6 | `018cc2c` | v6.0.0, v6 |
| `actions/cache/save` | v6 | `55cc834` | v6.1.0, v6 |
| `actions/setup-python` | v6 | `ece7cb0` | v6.3.0, v6 |

Checks run before pushing:

- All 42 changed lines are `uses:` lines. `git diff` is 42 insertions, 42 deletions, nothing else.
- Every pinned commit resolves on its action repository, and the referenced manifest exists at that commit, including `save/action.yml` for the `actions/cache/save` subaction.
- All 12 workflows parse, and `actionlint` reports nothing new. Its one remaining complaint, the custom `windows-2025-vs2026` runner label, predates this branch and is on a `runs-on:` line.
- Only `unsloth-*.yml` files are touched. No upstream llama.cpp workflow changes, so this costs nothing at the next repin.