### PR TITLE
Automate more of the pinned-PR merge treadmill

### DIFF
--- a/.github/workflows/unsloth-pin-preflight.yml
+++ b/.github/workflows/unsloth-pin-preflight.yml
@@ -19,6 +19,11 @@ on:
     paths:
       - scripts/unsloth/pr-set.json
   workflow_dispatch:
+    inputs:
+      cmake_extra:
+        description: 'Extra cmake flags for the compile gate, e.g. -DGGML_CUDA=ON'
+        required: false
+        default: ''
 
 permissions:
   # write, not read: the mirror step pushes refs/pins/<sha>. With read it
@@ -60,6 +65,7 @@ jobs:
             echo "status=skip" >> "$GITHUB_OUTPUT"; exit 0
           fi
           echo "base $BASE"
+          echo "base=$BASE" >> "$GITHUB_OUTPUT"
 
           git clone -q --filter=blob:none https://github.com/ggml-org/llama.cpp.git scratch
           cd scratch
@@ -170,6 +176,78 @@ jobs:
             echo 'ALERT_EOF'
           } >> "$GITHUB_OUTPUT"
 
+      # Merging is not building. Upstream deleting an enum value a pin still
+      # names, or changing a signature a pin still calls the old way, merges
+      # perfectly cleanly and then does not compile. Both shipped on 08-26, and
+      # the nightly is otherwise the first thing that ever compiles the mix --
+      # 3.5h after this job, with 39 build jobs already burning.
+      - name: ccache
+        if: ${{ steps.p.outputs.status == 'success' }}
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03  # v1.2.23
+        with:
+          key: preflight-cpu-${{ steps.p.outputs.base }}
+          restore-keys: |
+            preflight-cpu
+          append-timestamp: false
+          variant: ccache
+          max-size: 2G
+
+      - name: Compile the merged tree
+        id: compile
+        if: ${{ steps.p.outputs.status == 'success' }}
+        working-directory: scratch
+        env:
+          # CUDA/Metal/Vulkan/HIP are deliberately off: this is a 4 vCPU runner
+          # and the point is a fast answer, not full coverage. See the summary
+          # the alert prints for what that leaves uncovered.
+          EXTRA: ${{ github.event.inputs.cmake_extra }}
+        run: |
+          set -uo pipefail
+          # EXAMPLES=ON and TOOLS=ON are both load-bearing: the two real breaks
+          # were in tools/mtmd/clip.cpp and examples/diffusion-gemma-server/.
+          # The nightly's own CPU child builds with EXAMPLES=OFF and compiles
+          # the diffusion targets in a step that never fails the job, which is
+          # exactly why one of them would have shipped silently.
+          if ! cmake -S . -B build -G Ninja \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DGGML_NATIVE=OFF \
+              -DGGML_CUDA=OFF \
+              -DGGML_CPU_ALL_VARIANTS=OFF \
+              -DGGML_RPC=ON \
+              -DLLAMA_BUILD_TESTS=OFF \
+              -DLLAMA_BUILD_EXAMPLES=ON \
+              -DLLAMA_BUILD_TOOLS=ON \
+              -DLLAMA_BUILD_SERVER=ON \
+              -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+              ${EXTRA:-} > configure.log 2>&1; then
+            # A configure failure is usually the runner, not the code. Say so
+            # and stay green: a gate that cries wolf is a gate people mute.
+            echo "::warning::preflight compile could not configure; not treating this as a pin failure"
+            tail -30 configure.log
+            echo "status=skip" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if cmake --build build --config Release 2>&1 | tee build.log | tail -40; then
+            echo "status=success" >> "$GITHUB_OUTPUT"
+            echo "details=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "status=failure" >> "$GITHUB_OUTPUT"
+          {
+            echo 'details<<ALERT_EOF'
+            echo "The pins merge onto \`${{ steps.p.outputs.base }}\` but the merged tree does not compile."
+            echo "Tonight's nightly will fail unless a pin is fixed or dropped."
+            echo
+            echo '```'
+            grep -E 'error|Error' build.log | head -20
+            echo '```'
+            echo
+            echo "Checked: CPU only, examples + tools + server, RPC on."
+            echo "NOT checked: CUDA, Metal, Vulkan, HIP, SYCL, any runtime behaviour."
+            echo 'ALERT_EOF'
+          } >> "$GITHUB_OUTPUT"
+
       - name: Alert
         if: ${{ steps.p.outputs.status != 'skip' }}
         uses: ./.github/actions/prebuilt-alert
@@ -178,6 +256,16 @@ jobs:
           key: llama-pin-preflight
           title: 'Pinned PRs no longer merge onto the current base tag'
           details: ${{ steps.p.outputs.details }}
+          token: ${{ github.token }}
+
+      - name: Alert on a merged tree that does not compile
+        if: ${{ steps.compile.outputs.status == 'success' || steps.compile.outputs.status == 'failure' }}
+        uses: ./.github/actions/prebuilt-alert
+        with:
+          status: ${{ steps.compile.outputs.status }}
+          key: llama-pin-compile
+          title: 'Pins merge but the merged tree does not compile'
+          details: ${{ steps.compile.outputs.details }}
           token: ${{ github.token }}
 
       # The probe reports through its output, so without this the run still
@@ -189,4 +277,12 @@ jobs:
         if: ${{ steps.p.outputs.status == 'failure' }}
         run: |
           echo "::error::pins do not merge onto the current base tag; see the alert above"
+          exit 1
+
+      # Same reason as above: prebuilt-alert always exits 0, so without this the
+      # run stays green and the repin bot never sees a failed workflow_run.
+      - name: Fail the run when the merged tree does not compile
+        if: ${{ steps.compile.outputs.status == 'failure' }}
+        run: |
+          echo "::error::pins merge but the merged tree does not compile; see the alert above"
           exit 1

--- a/.github/workflows/unsloth-pin-preflight.yml
+++ b/.github/workflows/unsloth-pin-preflight.yml
@@ -208,12 +208,21 @@ jobs:
           # The nightly's own CPU child builds with EXAMPLES=OFF and compiles
           # the diffusion targets in a step that never fails the job, which is
           # exactly why one of them would have shipped silently.
+          #
+          # LLAMA_FATAL_WARNINGS=ON is what the macOS release leg configures, and
+          # cmake/common.cmake turns it into -Werror for GNU and Clang alike, so
+          # this gcc build reproduces the mechanism rather than approximating it.
+          # Without it the gate is blind to a whole class: an unused variable in
+          # a pinned arch built clean here and on every Linux leg, then failed
+          # both macOS legs and sank a four-hour release that had already
+          # produced 39 green jobs.
           if ! cmake -S . -B build -G Ninja \
               -DCMAKE_BUILD_TYPE=Release \
               -DGGML_NATIVE=OFF \
               -DGGML_CUDA=OFF \
               -DGGML_CPU_ALL_VARIANTS=OFF \
               -DGGML_RPC=ON \
+              -DLLAMA_FATAL_WARNINGS=ON \
               -DLLAMA_BUILD_TESTS=OFF \
               -DLLAMA_BUILD_EXAMPLES=ON \
               -DLLAMA_BUILD_TOOLS=ON \

--- a/.github/workflows/unsloth-pr-set-lint.yml
+++ b/.github/workflows/unsloth-pr-set-lint.yml
@@ -15,9 +15,13 @@ on:
   push:
     paths:
       - scripts/unsloth/pr-set.json
+      - scripts/unsloth/additive_merge.py
+      - scripts/unsloth/test_additive_merge.py
   pull_request:
     paths:
       - scripts/unsloth/pr-set.json
+      - scripts/unsloth/additive_merge.py
+      - scripts/unsloth/test_additive_merge.py
 
 permissions:
   contents: read
@@ -81,3 +85,14 @@ jobs:
           done < <(jq -r '.prs[] | if type == "string" then {url: ., required: true} else . end
                           | "\(.url)\t\(if .required == null then true else .required end)"' "$FILE" | tr '\t' ' ')
           exit "$fail"
+
+  resolver-tests:
+    name: additive_merge self-check
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
+      # additive_merge.py auto-resolves conflicts in the nightly's own merge
+      # loop, so a regression here lands in a release build. The suite builds
+      # real git conflicts and asserts on both what it resolves and what it
+      # must keep refusing.
+      - run: python3 scripts/unsloth/test_additive_merge.py

--- a/.github/workflows/unsloth-repin-bot.yml
+++ b/.github/workflows/unsloth-repin-bot.yml
@@ -77,8 +77,13 @@ jobs:
             --markdown "${RUNNER_TEMP}/repin.md"
           CHANGED="$(jq -r '.changed' "${RUNNER_TEMP}/repin.json")"
           BLOCKED="$(jq -r '[.results[] | select(.action == "conflict" or .action == "third-party")] | length' "${RUNNER_TEMP}/repin.json")"
+          # Kept apart from BLOCKED: these did not conflict, so there is no
+          # merge for anyone to resolve. Reporting them as pins-needing-a-human
+          # is what let a fetch bug look like ordinary churn for weeks.
+          ERRORED="$(jq -r '[.results[] | select(.action == "error")] | length' "${RUNNER_TEMP}/repin.json")"
           echo "changed=$CHANGED" >> "$GITHUB_OUTPUT"
           echo "blocked=$BLOCKED" >> "$GITHUB_OUTPUT"
+          echo "errored=$ERRORED" >> "$GITHUB_OUTPUT"
 
       - name: Push the merged branches and open the PR
         id: push
@@ -159,6 +164,7 @@ jobs:
         env:
           CHANGED: ${{ steps.repin.outputs.changed }}
           BLOCKED: ${{ steps.repin.outputs.blocked }}
+          ERRORED: ${{ steps.repin.outputs.errored }}
           OUTCOME: ${{ steps.repin.outcome }}
           MODE: ${{ steps.push.outputs.mode }}
           PR: ${{ steps.push.outputs.pr }}
@@ -193,6 +199,12 @@ jobs:
               STATUS=failure
               echo
               echo "${BLOCKED} pin(s) need a human, see the table above."
+            fi
+            if [ "${ERRORED:-0}" != "0" ]; then
+              STATUS=failure
+              echo
+              echo "${ERRORED} pin(s) failed without conflicting. That is a bug in the tooling or a"
+              echo "missing object, not a merge to resolve; read the message before hand-merging anything."
             fi
             echo 'ALERT_EOF'
           } >> "$GITHUB_OUTPUT"

--- a/scripts/unsloth/additive_merge.py
+++ b/scripts/unsloth/additive_merge.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -30,6 +31,16 @@ OURS = "<<<<<<< "
 BASE = "||||||| "
 SEP = "======="
 THEIRS = ">>>>>>> "
+
+# A line that closes a block and nothing else. Two sides that both append a
+# block collide on it without meaning the same thing.
+DELIMITER_RE = re.compile(r"^[}\)\];,]+$")
+
+VERSION_RE = re.compile(r"^#define\s+(RPC_PROTO_(?:MAJOR|MINOR|PATCH)_VERSION)\s+(\d+)\s*$")
+OP_ENUM_OPEN = "    enum ggml_op {"
+OP_ENUM_CLOSE = "    };"
+OP_MEMBER_RE = re.compile(r"^\s*(GGML_OP_[A-Z0-9_]+)\s*(=\s*[0-9]+\s*)?,\s*(//.*)?$")
+RPC_ASSERT_RE = re.compile(r"static_assert\(GGML_OP_COUNT == (\d+)")
 
 
 class Unresolvable(Exception):
@@ -87,8 +98,60 @@ def nonblank(lines: list[str]) -> list[str]:
     return [ln.strip() for ln in lines if ln.strip()]
 
 
-def resolve_region(ours: list[str], base: list[str], theirs: list[str]) -> list[str]:
-    """Return the union, or raise if this region is not a pure add/add."""
+def is_delimiter(line: str) -> bool:
+    """A closing brace / paren / semicolon and nothing else."""
+    s = line.strip()
+    return s == "#endif" or bool(DELIMITER_RE.match(s))
+
+
+def code_only(line: str) -> str:
+    """Drop // comments and the contents of quotes, so braces inside them do not count."""
+    out = []
+    quote = ""
+    i = 0
+    while i < len(line):
+        c = line[i]
+        if quote:
+            if c == "\\":
+                i += 2
+                continue
+            if c == quote:
+                quote = ""
+        elif c in "\"'":
+            quote = c
+        elif c == "/" and i + 1 < len(line) and line[i + 1] == "/":
+            break
+        else:
+            out.append(c)
+        i += 1
+    return "".join(out)
+
+
+def brace_balanced(lines: list[str]) -> bool:
+    """Every brace this text opens, it also closes. Blocks only, never fragments."""
+    depth = 0
+    for ln in lines:
+        for c in code_only(ln):
+            if c == "{":
+                depth += 1
+            elif c == "}":
+                depth -= 1
+                if depth < 0:
+                    return False
+    return depth == 0
+
+
+def resolve_region(
+    ours: list[str],
+    base: list[str],
+    theirs: list[str],
+    elsewhere: frozenset[str] = frozenset(),
+) -> list[str]:
+    """Return the union, or raise if this region is not a pure add/add.
+
+    `elsewhere` holds the file's lines outside every conflict, used to tell an
+    idiom the file already repeats from the construct actually being added.
+    """
     if nonblank(base):
         raise Unresolvable(
             "merge base is not empty, so at least one side edited existing text"
@@ -101,29 +164,151 @@ def resolve_region(ours: list[str], base: list[str], theirs: list[str]) -> list[
         # Both sides added byte-identical text; one copy is the resolution.
         return list(ours)
     shared = set(nonblank(ours)) & set(nonblank(theirs))
-    if shared:
-        # Overlapping content is the signature of one construct added twice,
-        # not two independent additions. Unioning it would duplicate code.
+    # A shared line only proves "one change made twice" when it is distinctive.
+    # A closing brace is not, and neither is a line the file already repeats
+    # outside this conflict: both sides writing `common_chat_params data;` means
+    # they both wrote a function of that file's usual shape, not the same one.
+    distinctive = sorted(s for s in shared if not is_delimiter(s) and s not in elsewhere)
+    if distinctive:
         raise Unresolvable(
             "both sides add the same line(s), so this is one change made twice: "
-            + ", ".join(sorted(shared)[:3])
+            + ", ".join(distinctive[:3])
         )
-    # Upstream first, then ours: the same order a human repin produces.
+    if shared and not (brace_balanced(ours) and brace_balanced(theirs)):
+        # Sides overlap and at least one is not a whole block, so the union
+        # would splice two fragments together.
+        raise Unresolvable(
+            "sides share a line and one of them is not brace-balanced, "
+            "so this is not two complete blocks"
+        )
+    # Upstream first, then ours. Order is arbitrary for disjoint additions;
+    # real repins have gone both ways.
     return list(theirs) + list(ours)
 
 
-def decide_file(path: Path) -> tuple[str, list[dict]]:
+def parse_versions(lines: list[str]) -> dict[str, tuple[int, str]] | None:
+    """{macro: (value, source line)} if the region is only version defines."""
+    out: dict[str, tuple[int, str]] = {}
+    for ln in lines:
+        if not ln.strip():
+            continue
+        m = VERSION_RE.match(ln.strip())
+        if not m:
+            return None
+        out[m.group(1)] = (int(m.group(2)), ln)
+    return out or None
+
+
+def three_way(ours: int, base: int, theirs: int) -> int | None:
+    """The side that moved, or None when both moved differently."""
+    if ours == theirs:
+        return ours
+    if ours == base:
+        return theirs
+    if theirs == base:
+        return ours
+    return None
+
+
+def ggml_op_count(repo: Path) -> int:
+    """Count enum ggml_op members in the merged tree. Raises if the shape is unfamiliar."""
+    header = repo / "ggml" / "include" / "ggml.h"
+    try:
+        lines = header.read_text(encoding="utf-8", errors="surrogateescape").splitlines()
+    except OSError as e:
+        raise Unresolvable(f"cannot read {header.name} to recount the ops: {e}")
+    try:
+        start = lines.index(OP_ENUM_OPEN)
+    except ValueError:
+        raise Unresolvable("could not find `enum ggml_op {` to recount the ops")
+    count = 0
+    for ln in lines[start + 1:]:
+        if ln == OP_ENUM_CLOSE:
+            # GGML_OP_COUNT is the last member and names the count of the rest.
+            return count - 1
+        if not ln.strip() or ln.strip().startswith("//"):
+            continue
+        if not OP_MEMBER_RE.match(ln):
+            # A #if, or two members on one line: stop rather than miscount.
+            raise Unresolvable(f"unexpected line in enum ggml_op, not recounting: {ln.strip()!r}")
+        count += 1
+    raise Unresolvable("enum ggml_op is not terminated")
+
+
+def resolve_rpc_version(
+    ours: list[str], base: list[str], theirs: list[str], repo: Path, whole_file: str
+) -> list[str]:
+    """Merge the RPC protocol version triple field by field.
+
+    Each field moved on at most one side, so ordinary three-way merge settles it
+    without needing to know the project's bump convention. Refuses otherwise.
+    """
+    vo, vb, vt = parse_versions(ours), parse_versions(base), parse_versions(theirs)
+    if not (vo and vb and vt):
+        raise Unresolvable("not a pure RPC version block")
+    if not (set(vo) == set(vb) == set(vt)):
+        raise Unresolvable("the two sides define different version macros")
+
+    out = []
+    for macro in vb:
+        merged = three_way(vo[macro][0], vb[macro][0], vt[macro][0])
+        if merged is None:
+            raise Unresolvable(f"{macro} moved on both sides ({vo[macro][0]} vs {vt[macro][0]})")
+        if macro.endswith("MAJOR_VERSION") and merged != vb[macro][0]:
+            # A major bump resets the other two, and how that interacts with the
+            # other side's bump is a judgement call.
+            raise Unresolvable("the RPC major version changed; resolve this one by hand")
+        # Keep the line from whichever side supplied the value, so the column
+        # alignment in this header survives.
+        src = vo[macro][1] if merged == vo[macro][0] else vt[macro][1]
+        out.append(src)
+
+    # The neighbouring static_assert pins the op count. It usually merges on its
+    # own, so check it rather than rewrite it: a stale count here is exactly the
+    # silent wire-protocol mismatch this file exists to prevent.
+    found = RPC_ASSERT_RE.search(whole_file)
+    if found:
+        actual = ggml_op_count(repo)
+        if int(found.group(1)) != actual:
+            raise Unresolvable(
+                f"static_assert says GGML_OP_COUNT == {found.group(1)} but the merged "
+                f"enum has {actual}; fix the assert by hand"
+            )
+    return out
+
+
+def decide_file(path: Path, repo: Path = Path(".")) -> tuple[str, list[dict]]:
     """Return the resolved content and a per-hunk record, without writing."""
-    lines = path.read_text(encoding="utf-8", errors="surrogateescape").splitlines(keepends=True)
+    text = path.read_text(encoding="utf-8", errors="surrogateescape")
+    lines = text.splitlines(keepends=True)
     regions = parse_conflicts(lines)
     if not regions:
         raise Unresolvable("no conflict markers found")
+
+    # Everything the file says outside its conflicts. A line repeated here is an
+    # idiom of the file, not evidence that one construct was added twice.
+    elsewhere: set[str] = set()
+    cursor = 0
+    for start, end, *_ in regions:
+        elsewhere.update(nonblank(lines[cursor:start]))
+        cursor = end
+    elsewhere.update(nonblank(lines[cursor:]))
+    frozen = frozenset(elsewhere)
+
+    is_rpc_header = path.name == "ggml-rpc.h"
 
     out: list[str] = []
     prev = 0
     hunks = []
     for start, end, ours, base, theirs in regions:
-        resolution = resolve_region(ours, base, theirs)
+        try:
+            resolution = resolve_region(ours, base, theirs, frozen)
+        except Unresolvable:
+            if not is_rpc_header:
+                raise
+            # The version triple is an edit/edit by construction, so the add/add
+            # path can never take it.
+            resolution = resolve_rpc_version(ours, base, theirs, repo, text)
         out.extend(lines[prev:start])
         out.extend(resolution)
         prev = end
@@ -167,7 +352,7 @@ def main() -> int:
     pending: list[tuple[Path, str]] = []
     for f in files:
         try:
-            content, hunks = decide_file(repo / f)
+            content, hunks = decide_file(repo / f, repo)
             pending.append((repo / f, content))
             report["resolved"].append({"file": f, "hunks": hunks})
         except Unresolvable as e:

--- a/scripts/unsloth/repin.py
+++ b/scripts/unsloth/repin.py
@@ -112,9 +112,21 @@ def repin_one(pin: dict, base: str, work: Path) -> dict:
         return out
 
     repo = work / f"r{pin['num']}"
-    run(["git", "clone", "-q", "--filter=blob:none", "--no-checkout",
+    # A full clone, not --filter=blob:none. A merge needs the blobs of both
+    # sides, and a partial clone re-fetches them one at a time from the
+    # promisor -- which fails outright when the branch history references an
+    # object that has since been force-pushed away, since nothing can serve it.
+    # That failure looked exactly like a conflict for weeks.
+    run(["git", "clone", "-q", "--no-checkout",
          f"https://github.com/{pin['src']}.git", str(repo)])
     run(["git", "fetch", "-q", "--no-tags", "origin", pin["sha"]], cwd=repo, check=False)
+    # A PR from a fork keeps its history in the fork. refs/pull/N/head on the
+    # upstream repo reaches the tip but not every object behind it, so fetch the
+    # branch from the head repo too.
+    if head_repo and head_repo != pin["src"]:
+        run(["git", "fetch", "-q", "--no-tags",
+             f"https://github.com/{head_repo}.git", head_ref or pin["sha"]],
+            cwd=repo, check=False)
     r = run(["git", "fetch", "-q", "--no-tags",
              "https://github.com/ggml-org/llama.cpp.git",
              f"refs/tags/{base}:refs/tags/{base}"], cwd=repo, check=False)
@@ -142,25 +154,31 @@ def repin_one(pin: dict, base: str, work: Path) -> dict:
 
     if m.returncode != 0:
         report = work / f"res{pin['num']}.json"
-        rc = subprocess.run(
+        am = subprocess.run(
             [sys.executable, str(HERE / "additive_merge.py"),
              "--repo", str(repo), "--report", str(report)],
             capture_output=True, text=True,
-        ).returncode
+        )
+        rc = am.returncode
         res = json.loads(report.read_text()) if report.exists() else {}
         if rc != 0:
-            out["action"] = "conflict"
             refused = res.get("refused", [])
             out["files"] = [x["file"] for x in refused if x["file"] != "-"]
             if out["files"]:
+                out["action"] = "conflict"
                 out["note"] = "; ".join(f"`{x['file']}`: {x['reason']}" for x in refused)
             else:
-                # git refused the merge without leaving a single conflicted
-                # file, so the conflict report explains nothing. Its stderr is
-                # the only thing that does, and discarding it turns a
-                # diagnosable failure into "no conflicted files".
+                # No conflicted file means git did not actually conflict, so
+                # this is not something a human can resolve by editing code:
+                # a missing object, unrelated histories, a broken index, or
+                # additive_merge itself crashing. Calling that a conflict sent
+                # people looking for a merge to fix and hid a real bug for
+                # weeks, so it gets its own action.
+                out["action"] = "error"
                 tail = ((m.stderr or "") + (m.stdout or "")).strip().splitlines()
-                out["note"] = ("merge failed with no conflicts: " + " / ".join(tail[-3:])
+                if not tail:
+                    tail = ((am.stderr or "") + (am.stdout or "")).strip().splitlines()
+                out["note"] = ("merge failed without conflicting: " + " / ".join(tail[-3:])
                                if tail else "merge failed and git said nothing")
             run(["git", "merge", "--abort"], cwd=repo, check=False)
             return out
@@ -193,6 +211,8 @@ def markdown(base: str, results: list[dict]) -> str:
                 what += f" ({len(r['hunks'])} add/add hunk(s) resolved)"
         elif r["action"] == "conflict":
             what = f"**conflict, not resolvable automatically** -- {r['note']}"
+        elif r["action"] == "error":
+            what = f"**failed, not a conflict** -- {r['note']}"
         elif r["action"] == "third-party":
             what = f"not ours -- {r['note']}"
         else:
@@ -237,7 +257,9 @@ def main() -> int:
         try:
             r = repin_one(pin, args.base, work)
         except RuntimeError as e:
-            r = dict(pin, action="skip", note=f"error: {e}", new_sha="", files=[], hunks=[])
+            # Clone or another checked git call blew up. Not a conflict, and not
+            # a deliberate skip either.
+            r = dict(pin, action="error", note=f"error: {e}", new_sha="", files=[], hunks=[])
         results.append(r)
         print(f"{r['src']}#{r['num']}: {r['action']} {r['note']}".rstrip())
 

--- a/scripts/unsloth/test_additive_merge.py
+++ b/scripts/unsloth/test_additive_merge.py
@@ -61,7 +61,7 @@ txt = f.read_text()
 check("add/add resolves", rc == 0 and rep["ok"], rep)
 check("add/add unions both labels",
       "LLM_ARCH_DEEPSEEK4" in txt and "LLM_ARCH_INKLING" in txt and "<<<<" not in txt, txt)
-check("add/add puts upstream first (matches hand repin)",
+check("add/add puts upstream first (order is arbitrary, this pins it)",
       txt.index("DEEPSEEK4") < txt.index("INKLING"), txt)
 check("add/add stages the file",
       git(repo, "diff", "--name-only", "--diff-filter=U").stdout.strip() == "")
@@ -125,6 +125,100 @@ before = f.read_text()
 rc, rep = run(repo, "--dry-run")
 check("dry-run reports ok", rc == 0 and rep["ok"])
 check("dry-run does not touch the file", f.read_text() == before)
+
+# --- 6. both sides append a block, colliding only on `};` -------------------
+# The real shape from tools/mtmd/clip-model.h and ggml/src/ggml-backend-meta.cpp:
+# two unrelated structs added at the same anchor. Only the closing brace is shared.
+base = "struct keep {\n    int a;\n};\n"
+ours = "struct keep {\n    int a;\n};\n\nstruct mine {\n    int m;\n};\n"
+theirs = "struct keep {\n    int a;\n};\n\nstruct theirs {\n    int t;\n};\n"
+repo, f = make_conflict(base, ours, theirs)
+rc, rep = run(repo)
+txt = f.read_text()
+check("block append sharing only `};` resolves", rc == 0 and rep["ok"], rep)
+check("block append keeps both structs",
+      "struct mine" in txt and "struct theirs" in txt and "<<<<" not in txt, txt)
+check("block append does not duplicate the shared brace",
+      txt.count("struct mine") == 1 and txt.count("struct theirs") == 1, txt)
+
+# --- 7. shared line is boilerplate the file already repeats -----------------
+# common/chat.cpp: every init function opens with the same two lines, so both
+# sides adding a new one collide on boilerplate, not on one construct twice.
+boiler = "    common_chat_params data;\n    auto parser = mk();\n"
+base = ("static params init_a() {\n" + boiler + "}\n"
+        "static params init_b() {\n" + boiler + "}\n")
+ours = base + "static params init_mine() {\n" + boiler + "}\n"
+theirs = base + "static params init_theirs() {\n" + boiler + "}\n"
+repo, f = make_conflict(base, ours, theirs)
+rc, rep = run(repo)
+txt = f.read_text()
+check("shared boilerplate resolves", rc == 0 and rep["ok"], rep)
+check("shared boilerplate keeps both functions",
+      "init_mine" in txt and "init_theirs" in txt and "<<<<" not in txt, txt)
+
+# --- 8. one construct added twice: must STILL refuse ------------------------
+# tools/mtmd/mtmd-image.cpp: upstream landed its own copy of a helper we had
+# already written. The signature line appears nowhere else, so it is distinctive.
+base = "static void other() {\n}\n"
+ours = base + "static bool resize_pillow(\n        const img & i,\n        bool use_lanczos) {\n    return a;\n}\n"
+theirs = base + "static bool resize_pillow(\n        const img & i,\n        bool use_lanczos) {\n    return b;\n}\n"
+repo, f = make_conflict(base, ours, theirs)
+rc, rep = run(repo)
+check("one construct added twice still refuses", rc == 1 and not rep["ok"], rep)
+check("refusal names the distinctive line",
+      "use_lanczos" in json.dumps(rep) or "resize_pillow" in json.dumps(rep), rep)
+check("refused file keeps its markers", "<<<<" in f.read_text())
+
+# --- 9. RPC version triple: three-way merge per field -----------------------
+HDR = "#define RPC_PROTO_MAJOR_VERSION    5\n#define RPC_PROTO_MINOR_VERSION    {}\n#define RPC_PROTO_PATCH_VERSION    {}\n"
+
+
+def make_rpc_conflict(ours_v, theirs_v, base_v=(0, 0), ops=3):
+    """Same as make_conflict but the file is ggml-rpc.h next to a real ggml.h."""
+    d = Path(tempfile.mkdtemp(prefix="am_rpc_"))
+    git(d, "init", "-q", "-b", "main")
+    inc = d / "ggml" / "include"
+    inc.mkdir(parents=True)
+    members = "".join(f"        GGML_OP_{i},\n" for i in range(ops))
+    (inc / "ggml.h").write_text("    enum ggml_op {\n" + members + "        GGML_OP_COUNT,\n    };\n")
+    f = inc / "ggml-rpc.h"
+    tail = f'\nstatic_assert(GGML_OP_COUNT == {ops}, "x");\n'
+    f.write_text(HDR.format(*base_v) + tail)
+    git(d, "add", "-A"); git(d, "commit", "-qm", "base")
+    git(d, "checkout", "-qb", "side")
+    f.write_text(HDR.format(*theirs_v) + tail)
+    git(d, "add", "-A"); git(d, "commit", "-qm", "theirs")
+    git(d, "checkout", "-q", "main")
+    f.write_text(HDR.format(*ours_v) + tail)
+    git(d, "add", "-A"); git(d, "commit", "-qm", "ours")
+    git(d, "-c", "merge.conflictStyle=diff3", "merge", "side")
+    return d, f
+
+
+# upstream bumped minor, we bumped patch: each field moved on one side only
+repo, f = make_rpc_conflict(ours_v=(0, 1), theirs_v=(1, 0))
+rc, rep = run(repo)
+txt = f.read_text()
+check("rpc version triple resolves", rc == 0 and rep["ok"], rep)
+check("rpc takes minor from upstream and patch from us",
+      "MINOR_VERSION    1" in txt and "PATCH_VERSION    1" in txt and "<<<<" not in txt, txt)
+check("rpc keeps the major untouched", "MAJOR_VERSION    5" in txt, txt)
+
+# both sides moved the same field: nothing to merge, must refuse
+repo, f = make_rpc_conflict(ours_v=(0, 4), theirs_v=(0, 2))
+rc, rep = run(repo)
+check("rpc refuses when one field moved on both sides", rc == 1 and not rep["ok"], rep)
+check("rpc refusal says which field", "PATCH_VERSION" in json.dumps(rep), rep)
+
+# a stale op count is the silent wire mismatch this header exists to prevent
+repo, f = make_rpc_conflict(ours_v=(0, 1), theirs_v=(1, 0), ops=3)
+(repo / "ggml" / "include" / "ggml.h").write_text(
+    "    enum ggml_op {\n" + "".join(f"        GGML_OP_{i},\n" for i in range(4))
+    + "        GGML_OP_COUNT,\n    };\n")
+rc, rep = run(repo)
+check("rpc refuses when static_assert disagrees with the merged enum",
+      rc == 1 and not rep["ok"], rep)
+check("rpc says the count is stale", "GGML_OP_COUNT" in json.dumps(rep), rep)
 
 print()
 print(f"{len(FAILS)} failure(s)" + (": " + ", ".join(FAILS) if FAILS else ""))


### PR DESCRIPTION
Three changes to cut the manual resync work on pinned PR branches. `add-inkling` needed 10 resync merges in a month; I did one of them by hand yesterday and went looking for why the existing automation was not doing it.

## 1. `repin.py` was failing daily, and calling it a conflict

The repin bot works. On 08-25 it auto-repinned `#70` and `#95`. On the same run it said this about the other two:

```
ggml-org#24423: conflict merge failed with no conflicts: fatal: remote error:
  upload-pack: not our ref 2ed780ae99... / could not fetch 7b0249da97... from promisor remote
ggml-org#25731: ...same...
```

Note its own words: **"merge failed with no conflicts"**. That is not a conflict, it is the blobless clone failing to re-fetch an object. Of the three shas in that message, two are fetchable from both repos and `7b0249da97` exists in **neither**, which is what a force-pushed-away object looks like from a partial clone.

`repin_one()` cloned the pin URL's owner (`ggml-org`) with `--filter=blob:none`, so a PR whose branch lives in a fork has history the promisor cannot serve. Now it clones in full and also fetches from `head.repo.full_name`, which it already knew.

The more useful half: `L143-152` labelled **any** non-zero merge exit as `conflict`, including `additive_merge.py` itself crashing. A merge that leaves no conflicted file is not something a human can fix by editing code, so it now gets `action="error"`, its own row in the report, and its own count in the bot, separate from "pins need a human".

Honest limit: the original failure no longer reproduces. I A/B'd old and new clone flags against the same pin and base today and both reach a genuine conflict, so I have not demonstrated old-fails/new-succeeds. The reasoning about the mechanism is sound and a full clone removes the lazy-fetch path entirely, but it is untested against the live failure. The reclassification is the part I would defend hardest, and it stands on its own.

## 2. Preflight now compiles what it merged

Preflight proved only that pins *textually merge*. Nothing compiled the mix until the nightly published it, 3.5h later, with 39 build jobs already running. Both breakages I fixed on 08-26 merged perfectly cleanly:

- upstream deleted `RESIZE_ALGO_BICUBIC_PILLOW` while a pin still named it
- upstream put a `common_json` wrapper in front of nlohmann while a pin still called the old signature

Neither conflicted, so no amount of better conflict resolution would have caught either. The second is the nastier one: the prebuilt workflows build the diffusion example targets **best-effort and never fail the job**, so it would have shipped bundles quietly missing binaries.

New step after the merge probe, gated on it succeeding, building the already-merged `scratch/` tree. CPU only, `EXAMPLES=ON` and `TOOLS=ON` because those are what reach the two files that broke (the nightly's own CPU child uses `EXAMPLES=OFF`). ccache via the action already pinned in the CPU child.

Proved against both real breakages, each reintroduced in isolation and built with the gate's exact flags:

```
tools/mtmd/clip.cpp:1420: error: 'RESIZE_ALGO_BICUBIC_PILLOW' was not declared in this scope
common/json.h:148:      error: call of overloaded 'common_json_value(...)' is ambiguous
```

and the corrected carries build clean under the same flags (149/149).

A configure failure warns rather than failing the run; only a compile error goes red. The alert states what the gate did **not** check (CUDA, Metal, Vulkan, HIP, SYCL, anything at runtime) so a green result is not overread.

## 3. `additive_merge.py` resolves two more shapes

Measured over the real merge history of both pinned branches, the resolver already handled 16 of 31 conflicted files. Of the 15 refusals, 4 were false alarms.

**Shared lines.** It refused if both sides' additions shared *any* line. A shared line only proves "one construct added twice" when it is distinctive: a closing brace is not, and neither is a line the file already repeats outside the conflict. Both sides writing `common_chat_params data;` means they both wrote a function of that file's usual shape. Sides that overlap must also each be brace-balanced, so the union is two complete blocks and never two fragments.

**The RPC version triple** gets a three-way merge per field. Upstream bumps minor, a pin bumps patch, each field moved on one side only, so ordinary three-way settles it without encoding any bump convention. It refuses when a field moved on both sides or the major changed. The neighbouring `static_assert(GGML_OP_COUNT == N)` is checked against the merged enum rather than rewritten, because a stale count there is exactly the silent wire mismatch that header exists to prevent.

Validated against all five historical refusals using the human's actual resolution as ground truth:

| case | shared | verdict | what the human did |
|---|---|---|---|
| `clip-model.h` x2, `ggml-backend-meta.cpp` | `};` | resolve | exact union |
| `common/chat.cpp` | 3 lines, appear 11/10/10x elsewhere | resolve | exact union |
| `mtmd-image.cpp` | 3 lines, one appears **0x** elsewhere | **refuse** | took theirs, dropped ours -- the union would have been a redefinition |

On the RPC case it reproduces the hand resolution byte for byte, alignment included.

Net over the real corpus: files needing a human go from **15 to 10**, and the one case where the union would have been wrong is still refused.

These rules run in the nightly's resolve step too, so the safety bar is a release build. Both refuse on ambiguity, and item 2 means a bad union now has to survive a compile.

`test_additive_merge.py` gains cases for every shape above including the must-refuse one, and the suite is wired into CI, which it never was.
