### PR TITLE
Build the Linux release legs with -Werror

### DIFF
--- a/.github/workflows/unsloth-prebuilt-cpu.yml
+++ b/.github/workflows/unsloth-prebuilt-cpu.yml
@@ -119,6 +119,7 @@ jobs:
             -DGGML_BACKEND_DL=ON \
             -DGGML_CPU_ALL_VARIANTS=ON \
             -DGGML_RPC=ON \
+            -DLLAMA_FATAL_WARNINGS=ON \
             -DLLAMA_BUILD_TESTS=OFF \
             -DLLAMA_BUILD_EXAMPLES=OFF \
             -DLLAMA_BUILD_TOOLS=ON \

--- a/.github/workflows/unsloth-prebuilt-cuda.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda.yml
@@ -178,6 +178,7 @@ jobs:
             -DGGML_RPC=ON \
             -DGGML_CUDA=ON \
             -DGGML_CUDA_CUB_3DOT2=ON \
+            -DLLAMA_FATAL_WARNINGS=ON \
             -DLLAMA_BUILD_TESTS=OFF \
             -DLLAMA_BUILD_EXAMPLES=OFF \
             -DLLAMA_BUILD_TOOLS=ON \

--- a/.github/workflows/unsloth-prebuilt-vulkan.yml
+++ b/.github/workflows/unsloth-prebuilt-vulkan.yml
@@ -164,6 +164,7 @@ jobs:
             -DGGML_CPU_ALL_VARIANTS=ON \
             -DGGML_RPC=ON \
             -DGGML_VULKAN=ON \
+            -DLLAMA_FATAL_WARNINGS=ON \
             -DLLAMA_BUILD_TESTS=OFF \
             -DLLAMA_BUILD_EXAMPLES=OFF \
             -DLLAMA_BUILD_TOOLS=ON \


### PR DESCRIPTION
Adds `-DLLAMA_FATAL_WARNINGS=ON` to the three Linux release legs: CPU, CUDA and Vulkan.

## Why

An unused variable in a pinned arch compiled clean on every Linux leg, then failed both macOS legs and sank run `32989062368` after 39 green jobs and ~4 hours, publishing nothing. macOS was the only leg configuring `LLAMA_FATAL_WARNINGS=ON`, so it was the only one that could see that class of defect, and it sees it at the *end* of the run rather than the start.

## Verified before committing, not after

Each leg's configuration was built on the current seven-pin tree:

| leg | what the flag becomes | result |
|---|---|---|
| cpu | `gcc -Werror` | 558/558 targets, 0 errors, 0 warnings |
| cuda | `gcc -Werror` + nvcc `-Werror all-warnings` | 550/550 targets, 0 errors; 147/147 `.cu` carried the flag |
| vulkan | `gcc -Werror`, same host path as cpu | covered by the cpu run |

The CUDA case mattered most, because the flag is *not* the same everywhere. `ggml/src/ggml-cuda/CMakeLists.txt:213` turns it into `-Werror all-warnings` for nvcc, which is far more aggressive than the host `-Werror` already shipping on macOS. It passes, but it needed proving rather than assuming.

## Cost: none, and this is measured

`LLAMA_ALL_WARNINGS` is already `ON` by default (`CMakeLists.txt:117`), so the diagnostics were being computed either way; `-Werror` only changes their severity. It adds no analysis passes.

To confirm nothing reaches the shipped binaries, the same tree was built twice, identical config except the flag, and every object file byte-compared:

```
identical: 215   differing: 0
```

The compiler emits the same bytes or fails the build. Throughput and generation cannot move.

## What is deliberately NOT included

`unsloth-prebuilt-cuda-windows.yml` and `unsloth-prebuilt-rocm.yml` are untouched. There the flag becomes MSVC `/WX` or hipcc's `-Werror`, and neither can be exercised from a Linux box. Switching warnings to errors on a release leg without testing it trades a known gap for an unknown outage, on the very legs that take longest to fail.

Those two deserve a `publish=false` trial dispatch first. Happy to do that as a follow-up.

## Residual risk

Because only macOS previously used `-Werror`, a warning that the Linux legs used to tolerate will now fail them. That is the intended behaviour, but it is a new way for a release to go red, and the first occurrence will most likely be upstream's warning rather than ours.
