### PR TITLE
Pin ggml-org#27742 (Qwen3.8-Flash-Next)

### DIFF
--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -22,6 +22,7 @@
     "https://github.com/unslothai/llama.cpp/pull/108/commits/27278df7000ade4a638d044202dbe82975421df6",
     "https://github.com/unslothai/llama.cpp/pull/70/commits/edfd4c1a3b7a653303a85257ddac2a1f3ce39a2f",
     "https://github.com/unslothai/llama.cpp/pull/91/commits/c86ed269986f2dced6325c5c58bda966a2e2ead1",
-    "https://github.com/unslothai/llama.cpp/pull/95/commits/3db8cb5b2e9bf291057b9f19960e8601a162da81"
+    "https://github.com/unslothai/llama.cpp/pull/95/commits/3db8cb5b2e9bf291057b9f19960e8601a162da81",
+    "https://github.com/unslothai/llama.cpp/pull/112/commits/e1a498876223efb9222cac2cdebdd81b6e14e307"
   ]
 }


### PR DESCRIPTION
Adds [ggml-org#27742](https://github.com/ggml-org/llama.cpp/pull/27742) (Qwen3.8-Flash-Next / qwen4exp) to the nightly pin set.

The pin points at the carry branch in #112, not at the upstream PR head. The upstream branch sits on `4d19b2876`, upstream master from about two hours ago, so pinning it directly would drag five unaged upstream commits into the nightly and void the `UNSLOTH_LLAMA_MIN_RELEASE_AGE_HOURS` window. #112 is the PR's own 18 commits replayed onto `b10631`, with its 24 files byte-identical to the upstream head.

Two extra commits on the carry exist only so the set composes. Merged after the inkling pin, the PR as written conflicted in `llama-kv-cache.cpp`, `llama-kv-cache.h` and `llama-model.cpp`, and none of it was resolvable by `additive_merge.py`: one region is a genuine edit/edit on the line inkling changes, and the add/add ones share a `for (int64_t j = 0; j < n_kv; ++j) {` that appears nowhere outside the conflict, so the resolver refuses it. Moving the `filter_idx` declaration off inkling's line and grouping the QSA methods at a different anchor removes all three, rather than leaving the nightly to hit a conflict nobody can resolve unattended.

Placed last in the list because it is the pin that was adapted to fit the others.

Verified against `b10631`:

- all six pins merge in list order, with only `additive_merge.py` resolutions, no hand edits
- the merged tree compiles clean, 567/567 targets, with the preflight gate's config plus `LLAMA_BUILD_TESTS=ON`
- `test-llama-archs` exits 0; `qwen4exp` reports OK, and inkling still reports its documented skip
- `e1a4988762` is in #112's commit list, so the nightly's pin membership gate passes
- the commit is mirrored to `refs/pins/e1a498876223efb9222cac2cdebdd81b6e14e307`

Merge #112 before this, or at least do not delete its branch while this pin is listed.
