### PR TITLE
Repin ggml-org#27742 onto the b10632 carry

### DIFF
--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -23,6 +23,6 @@
     "https://github.com/unslothai/llama.cpp/pull/70/commits/edfd4c1a3b7a653303a85257ddac2a1f3ce39a2f",
     "https://github.com/unslothai/llama.cpp/pull/91/commits/c86ed269986f2dced6325c5c58bda966a2e2ead1",
     "https://github.com/unslothai/llama.cpp/pull/95/commits/3db8cb5b2e9bf291057b9f19960e8601a162da81",
-    "https://github.com/unslothai/llama.cpp/pull/112/commits/e1a498876223efb9222cac2cdebdd81b6e14e307"
+    "https://github.com/unslothai/llama.cpp/pull/114/commits/ca5d0a1dd15d1abe09de0760d784239e9eac628b"
   ]
 }


### PR DESCRIPTION
Moves the qwen4exp pin from the #112 carry to the #114 carry, after two new commits on [ggml-org#27742](https://github.com/ggml-org/llama.cpp/pull/27742).

The upstream PR is now 20 commits on `4d19b2876`. #114 replays them onto `b10632`, the current aged base tag, so the nightly does not pick up the four unaged upstream commits the PR branch sits on. The PR's 21 files are byte-identical to its head.

Only one decoupling commit is needed this time. `llama: keep the qwen4exp top-k attention mask arch-local` moved the QSA input helpers out of `llama-kv-cache.cpp`, so the reordering #112 carried is no longer required; what remains is moving `filter_idx` and `needs_mem_idx` off the `llama-model.cpp` line the inkling arch edits.

Verified against `b10632`:

- all six pins merge in list order; five clean, `#70` via `additive_merge.py`, and the carry now merges clean with no resolution at all
- the merged tree compiles clean, 525/525 targets, with the preflight gate's config plus `LLAMA_BUILD_TESTS=ON`
- `test-llama-archs` exits 0, `qwen4exp` OK
- `ca5d0a1dd1` is in #114's commit list, so the pin membership gate passes
- mirrored to `refs/pins/ca5d0a1dd15d1abe09de0760d784239e9eac628b`

The old carry branch `qwen4exp-27742-b10631` and `refs/pins/e1a4988762` are left in place; nothing references them once this merges.
