### PR TITLE
Prebuilt: repin #24423 and #25731 onto carry branches

### DIFF
--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -19,7 +19,7 @@
   ],
   "prs": [
     "https://github.com/unslothai/llama.cpp/pull/107/commits/74acc40c37ae2eb36031981feda392b793944f72",
-    "https://github.com/unslothai/llama.cpp/pull/108/commits/60007bad6347a68bb662a2d490f20d383cad2678",
+    "https://github.com/unslothai/llama.cpp/pull/108/commits/27278df7000ade4a638d044202dbe82975421df6",
     "https://github.com/unslothai/llama.cpp/pull/70/commits/edfd4c1a3b7a653303a85257ddac2a1f3ce39a2f",
     "https://github.com/unslothai/llama.cpp/pull/91/commits/c86ed269986f2dced6325c5c58bda966a2e2ead1",
     "https://github.com/unslothai/llama.cpp/pull/95/commits/3db8cb5b2e9bf291057b9f19960e8601a162da81"

--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -18,8 +18,8 @@
     "tag + pins), so keep its pin listed until the change lands upstream."
   ],
   "prs": [
-    "https://github.com/ggml-org/llama.cpp/pull/24423/commits/daca8075d871483545dd85d58ce11970b304b541",
-    "https://github.com/ggml-org/llama.cpp/pull/25731/commits/c44c9a11a77cf47a24e69d79504bcbddf9f69017",
+    "https://github.com/unslothai/llama.cpp/pull/107/commits/74acc40c37ae2eb36031981feda392b793944f72",
+    "https://github.com/unslothai/llama.cpp/pull/108/commits/60007bad6347a68bb662a2d490f20d383cad2678",
     "https://github.com/unslothai/llama.cpp/pull/70/commits/edfd4c1a3b7a653303a85257ddac2a1f3ce39a2f",
     "https://github.com/unslothai/llama.cpp/pull/91/commits/c86ed269986f2dced6325c5c58bda966a2e2ead1",
     "https://github.com/unslothai/llama.cpp/pull/95/commits/3db8cb5b2e9bf291057b9f19960e8601a162da81"


### PR DESCRIPTION
The nightly has been failing in the merge loop since the aged base moved past `b10549`. Two third-party pins stopped merging:

- `ggml-org#24423` (DiffusionGemma) conflicted in `common/arg.cpp`
- `ggml-org#25731` (TML Inkling) conflicted in five files

The loop stops at the first conflict, so this did not just drop those two, it dropped the whole mix: `#70`, `#91` and `#95` all merge cleanly and were never applied.

Neither upstream PR can be repinned to a newer author commit. Both pins already equal their PR's current head, both are `mergeable_state=dirty` against upstream master too, and the authors have not touched them since 08-10 and 08-17. So both move to carry branches, following #99:

```
-  .../ggml-org/llama.cpp/pull/24423/commits/daca8075d871483545dd85d58ce11970b304b541
+  .../unslothai/llama.cpp/pull/107/commits/74acc40c37ae2eb36031981feda392b793944f72
-  .../ggml-org/llama.cpp/pull/25731/commits/c44c9a11a77cf47a24e69d79504bcbddf9f69017
+  .../unslothai/llama.cpp/pull/108/commits/60007bad6347a68bb662a2d490f20d383cad2678
```

The conflict resolutions and their verification are documented on #107 and #108. Both carries also needed one fix each for an upstream API change that did *not* conflict textually and so only showed up at build time: `RESIZE_ALGO_BICUBIC_PILLOW` was deleted upstream (#108), and the diffusion visual server had to move to the new `common_json` wrapper (#107). The second one matters here because the prebuilt workflows build the diffusion binaries best-effort and never fail the job, so it would have shipped bundles quietly missing them.

A side benefit: both pins are now fork-owned, so `repin.py` can maintain them automatically when the base tag moves, instead of emitting `third-party` and asking the author to merge master.

## Verification

Replayed the merge loop from `unsloth-prebuilt.yml` against the aged base, in `pr-set.json` order:

```
base: b10630

CLEAN                    unslothai/llama.cpp#107  74acc40c37
CLEAN                    unslothai/llama.cpp#108  60007bad63
CLEAN (additive resolve) unslothai/llama.cpp#70   edfd4c1a3b
CLEAN                    unslothai/llama.cpp#91   c86ed26998
CLEAN                    unslothai/llama.cpp#95   3db8cb5b2e
```

Each pin was also probed in isolation onto the bare tag, so a clean result is not hiding an interaction between pins. All five are clean both ways.
