### PR TITLE
Repin GLM-5-Next onto the ggml-org#27754 carry

### DIFF
--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -24,6 +24,6 @@
     "https://github.com/unslothai/llama.cpp/pull/91/commits/c86ed269986f2dced6325c5c58bda966a2e2ead1",
     "https://github.com/unslothai/llama.cpp/pull/95/commits/3db8cb5b2e9bf291057b9f19960e8601a162da81",
     "https://github.com/unslothai/llama.cpp/pull/114/commits/c4ddc4805dbc12727897b354237bfd9225212b06",
-    "https://github.com/unslothai/llama.cpp/pull/118/commits/3766b41229c20249fd4d83d7ba297499d50e9b80"
+    "https://github.com/unslothai/llama.cpp/pull/125/commits/f48b99e1fd04628da2a3d4ea5acc335d9ea67f7a"
   ]
 }


### PR DESCRIPTION
Points the GLM-5-Next pin at the new carry in #125 and away from `#118`.

`scripts/unsloth/pr-set.json`, one line: `#118`'s `3766b41229` becomes `#125`'s `f48b99e1fd`.

### Why a new PR number rather than a repin in place

`ggml-org#27754` is the upstream version of the same feature `#118` carries. It is not an additional pin: both add `conversion/glm5next.py`, `src/models/glm5next.cpp`, `tests/test-glm5next-memory.cpp` and `tools/mtmd/models/glm5next-vision.cpp`, so pinning both would add the model twice. And `#118` is merged, so pushing to its branch does not refresh its commit list and the pin membership check cannot follow it. Hence a fresh carry PR.

### This fixes a bug we currently ship

`#118` sets `hparams.n_embd_out_impl = dsv4_hc_mult * n_embd`, inherited from deepseek4. `27754` sets it to `0` because `t_embd` is `[n_embd, n_tokens]` while `n_embd_out()` would report `4*n_embd`, so `llama-context.cpp` reads four times more floats than the tensor holds. The assert there sizes the destination, so nothing catches the short source. Reachable through `--embeddings` and `llama_get_embeddings*` only, which is why generation never showed it.

### Verification

- All seven pins replay on `b10639` in order: `#107`, `#108`, `#70` (additive), `#91`, `#95`, `#114`, `#125`.
- The composed tree builds with `-DLLAMA_FATAL_WARNINGS=ON -DGGML_RPC=ON`: 573/573, exit 0, zero warnings. `test-llama-archs` exits 0 with qwen4exp, glm5next and inkling registered.
- `f48b99e1fd` is in `#125`'s commit list and mirrored to `refs/pins/f48b99e1fd`.

### Order

This probe assumed `#123` (the `#108` RPC repin) and `#124` (qwen4exp) are in. All three are independent single-line edits to `pr-set.json` and do not conflict with each other, but the nightly needs all three: without `#123` the resolve still stops at `#108`.

The composition work and the three ways the merge went wrong are written up on #125 rather than repeated here.