### PR TITLE
Pin unslothai#116 (GLM-5-Next)

### DIFF
--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -23,6 +23,7 @@
     "https://github.com/unslothai/llama.cpp/pull/70/commits/edfd4c1a3b7a653303a85257ddac2a1f3ce39a2f",
     "https://github.com/unslothai/llama.cpp/pull/91/commits/c86ed269986f2dced6325c5c58bda966a2e2ead1",
     "https://github.com/unslothai/llama.cpp/pull/95/commits/3db8cb5b2e9bf291057b9f19960e8601a162da81",
-    "https://github.com/unslothai/llama.cpp/pull/114/commits/ca5d0a1dd15d1abe09de0760d784239e9eac628b"
+    "https://github.com/unslothai/llama.cpp/pull/114/commits/ca5d0a1dd15d1abe09de0760d784239e9eac628b",
+    "https://github.com/unslothai/llama.cpp/pull/118/commits/3766b41229c20249fd4d83d7ba297499d50e9b80"
   ]
 }


### PR DESCRIPTION
Adds [#116](https://github.com/unslothai/llama.cpp/pull/116) (GLM-5-Next / GLM-5.3-Flash) to the nightly pin set, via the carry in #118.

The pin points at the carry, not at `glm5next/public`. The PR branches off fork master, so its head carries 77 fork CI paths including `pr-set.json` itself; #118 is `b10632` plus the PR's 42 paths and nothing else, byte-identical to the PR head on all of them.

#118 is built on top of the qwen4exp carry rather than on `b10632` directly, because those two pins are not independent: both add a sparse-attention indexer cache and both declare the same `filter_idx` in `create_memory`, so a side-by-side merge declares it twice and the build stops. That composition is resolved once in #118 rather than attempted nightly. The consequence is recorded there: dropping the qwen4exp pin no longer drops its code.

Placed last, after the qwen4exp pin it depends on.

Verified against `b10632`:

- all seven pins merge in list order; six clean, `#70` via `additive_merge.py`, no hand resolution in the nightly path
- the merged tree compiles clean, 573/573 targets, with the preflight gate's config plus `LLAMA_BUILD_TESTS=ON`
- `test-llama-archs` exits 0; `glm5next` OK, `qwen4exp` OK, inkling's documented skip intact
- `3766b41229` is in #118's commit list, so the pin membership gate passes
- mirrored to `refs/pins/3766b41229c20249fd4d83d7ba297499d50e9b80`

Merge #118 first, or at least do not delete its branch while this pin is listed.
