### PR TITLE
Repin the Inkling carry (ggml-org#25731) onto b10639

### DIFF
--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -19,7 +19,7 @@
   ],
   "prs": [
     "https://github.com/unslothai/llama.cpp/pull/107/commits/74acc40c37ae2eb36031981feda392b793944f72",
-    "https://github.com/unslothai/llama.cpp/pull/108/commits/27278df7000ade4a638d044202dbe82975421df6",
+    "https://github.com/unslothai/llama.cpp/pull/108/commits/2c5b0007bca737c15c77217e864c072953a3fe2d",
     "https://github.com/unslothai/llama.cpp/pull/70/commits/edfd4c1a3b7a653303a85257ddac2a1f3ce39a2f",
     "https://github.com/unslothai/llama.cpp/pull/91/commits/c86ed269986f2dced6325c5c58bda966a2e2ead1",
     "https://github.com/unslothai/llama.cpp/pull/95/commits/3db8cb5b2e9bf291057b9f19960e8601a162da81",


### PR DESCRIPTION
Last piece needed for the nightly to resolve on `b10639`. With `#122` merged, preflight got past `#107` and stopped on `#108`, which conflicts in `ggml/include/ggml-rpc.h`.

### The conflict

One hunk, the RPC protocol version triple:

| | major | minor | patch | `GGML_OP_COUNT` assert |
|---|---|---|---|---|
| merge base `d222767c7` | 5 | 1 | 0 | 101 |
| upstream `b10639` | 6 | 0 | 0 | 101 |
| the carry | 5 | 1 | 1 | 102 |

Resolved to `6/0/1`. Upstream's major bump is a real protocol change and has to be taken; the carry's patch bump is its own signal that it added an op, and `negotiate_hello()` compares major exactly and minor with `<=` but never looks at patch, so keeping it costs nothing at handshake. The `static_assert(GGML_OP_COUNT == 102)` merged outside the conflict, and I checked it against the merged header rather than trusting it: the `ggml_op` enum in the merged tree has exactly 102 members, and it compiles.

Nothing else conflicted. The carry's own `ggml-rpc.cpp` changes survived `b10639`'s 440-line rewrite of that file intact, including the `GGML_OP_FLASH_ATTN_EXT_BANDED` line now sitting directly beside upstream's `GGML_OP_FLASH_ATTN_EXT` in the same `rpc_get` block.

### Verification

- Carry alone on `b10639`, `-DLLAMA_FATAL_WARNINGS=ON -DGGML_RPC=ON`: 558/558, exit 0, zero warnings.
- All seven pins replayed on `b10639` in order: `#107`, `#108`, `#70` (additive), `#91`, `#95`, `#114`, `#118`, all merging.
- That fully composed tree built with the same flags: 573/573, exit 0. `test-llama-archs` exits 0 with qwen4exp, glm5next and inkling all registered.
- `2c5b0007bc` is in `#108`'s commit list and mirrored to `refs/pins/2c5b0007bc`.
- `inkling-25731-upstream-base` fast-forwarded `b10630` to `b10639`, so the PR diff is the 64 feature files with no upstream noise mixed in.

### Two things worth knowing

`#108` had been closed, and a closed PR does not refresh its commit list when you push to its branch, so the pin membership check rejected the new sha until I reopened it. Worth remembering for any future carry refresh on a closed PR.

Separately, and not introduced here: the carry inserts `GGML_OP_FLASH_ATTN_EXT_BANDED` in the middle of the `ggml_op` enum rather than appending it, which renumbers every op after index 75. `ggml-rpc.cpp` puts the raw ordinal on the wire (`result.op = tensor->op`) and casts it straight back on receipt, so these binaries are wire-incompatible with a stock `6/0/0` peer for those ops, and because the handshake ignores patch the mismatch will not be caught. This is inherent to the upstream PR and was equally true of the previous `5/1/1` pin. It only matters if someone points our `llama-rpc-server` at a stock client or the reverse; everything we ship is built from one tree and is self-consistent.