### PR TITLE
Keep -Werror off a libstdc++ deprecation, and stop reclaim racing the build legs

### DIFF
--- a/.github/workflows/unsloth-prebuilt-cpu.yml
+++ b/.github/workflows/unsloth-prebuilt-cpu.yml
@@ -113,6 +113,12 @@ jobs:
           # Build recipe mirrors llama-cpp-binaries' CPU wheel (backend-DL +
           # all CPU variants + RPC, no GPU backend). RPATH=$ORIGIN so the
           # bundle's sibling .so files resolve from the binary's own directory.
+          # LLAMA_FATAL_WARNINGS below is -Werror. The arm64 image compiles with
+          # clang-19 against GCC 12's libstdc++, where std::stable_sort still
+          # reaches the deprecated get_temporary_buffer; GCC buries that in a
+          # system header, clang reports it at our instantiation. That failed
+          # this leg on 08-27 over a deprecation in code we do not own, so that
+          # one diagnostic is off. Every other warning stays fatal.
           cmake -S . -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DGGML_NATIVE=OFF \
@@ -120,6 +126,7 @@ jobs:
             -DGGML_CPU_ALL_VARIANTS=ON \
             -DGGML_RPC=ON \
             -DLLAMA_FATAL_WARNINGS=ON \
+            -DCMAKE_CXX_FLAGS=-Wno-deprecated-declarations \
             -DLLAMA_BUILD_TESTS=OFF \
             -DLLAMA_BUILD_EXAMPLES=OFF \
             -DLLAMA_BUILD_TOOLS=ON \

--- a/.github/workflows/unsloth-prebuilt-cuda.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda.yml
@@ -170,6 +170,12 @@ jobs:
           #  - CMAKE_*_COMPILER_LAUNCHER=ccache: Jimver installs nvcc outside
           #    /usr/local/bin, so PATH-symlinked ccache misses CUDA TUs --
           #    setting the launcher explicitly caches nvcc too.
+          # LLAMA_FATAL_WARNINGS below is -Werror. The arm64 image compiles with
+          # clang-19 against GCC 12's libstdc++, where std::stable_sort still
+          # reaches the deprecated get_temporary_buffer; GCC buries that in a
+          # system header, clang reports it at our instantiation. That failed
+          # this leg on 08-27 over a deprecation in code we do not own, so that
+          # one diagnostic is off. Every other warning stays fatal.
           cmake -S . -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DGGML_NATIVE=OFF \
@@ -179,6 +185,7 @@ jobs:
             -DGGML_CUDA=ON \
             -DGGML_CUDA_CUB_3DOT2=ON \
             -DLLAMA_FATAL_WARNINGS=ON \
+            -DCMAKE_CXX_FLAGS=-Wno-deprecated-declarations \
             -DLLAMA_BUILD_TESTS=OFF \
             -DLLAMA_BUILD_EXAMPLES=OFF \
             -DLLAMA_BUILD_TOOLS=ON \

--- a/.github/workflows/unsloth-prebuilt-vulkan.yml
+++ b/.github/workflows/unsloth-prebuilt-vulkan.yml
@@ -157,6 +157,12 @@ jobs:
           # Build recipe mirrors llama-cpp-binaries' Vulkan wheel: the CPU recipe
           # (backend-DL + all CPU variants + RPC) plus GGML_VULKAN. RPATH=$ORIGIN
           # so the bundle's sibling .so files resolve from the binary's own dir.
+          # LLAMA_FATAL_WARNINGS below is -Werror. The arm64 image compiles with
+          # clang-19 against GCC 12's libstdc++, where std::stable_sort still
+          # reaches the deprecated get_temporary_buffer; GCC buries that in a
+          # system header, clang reports it at our instantiation. That failed
+          # this leg on 08-27 over a deprecation in code we do not own, so that
+          # one diagnostic is off. Every other warning stays fatal.
           cmake -S . -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DGGML_NATIVE=OFF \
@@ -165,6 +171,7 @@ jobs:
             -DGGML_RPC=ON \
             -DGGML_VULKAN=ON \
             -DLLAMA_FATAL_WARNINGS=ON \
+            -DCMAKE_CXX_FLAGS=-Wno-deprecated-declarations \
             -DLLAMA_BUILD_TESTS=OFF \
             -DLLAMA_BUILD_EXAMPLES=OFF \
             -DLLAMA_BUILD_TOOLS=ON \

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -972,7 +972,12 @@ jobs:
   # assets match whichever run wrote them.
   reclaim:
     name: Reclaim artifact storage
-    needs: [resolve, assemble]
+    # Every build leg, not just assemble. assemble needs only resolve, so one
+    # failing leg fails it immediately while slower legs are still building, and
+    # with always() this job then deleted the app-source-* artifact out from under
+    # them. On 08-27 one arm64 CPU failure became ten: nine ROCm legs died on
+    # "Artifact not found" seconds later, which reads as a ROCm fault and is not.
+    needs: [resolve, build-cuda, build-windows-cuda, build-rocm, build-macos, build-cpu, build-vulkan, assemble]
     # always(), so a run that publishes NOTHING still cleans up after itself.
     # Gating this on `published` leaked every non-publishing run's bundles: a
     # workflow_dispatch defaults to publish:false, and a cancelled run never


### PR DESCRIPTION
Fixes both faults behind run [33034661501](https://github.com/unslothai/llama.cpp/actions/runs/33034661501), where ten jobs failed. Only one of them actually broke.

### 1. `-Werror` killed `CPU / linux/arm64`

```
error: 'get_temporary_buffer<common_json>' is deprecated [-Werror,-Wdeprecated-declarations]
  /usr/lib/gcc/aarch64-linux-gnu/12/../../../../include/c++/12/bits/stl_tempbuf.h:263
```

`common/chat.cpp` calls `std::stable_sort`, and on the arm64 image that means clang-19 compiling against GCC 12's libstdc++, whose `stable_sort` still routes through the deprecated `std::get_temporary_buffer`. GCC keeps that quiet as a system header; clang attributes it to our instantiation and `-Werror` turns it into a hard failure. The deprecation is in a standard library we do not choose, over a call we do not make directly.

So `-Wno-deprecated-declarations` is added alongside `-DLLAMA_FATAL_WARNINGS=ON` on the three Linux legs that have it (cpu, cuda, vulkan). Every other warning stays fatal, which keeps the property that motivated adding `-Werror`: it is what would have caught the unused `mem_size` variable that broke the 08-26 release.

I should be straight about how this got in. When `-Werror` was added I verified it on x86-64 with gcc, got 215/215 byte-identical objects, and said it would not break anything. That verification never covered clang-against-libstdc++, which is what the arm64 leg uses, and this is the same class of blind spot I had already described in the 08-26 postmortem.

### 2. One failure became ten

`assemble` declares `needs: [resolve]` only. It does not wait for the build legs, so the moment `CPU / linux/arm64` failed, `assemble` failed with it, while nine ROCm legs were still compiling. `reclaim` runs `if: always()` and needed only `[resolve, assemble]`, so it started immediately, decided "run published nothing", and deleted the run's three live artifacts at 02:59:59:

```
run published nothing; deleting its 3 live artifact(s)
deleted 3 artifacts, freed 63 MiB, failed 0
```

Thirteen seconds later the ROCm legs reached their download step:

```
##[error]Unable to download artifact(s): Artifact not found for name: app-source-b10639-mix-f6f92fe
```

None of those nine failures is a ROCm fault, and each one reads like one. `alert` already lists every build job in its `needs`; `reclaim` now does the same, so it cannot delete the source artifact while anything is still consuming it.

This is worth fixing on its own terms rather than as release cleanup: it converts any single-leg failure into a mass failure and buries the real cause under nine misleading ones.

### Verification

- All four workflows parse as YAML, `bash -n` accepts each modified `run:` block, and both flags remain on the same logical `cmake` line.
- Checked specifically that no comment sits inside a backslash continuation. The first version of this change put one there; YAML still parsed, because a `run:` body is an opaque block scalar, but the shell would have truncated the whole `cmake` invocation at the `#`.
- Local build with `-DLLAMA_FATAL_WARNINGS=ON -DCMAKE_CXX_FLAGS=-Wno-deprecated-declarations` over the full seven-pin composed tree: 573/573, exit 0.
- `reclaim.needs` now resolves to `[resolve, build-cuda, build-windows-cuda, build-rocm, build-macos, build-cpu, build-vulkan, assemble]`.

What this cannot show is the arm64 leg itself: there is no clang and no aarch64 libstdc++-12 on the machine I verified from, so the fix for fault 1 is argued rather than reproduced. `-Wno-deprecated-declarations` can only suppress the diagnostic that failed and cannot introduce a new one, so the risk is that it is unnecessary, not that it is harmful. The re-dispatched release is the real test.