### PR TITLE
Repin qwen4exp (ggml-org#27742) to pick up the nextn draft head

### DIFF
--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -23,7 +23,7 @@
     "https://github.com/unslothai/llama.cpp/pull/70/commits/edfd4c1a3b7a653303a85257ddac2a1f3ce39a2f",
     "https://github.com/unslothai/llama.cpp/pull/91/commits/c86ed269986f2dced6325c5c58bda966a2e2ead1",
     "https://github.com/unslothai/llama.cpp/pull/95/commits/3db8cb5b2e9bf291057b9f19960e8601a162da81",
-    "https://github.com/unslothai/llama.cpp/pull/114/commits/92ee7a5ce06ca4f8373dfec7de0a7729f391b7ff",
+    "https://github.com/unslothai/llama.cpp/pull/114/commits/950f135b28789057721a65d76de98fbbcd2f7dd6",
     "https://github.com/unslothai/llama.cpp/pull/118/commits/3766b41229c20249fd4d83d7ba297499d50e9b80"
   ]
 }

--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -23,7 +23,7 @@
     "https://github.com/unslothai/llama.cpp/pull/70/commits/edfd4c1a3b7a653303a85257ddac2a1f3ce39a2f",
     "https://github.com/unslothai/llama.cpp/pull/91/commits/c86ed269986f2dced6325c5c58bda966a2e2ead1",
     "https://github.com/unslothai/llama.cpp/pull/95/commits/3db8cb5b2e9bf291057b9f19960e8601a162da81",
-    "https://github.com/unslothai/llama.cpp/pull/114/commits/c4ddc4805dbc12727897b354237bfd9225212b06",
+    "https://github.com/unslothai/llama.cpp/pull/114/commits/92ee7a5ce06ca4f8373dfec7de0a7729f391b7ff",
     "https://github.com/unslothai/llama.cpp/pull/118/commits/3766b41229c20249fd4d83d7ba297499d50e9b80"
   ]
 }


### PR DESCRIPTION
Second qwen4exp repin today. `#122` pinned `c4ddc4805`; the carry has moved on four commits since, and the upstream PR has gone from 27 to 30. The base tag is unchanged at `b10639`, so unlike `#122` this is purely a content refresh.

`scripts/unsloth/pr-set.json`, one line: `#114` moves from `c4ddc4805` to `92ee7a5ce`.

### What is in it

Three of the four new carry commits correspond one to one with the three new upstream commits:

- `qwen4exp: include llama-impl.h explicitly for llama_mul_mat_hadamard`
- `llama: fix the qwen4exp PLE history seq_rm(-1) iterator invalidation and the fatal-warning build`
- `llama: segment the qwen4exp fused QKV for tensor split`

The fourth, `92ee7a5ce qwen4exp: multi-token prediction (nextn) draft head`, is **not in the upstream PR** and has no counterpart there. It is 337 lines across 9 files, mostly `src/models/qwen4exp.cpp` (+235), and it adds two GGUF tensors to the existing NEXTN family: `blk.{bid}.nextn.shared_head_down` and `..._up`.

I checked this rather than assuming, because it changes what a pin means. Below the nextn commit the carry is byte-identical to upstream `0b19188e9` on every file the PR touches except `src/llama-model.cpp`, and that difference is entirely the `filter_attn` / `filter_recr` reorder below `filter_idx` that lets `#118` add its own without colliding. So: upstream-equivalent plus one reviewed-only-here feature.

### Verification

- All seven pins replay on `b10639` in order: `#107`, `#108`, `#70` (additive), `#91`, `#95`, `#114`, `#118`.
- The composed tree built with `-DLLAMA_FATAL_WARNINGS=ON -DGGML_RPC=ON`: 573/573, exit 0, zero warnings. `test-llama-archs` exits 0 with qwen4exp, glm5next and inkling registered. `gguf-py` imports and exposes the new tensor enums.
- `ca5d0a1dd1` is still an ancestor, so `#118` composes unchanged, and it does.
- `92ee7a5ce` is in `#114`'s commit list and mirrored to `refs/pins/92ee7a5ce`.

### One thing to decide

This probe used `2c5b0007bc` for pin `#108`, which is what `#123` proposes and master does not have yet. Merge `#123` first, or the nightly still stops at `#108` on `b10639` regardless of this PR.

Worth being explicit that pinning `92ee7a5ce` ships the nextn draft head in the prebuilt binaries with no upstream review behind it, and that a qwen4exp GGUF converted with those two tensors present will not load in a stock build once `#27742` lands there. That is a call for whoever owns the feature, not a blocker for the pin; drop the last carry commit and repin at `dbdcd49ea` if the intent was upstream parity only.