### PR TITLE
Prebuilt: pick the base tag by shape, upstream now flags b#### prerelease

### DIFF
--- a/.github/workflows/unsloth-pin-preflight.yml
+++ b/.github/workflows/unsloth-pin-preflight.yml
@@ -51,8 +51,10 @@ jobs:
           set -uo pipefail
           AGE_H="${UNSLOTH_LLAMA_MIN_RELEASE_AGE_HOURS:-6}"
           CUTOFF="$(date -u -d "-${AGE_H} hours" +%s)"
+          # Same base tag the nightly resolves: newest aged b#### build.
+          # Upstream marks those prerelease since 08-21, so match the tag shape.
           BASE="$(gh api 'repos/ggml-org/llama.cpp/releases?per_page=100' \
-            --jq "[.[] | select(.draft==false and .prerelease==false) | select((.published_at|fromdateiso8601) <= ${CUTOFF})] | max_by(.published_at|fromdateiso8601) | .tag_name")"
+            | jq -r --argjson cutoff "$CUTOFF" '[.[] | select(.draft==false) | select(.tag_name|test("^b[0-9]+$")) | select((.published_at|fromdateiso8601) <= $cutoff)] | max_by(.published_at|fromdateiso8601) | .tag_name')"
           if [ -z "$BASE" ] || [ "$BASE" = "null" ]; then
             echo "::warning::no aged upstream release found; skipping"
             echo "status=skip" >> "$GITHUB_OUTPUT"; exit 0

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -146,15 +146,18 @@ jobs:
           fi
           [ -n "$AGE_H" ] || AGE_H="${UNSLOTH_LLAMA_MIN_RELEASE_AGE_HOURS:-6}"
           if [ "$REQ" = "latest" ]; then
-            # Newest published (non-draft, non-prerelease) release that has been
-            # public for >= AGE_H hours -- the supply-chain aging window. GitHub
-            # does not guarantee the list order, so pick the max by published_at
+            # Newest published b#### build release that has been public for
+            # >= AGE_H hours -- the supply-chain aging window. GitHub does not
+            # guarantee the list order, so pick the max by published_at
             # explicitly rather than trusting `first`.
+            # Select on the tag shape, not on prerelease: since 08-21 upstream
+            # marks the b#### builds prerelease and keeps that flag clear only
+            # for the semver v#.#.# releases, which are not what we build.
             CUTOFF="$(date -u -d "-${AGE_H} hours" +%s)"
             BASE="$(gh api 'repos/ggml-org/llama.cpp/releases?per_page=100' \
-              --jq "[.[] | select(.draft==false and .prerelease==false) | select((.published_at|fromdateiso8601) <= ${CUTOFF})] | max_by(.published_at|fromdateiso8601) | .tag_name")"
+              | jq -r --argjson cutoff "$CUTOFF" '[.[] | select(.draft==false) | select(.tag_name|test("^b[0-9]+$")) | select((.published_at|fromdateiso8601) <= $cutoff)] | max_by(.published_at|fromdateiso8601) | .tag_name')"
             if [ -z "$BASE" ] || [ "$BASE" = "null" ]; then
-              echo "refusing: no ggml-org release older than ${AGE_H}h in the last 100 releases" >&2
+              echo "refusing: no ggml-org b#### release older than ${AGE_H}h in the last 100 releases" >&2
               exit 1
             fi
             echo "selected $BASE (aged >= ${AGE_H}h)"

--- a/.github/workflows/unsloth-repin-bot.yml
+++ b/.github/workflows/unsloth-repin-bot.yml
@@ -51,8 +51,10 @@ jobs:
           set -euo pipefail
           AGE_H="${UNSLOTH_LLAMA_MIN_RELEASE_AGE_HOURS:-6}"
           CUTOFF="$(date -u -d "-${AGE_H} hours" +%s)"
+          # Same base tag the nightly resolves: newest aged b#### build.
+          # Upstream marks those prerelease since 08-21, so match the tag shape.
           BASE="$(gh api 'repos/ggml-org/llama.cpp/releases?per_page=100' \
-            --jq "[.[] | select(.draft==false and .prerelease==false) | select((.published_at|fromdateiso8601) <= ${CUTOFF})] | max_by(.published_at|fromdateiso8601) | .tag_name")"
+            | jq -r --argjson cutoff "$CUTOFF" '[.[] | select(.draft==false) | select(.tag_name|test("^b[0-9]+$")) | select((.published_at|fromdateiso8601) <= $cutoff)] | max_by(.published_at|fromdateiso8601) | .tag_name')"
           if [ -z "$BASE" ] || [ "$BASE" = "null" ]; then
             echo "::warning::no aged upstream release found; nothing to repin onto"
             echo "base=" >> "$GITHUB_OUTPUT"; exit 0


### PR DESCRIPTION
The nightly has failed in `Resolve tag` on every scheduled run since 08-21, e.g. [run 32897191644](https://github.com/unslothai/llama.cpp/actions/runs/32897191644):

```
selected v0.3.0 (aged >= 6h)
refusing non-release tag 'v0.3.0'
```

Upstream changed how it labels releases. The `b####` build tags are now published with `prerelease: true`, and the only releases left with that flag clear are the new semver ones (`v0.2.0`, `v0.3.0`). `b10549` on 08-21 was the last build tag that was not a prerelease.

That breaks the base tag resolver: it picks the newest non-draft, non-prerelease release, which is now `v0.3.0`, and the `^b[0-9]+$` guard on the next line rejects it. The two filters no longer have anything in common, so it fails every time.

Select on the tag shape instead of the prerelease flag, which is what the guard already wanted. The aging window and the draft filter are unchanged. Against the current release list this resolves `b10630`.

The same resolver is copied in the pin preflight and the repin bot, so all three are updated together. The deadman check reads our own releases, which are still published non-prerelease, so it is left alone.
