### PR TITLE
Drop -Werror from the CUDA leg, where the warning set cannot be narrowed

### DIFF
--- a/.github/workflows/unsloth-prebuilt-cuda.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda.yml
@@ -170,12 +170,14 @@ jobs:
           #  - CMAKE_*_COMPILER_LAUNCHER=ccache: Jimver installs nvcc outside
           #    /usr/local/bin, so PATH-symlinked ccache misses CUDA TUs --
           #    setting the launcher explicitly caches nvcc too.
-          # LLAMA_FATAL_WARNINGS below is -Werror. The arm64 image compiles with
-          # clang-19 against GCC 12's libstdc++, where std::stable_sort still
-          # reaches the deprecated get_temporary_buffer; GCC buries that in a
-          # system header, clang reports it at our instantiation. That failed
-          # this leg on 08-27 over a deprecation in code we do not own, so that
-          # one diagnostic is off. Every other warning stays fatal.
+          # No LLAMA_FATAL_WARNINGS on this leg, unlike cpu/vulkan/macos. Here it also
+          # sets nvcc -Werror all-warnings, and the host warnings arrive through an
+          # -Xcompiler list llama.cpp composes itself, which CMAKE_CXX_FLAGS does not
+          # reach -- verified on 08-27, where the suppression added that morning was
+          # absent from the actual nvcc command line. So the warning set here is
+          # all-or-nothing, and 'all' means every libstdc++ false positive fails a
+          # release: cuda13-newer and cuda13-portable both died on a GCC 11
+          # -Wstringop-overflow inside std::copy, from ggml_cuda_try_fuse.
           cmake -S . -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DGGML_NATIVE=OFF \
@@ -184,8 +186,6 @@ jobs:
             -DGGML_RPC=ON \
             -DGGML_CUDA=ON \
             -DGGML_CUDA_CUB_3DOT2=ON \
-            -DLLAMA_FATAL_WARNINGS=ON \
-            -DCMAKE_CXX_FLAGS=-Wno-deprecated-declarations \
             -DLLAMA_BUILD_TESTS=OFF \
             -DLLAMA_BUILD_EXAMPLES=OFF \
             -DLLAMA_BUILD_TOOLS=ON \


### PR DESCRIPTION
Second correction to the `-Werror` change I made this morning. Run [33035516146](https://github.com/unslothai/llama.cpp/actions/runs/33035516146) got past the arm64 failure and then lost `CUDA / x64/cuda13-newer` and `CUDA / x64/cuda13-portable`:

```
/usr/include/c++/11/bits/stl_algobase.h:431:25: error: '__builtin_memcpy' writing 20 bytes
  into a region of size 4 overflows the destination [-Werror=stringop-overflow=]
  ... In function 'int ggml_cuda_try_fuse(ggml_backend_cuda_context*, ggml_cgraph*, int)'
```

A GCC 11 `-Wstringop-overflow` false positive inside libstdc++'s `std::copy`. Not our code, and a warning class entirely different from the arm64 deprecation.

### Why this leg gets no flag rather than another suppression

`-DCMAKE_CXX_FLAGS=-Wno-deprecated-declarations`, added this morning, never reached this compiler at all. From the failing job's own command line:

```
-Werror all-warnings -Xcompiler "-Werror -Wmissing-declarations -Wmissing-noreturn -Wall
 -Wextra -Wpedantic -Wcast-qual -Wno-unused-function -Wno-array-bounds -Wextra-semi -Wno-pedantic"
```

The suppression is absent. On a CUDA target the host warnings arrive through an `-Xcompiler` list llama.cpp composes itself, which `CMAKE_CXX_FLAGS` does not feed, and `LLAMA_FATAL_WARNINGS` additionally turns on nvcc's `-Werror all-warnings`. So the warning set on this leg is all-or-nothing, and "all" means any standard-library false positive on any GCC the CUDA images ship fails a release. That is not a property worth having on a build leg.

`cpu` and `vulkan` keep the flag, because there the set is tunable and it now demonstrably works: both `CPU / linux/arm64` and `CPU / linux/x64` are green in that run with the deprecation suppressed, and `Vulkan / windows/x64` is green.

### On the original justification

Adding `-Werror` to these Linux legs was supposed to catch the class of bug that broke the 08-26 release, the unused `mem_size` variable. That protection already existed: `unsloth-prebuilt-macos.yml` has carried `-DLLAMA_FATAL_WARNINGS=ON` since well before this change, and it is the leg that actually caught `mem_size`. I said adding it elsewhere would not break anything, having checked only x86-64 with gcc; it has since broken two legs on two toolchains with two different libstdc++ false positives. Keeping it where the warning set is controllable and dropping it where it is not is the line I should have drawn at the start.

The remaining `-Werror` coverage after this: `cpu`, `vulkan`, `macos`. `cuda`, `cuda-windows` and `rocm` have none.

### Verification

YAML parses, `bash -n` accepts the `run:` block, no `LLAMA_FATAL_WARNINGS` or orphaned `-Wno-` flag remains on this leg, and no comment sits inside a backslash continuation.