### PR TITLE
Repin qwen4exp (ggml-org#27742) onto b10639

### DIFF
--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -23,7 +23,7 @@
     "https://github.com/unslothai/llama.cpp/pull/70/commits/edfd4c1a3b7a653303a85257ddac2a1f3ce39a2f",
     "https://github.com/unslothai/llama.cpp/pull/91/commits/c86ed269986f2dced6325c5c58bda966a2e2ead1",
     "https://github.com/unslothai/llama.cpp/pull/95/commits/3db8cb5b2e9bf291057b9f19960e8601a162da81",
-    "https://github.com/unslothai/llama.cpp/pull/114/commits/ca5d0a1dd15d1abe09de0760d784239e9eac628b",
+    "https://github.com/unslothai/llama.cpp/pull/114/commits/c4ddc4805dbc12727897b354237bfd9225212b06",
     "https://github.com/unslothai/llama.cpp/pull/118/commits/3766b41229c20249fd4d83d7ba297499d50e9b80"
   ]
 }


### PR DESCRIPTION
Refreshes the qwen4exp carry pin. The upstream PR has grown from 20 to 27 commits since it was last pinned, and the aged base tag has moved from `b10632` to `b10639`.

### What changed

`scripts/unsloth/pr-set.json`, one line: the `#114` pin moves from `ca5d0a1dd1` to `c4ddc4805`.

The carry branch already carried all 27 upstream commits, including the `mem_size` removal that broke the macOS leg of the last release. Checked file by file: 22 of the 23 files the upstream PR touches are byte-identical between the carry and `ef9fa1ba1`. The one that differs is `src/llama-model.cpp`, and the whole difference is the deliberate reordering of the `filter_attn` / `filter_recr` declarations below `filter_idx` so `#118` (glm5next) can add its own without a double-declaration conflict. The qwen4exp lines themselves are identical.

So the only work here was the base bump: `b10639` merged into the carry with no conflicts, and it does not touch a single line of the feature.

### Verification

- `b10639` merges into the carry cleanly; the feature files (`src/models/qwen4exp.cpp`, `src/llama-memory-hybrid-idx.cpp`, `conversion/qwen4exp.py`) are unchanged by the bump.
- `ca5d0a1dd1`, the previously pinned commit, is still an ancestor of the new head. This is the reason the base was merged in rather than the 27 commits rebased onto it: `#118` is composed on top of that commit, and a rebase would have severed the relationship.
- Full build on `b10639` + the refreshed carry with `-DLLAMA_FATAL_WARNINGS=ON`: 554/554 targets, exit 0, zero warnings. `test-llama-archs` exits 0 with qwen4exp registered.
- Whole pin set replayed on `b10639` in order: `#107` ok, `#70` ok, `#91` ok, `#95` ok, `#114` ok, `#118` ok. `#118` still composes on the refreshed carry, which confirms the ancestry held.
- `c4ddc4805` is in `#114`'s commit list, and is mirrored to `refs/pins/c4ddc4805`.
- `qwen4exp-27742-b10632-upstream-base` fast-forwarded `b10632` to `b10639`, so `#114`'s diff is back to the 23 feature files rather than 47.

### Still outstanding

This does not unblock the nightly on its own. Pin `#108` conflicts on `b10639` in `ggml/include/ggml-rpc.h` (base `5/1/0`, upstream `6/0/0`, pin `5/1/1`, resolving to `6/0/1`), which is the same two-line resolution already landed on `ggml-org#25731` but on a different branch. That carry needs its own refresh.