### PR TITLE
Automate the merge resolutions that are provable, and gate the ones that are not

### DIFF
--- a/.github/workflows/unsloth-pin-preflight.yml
+++ b/.github/workflows/unsloth-pin-preflight.yml
@@ -107,6 +107,7 @@ jobs:
                      ../scripts/unsloth/pr-set.json)
 
           PROBLEMS=""
+          MERGED=""
           while read -r url REQUIRED; do
             SRC="$(sed -E 's|https://github.com/([^/]+)/llama.cpp/pull/.*|\1|' <<<"$url")/llama.cpp"
             NUM="$(sed -E 's|.*/pull/([0-9]+)/commits/.*|\1|' <<<"$url")"
@@ -130,6 +131,7 @@ jobs:
                  -c merge.conflictStyle=diff3 \
                  merge --no-ff --no-edit -m "probe ${SRC}#${NUM}" "$SHA" >/dev/null 2>&1; then
               echo "ok ${SRC}#${NUM}"
+              MERGED=1
               continue
             fi
             # Mirror resolve: a pure add/add is what the nightly will merge
@@ -139,6 +141,7 @@ jobs:
                  && [ -z "$(git diff --name-only --diff-filter=U)" ]; then
               git -c user.name=preflight -c user.email=preflight@local commit -q --no-edit
               echo "ok ${SRC}#${NUM} (additive resolve)"
+              MERGED=1
               continue
             fi
             FILES="$(git diff --name-only --diff-filter=U | sed 's/^/  /')"
@@ -153,7 +156,8 @@ jobs:
                           | "\(.url)\t\(if .required == null then true else .required end)"' \
                      ../scripts/unsloth/pr-set.json | tr '\t' ' ')
 
-          if [ -z "$PROBLEMS" ]; then
+          # Only when a pin actually merged. With no pins, or only optional closed ones, this tree is pristine upstream, and a finding there is not a pin problem to alert on. The nightly gates the same check on MERGED_PINS.
+          if [ -z "$PROBLEMS" ] && [ -n "$MERGED" ]; then
             # Merging cleanly is not the same as merging correctly. Two mistakes
             # made on 08-27 compiled fine and would have shipped: a tensor-map key
             # defined twice, which Python resolves silently by keeping the last,

--- a/.github/workflows/unsloth-pin-preflight.yml
+++ b/.github/workflows/unsloth-pin-preflight.yml
@@ -154,6 +154,18 @@ jobs:
                      ../scripts/unsloth/pr-set.json | tr '\t' ' ')
 
           if [ -z "$PROBLEMS" ]; then
+            # Merging cleanly is not the same as merging correctly. Two mistakes
+            # made on 08-27 compiled fine and would have shipped: a tensor-map key
+            # defined twice, which Python resolves silently by keeping the last,
+            # and an arch arm made unreachable by the same arch appearing in an
+            # earlier fallthrough condition. Both are checked here, on the tree the
+            # pins just produced, because this is the first point it exists.
+            if ! python3 ../scripts/unsloth/merge_checks.py --root . ; then
+              PROBLEMS="${PROBLEMS}- the merged tree builds, but \`scripts/unsloth/merge_checks.py\` found a resolution that is silently wrong. See the run log for file and line.\n"
+            fi
+          fi
+
+          if [ -z "$PROBLEMS" ]; then
             echo "all pins merge cleanly onto ${BASE}"
             echo "status=success" >> "$GITHUB_OUTPUT"
             echo "details=" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/unsloth-pr-set-lint.yml
+++ b/.github/workflows/unsloth-pr-set-lint.yml
@@ -22,9 +22,9 @@ on:
       - scripts/unsloth/sync_deletes.py
       - scripts/unsloth/test_*.py
       - scripts/unsloth/check_workflow_scalars.py
-      # Every workflow, not just this one: the size guard below protects all of
-      # them, and it only protects them if editing one runs it.
+      # Every workflow, not just this one: the size guard only guards a file if editing it runs the guard.
       - .github/workflows/*.yml
+      - .github/workflows/*.yaml
   pull_request:
     paths:
       - scripts/unsloth/pr-set.json
@@ -35,9 +35,9 @@ on:
       - scripts/unsloth/sync_deletes.py
       - scripts/unsloth/test_*.py
       - scripts/unsloth/check_workflow_scalars.py
-      # Every workflow, not just this one: the size guard below protects all of
-      # them, and it only protects them if editing one runs it.
+      # Every workflow, not just this one: the size guard only guards a file if editing it runs the guard.
       - .github/workflows/*.yml
+      - .github/workflows/*.yaml
 
 permissions:
   contents: read
@@ -127,12 +127,7 @@ jobs:
           done
           exit "$fail"
 
-      # Separate from the tests above because it guards the workflows rather
-      # than the resolvers, and because it is the check that would have caught
-      # a break nothing else could see: a run: script over GitHub's 21000
-      # character limit makes the whole file uncompilable, and every run of it
-      # then fails with no jobs, no annotation and no usable error, while yaml,
-      # actionlint and GitHub's own published parser all pass it.
+      # An over-limit run: script makes the whole file uncompilable, and nothing else sees it: yaml, actionlint and GitHub's own parser all pass it. See check_workflow_scalars.py.
       - name: Check no workflow string is near GitHub's size limit
         run: python3 scripts/unsloth/check_workflow_scalars.py --root .
 

--- a/.github/workflows/unsloth-pr-set-lint.yml
+++ b/.github/workflows/unsloth-pr-set-lint.yml
@@ -15,9 +15,21 @@ on:
   push:
     paths:
       - scripts/unsloth/pr-set.json
+      - scripts/unsloth/additive_merge.py
+      - scripts/unsloth/pin_merge.py
+      - scripts/unsloth/merge_checks.py
+      - scripts/unsloth/carry_vintage.py
+      - scripts/unsloth/test_*.py
+      - .github/workflows/unsloth-pr-set-lint.yml
   pull_request:
     paths:
       - scripts/unsloth/pr-set.json
+      - scripts/unsloth/additive_merge.py
+      - scripts/unsloth/pin_merge.py
+      - scripts/unsloth/merge_checks.py
+      - scripts/unsloth/carry_vintage.py
+      - scripts/unsloth/test_*.py
+      - .github/workflows/unsloth-pr-set-lint.yml
 
 permissions:
   contents: read

--- a/.github/workflows/unsloth-pr-set-lint.yml
+++ b/.github/workflows/unsloth-pr-set-lint.yml
@@ -19,6 +19,7 @@ on:
       - scripts/unsloth/pin_merge.py
       - scripts/unsloth/merge_checks.py
       - scripts/unsloth/carry_vintage.py
+      - scripts/unsloth/sync_deletes.py
       - scripts/unsloth/test_*.py
       - .github/workflows/unsloth-pr-set-lint.yml
   pull_request:
@@ -28,6 +29,7 @@ on:
       - scripts/unsloth/pin_merge.py
       - scripts/unsloth/merge_checks.py
       - scripts/unsloth/carry_vintage.py
+      - scripts/unsloth/sync_deletes.py
       - scripts/unsloth/test_*.py
       - .github/workflows/unsloth-pr-set-lint.yml
 
@@ -111,7 +113,8 @@ jobs:
           for t in scripts/unsloth/test_additive_merge.py \
                    scripts/unsloth/test_pin_merge.py \
                    scripts/unsloth/test_merge_checks.py \
-                   scripts/unsloth/test_sync_deletes.py; do
+                   scripts/unsloth/test_sync_deletes.py \
+                   scripts/unsloth/test_carry_vintage.py; do
             echo "::group::$t"
             python3 "$t" || fail=1
             echo "::endgroup::"

--- a/.github/workflows/unsloth-pr-set-lint.yml
+++ b/.github/workflows/unsloth-pr-set-lint.yml
@@ -81,3 +81,27 @@ jobs:
           done < <(jq -r '.prs[] | if type == "string" then {url: ., required: true} else . end
                           | "\(.url)\t\(if .required == null then true else .required end)"' "$FILE" | tr '\t' ' ')
           exit "$fail"
+
+  resolver-tests:
+    # These tests existed for additive_merge.py and ran nowhere, so a change to
+    # a merge resolver was covered by nothing at all. Every resolver and check
+    # under scripts/unsloth/ runs here.
+    name: Resolver and merge-check tests
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
+        with: { fetch-depth: 1 }
+
+      - name: Run the resolver tests
+        run: |
+          set -euo pipefail
+          fail=0
+          for t in scripts/unsloth/test_additive_merge.py \
+                   scripts/unsloth/test_pin_merge.py \
+                   scripts/unsloth/test_merge_checks.py; do
+            echo "::group::$t"
+            python3 "$t" || fail=1
+            echo "::endgroup::"
+          done
+          exit "$fail"
+

--- a/.github/workflows/unsloth-pr-set-lint.yml
+++ b/.github/workflows/unsloth-pr-set-lint.yml
@@ -110,7 +110,8 @@ jobs:
           fail=0
           for t in scripts/unsloth/test_additive_merge.py \
                    scripts/unsloth/test_pin_merge.py \
-                   scripts/unsloth/test_merge_checks.py; do
+                   scripts/unsloth/test_merge_checks.py \
+                   scripts/unsloth/test_sync_deletes.py; do
             echo "::group::$t"
             python3 "$t" || fail=1
             echo "::endgroup::"

--- a/.github/workflows/unsloth-pr-set-lint.yml
+++ b/.github/workflows/unsloth-pr-set-lint.yml
@@ -103,9 +103,8 @@ jobs:
           exit "$fail"
 
   resolver-tests:
-    # These tests existed for additive_merge.py and ran nowhere, so a change to
-    # a merge resolver was covered by nothing at all. Every resolver and check
-    # under scripts/unsloth/ runs here.
+    # These tests existed for additive_merge.py and ran nowhere, so a change to a merge resolver was covered by nothing at all.
+    # Every resolver and check under scripts/unsloth/ runs here.
     name: Resolver and merge-check tests
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/unsloth-pr-set-lint.yml
+++ b/.github/workflows/unsloth-pr-set-lint.yml
@@ -21,7 +21,10 @@ on:
       - scripts/unsloth/carry_vintage.py
       - scripts/unsloth/sync_deletes.py
       - scripts/unsloth/test_*.py
-      - .github/workflows/unsloth-pr-set-lint.yml
+      - scripts/unsloth/check_workflow_scalars.py
+      # Every workflow, not just this one: the size guard below protects all of
+      # them, and it only protects them if editing one runs it.
+      - .github/workflows/*.yml
   pull_request:
     paths:
       - scripts/unsloth/pr-set.json
@@ -31,7 +34,10 @@ on:
       - scripts/unsloth/carry_vintage.py
       - scripts/unsloth/sync_deletes.py
       - scripts/unsloth/test_*.py
-      - .github/workflows/unsloth-pr-set-lint.yml
+      - scripts/unsloth/check_workflow_scalars.py
+      # Every workflow, not just this one: the size guard below protects all of
+      # them, and it only protects them if editing one runs it.
+      - .github/workflows/*.yml
 
 permissions:
   contents: read
@@ -120,4 +126,13 @@ jobs:
             echo "::endgroup::"
           done
           exit "$fail"
+
+      # Separate from the tests above because it guards the workflows rather
+      # than the resolvers, and because it is the check that would have caught
+      # a break nothing else could see: a run: script over GitHub's 21000
+      # character limit makes the whole file uncompilable, and every run of it
+      # then fails with no jobs, no annotation and no usable error, while yaml,
+      # actionlint and GitHub's own published parser all pass it.
+      - name: Check no workflow string is near GitHub's size limit
+        run: python3 scripts/unsloth/check_workflow_scalars.py --root .
 

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -446,30 +446,8 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           echo "Resolved $REQ -> $TAG ($COMMIT); prs=$PRS; source_artifact=${SRC_ARTIFACT:-none}; release exists=$EXISTS; only=$ONLY; gfx=$GFX"
 
-      # Every pin merged. Merging cleanly is not the same as merging correctly,
-      # and the two ways it goes wrong both survive a full build, so the compile
-      # legs would not catch either:
-      #
-      #   - an architecture registered twice in a python tensor map. Python
-      #     keeps the last duplicate key silently, so the wrong mapping is used
-      #     and the model converts wrong.
-      #   - an arch arm made unreachable because an earlier fallthrough already
-      #     matches that arch. It compiles, and the model runs without whatever
-      #     that arm was meant to set up.
-      #
-      # Both were made by hand on 08-27. This runs before the source artifact is
-      # uploaded, so a model-affecting mis-resolution stops here rather than
-      # reaching 39 build jobs and shipping.
-      #
-      # A separate step, not more script inside `resolve`, because GitHub caps a
-      # single workflow string at 21000 characters and refuses to compile the
-      # whole file past it. That step is already at 20.5k, so the prose above
-      # alone was enough to break it: the run then reports as a zero-job failure
-      # with no annotation anywhere, and neither yaml parsing nor actionlint nor
-      # GitHub's own published parser sees a problem, because the limit is only
-      # enforced server-side. YAML comments outside a block scalar cost nothing
-      # against it. No step here sets working-directory, so this starts in the
-      # same $GITHUB_WORKSPACE the merge loop left behind.
+      # A bad pin resolution can still build fine, so it must be caught before the source artifact ships. See merge_checks.py.
+      # Its own step, not more script in `resolve`: GitHub caps one workflow string at 21000 chars and that step is near it. See check_workflow_scalars.py.
       - name: Check the merged tree for silently wrong resolutions
         if: ${{ env.MERGED_PINS == '1' }}
         run: |

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -985,11 +985,9 @@ jobs:
   # assets match whichever run wrote them.
   reclaim:
     name: Reclaim artifact storage
-    # Every build leg, not just assemble. assemble needs only resolve, so one
-    # failing leg fails it immediately while slower legs are still building, and
-    # with always() this job then deleted the app-source-* artifact out from under
-    # them. On 08-27 one arm64 CPU failure became ten: nine ROCm legs died on
-    # "Artifact not found" seconds later, which reads as a ROCm fault and is not.
+    # Every build leg, not just assemble.
+    # assemble needs only resolve, so one failing leg fails it immediately while slower legs are still building, and with always() this job then deleted the app-source-* artifact out from under them.
+    # On 08-27 one arm64 CPU failure became ten: nine ROCm legs died on "Artifact not found" seconds later, which reads as a ROCm fault and is not.
     needs: [resolve, build-cuda, build-windows-cuda, build-rocm, build-macos, build-cpu, build-vulkan, assemble]
     # always(), so a run that publishes NOTHING still cleans up after itself.
     # Gating this on `published` leaked every non-publishing run's bundles: a

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -287,6 +287,8 @@ jobs:
             # somewhere the checkout cannot take away.
             ADDITIVE_MERGE="${RUNNER_TEMP}/additive_merge.py"
             cp scripts/unsloth/additive_merge.py "$ADDITIVE_MERGE"
+            MERGE_CHECKS="${RUNNER_TEMP}/merge_checks.py"
+            cp scripts/unsloth/merge_checks.py "$MERGE_CHECKS"
             if [ "$(jq length <<<"$PRS")" != 0 ]; then
               # Merges need a merge-base, so unshallow first.
               if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
@@ -329,6 +331,25 @@ jobs:
                   fi
                 fi
               done < <(jq -r '.[] | "\(.repo) \(.number) \(.sha)"' <<<"$PRS")
+
+              # Every pin merged. Merging cleanly is not the same as merging
+              # correctly, and the two ways it goes wrong both survive a full
+              # build, so the compile legs below would not catch either:
+              #
+              #   - an architecture registered twice in a python tensor map.
+              #     Python keeps the last duplicate key silently, so the wrong
+              #     mapping is used and the model converts wrong.
+              #   - an arch arm made unreachable because an earlier fallthrough
+              #     already matches that arch. It compiles, and the model runs
+              #     without whatever that arm was meant to set up.
+              #
+              # Both were made by hand on 08-27. This is the last point where the
+              # composed tree exists before 39 build jobs run on it, so a
+              # model-affecting mis-resolution stops here rather than shipping.
+              if ! python3 "$MERGE_CHECKS" --root . ; then
+                echo "::error::the pinned PRs merged, but merge_checks.py found a resolution that is silently wrong; see the log for file and line" >&2
+                exit 1
+              fi
             else
               # Plain build: only the base tree is needed. Shallow is fine -- the
               # build number is baked below, so no git history is needed at build time.

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -287,8 +287,7 @@ jobs:
             # somewhere the checkout cannot take away.
             ADDITIVE_MERGE="${RUNNER_TEMP}/additive_merge.py"
             cp scripts/unsloth/additive_merge.py "$ADDITIVE_MERGE"
-            MERGE_CHECKS="${RUNNER_TEMP}/merge_checks.py"
-            cp scripts/unsloth/merge_checks.py "$MERGE_CHECKS"
+            cp scripts/unsloth/merge_checks.py "${RUNNER_TEMP}/merge_checks.py"
             if [ "$(jq length <<<"$PRS")" != 0 ]; then
               # Merges need a merge-base, so unshallow first.
               if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
@@ -331,25 +330,7 @@ jobs:
                   fi
                 fi
               done < <(jq -r '.[] | "\(.repo) \(.number) \(.sha)"' <<<"$PRS")
-
-              # Every pin merged. Merging cleanly is not the same as merging
-              # correctly, and the two ways it goes wrong both survive a full
-              # build, so the compile legs below would not catch either:
-              #
-              #   - an architecture registered twice in a python tensor map.
-              #     Python keeps the last duplicate key silently, so the wrong
-              #     mapping is used and the model converts wrong.
-              #   - an arch arm made unreachable because an earlier fallthrough
-              #     already matches that arch. It compiles, and the model runs
-              #     without whatever that arm was meant to set up.
-              #
-              # Both were made by hand on 08-27. This is the last point where the
-              # composed tree exists before 39 build jobs run on it, so a
-              # model-affecting mis-resolution stops here rather than shipping.
-              if ! python3 "$MERGE_CHECKS" --root . ; then
-                echo "::error::the pinned PRs merged, but merge_checks.py found a resolution that is silently wrong; see the log for file and line" >&2
-                exit 1
-              fi
+              echo "MERGED_PINS=1" >> "$GITHUB_ENV"
             else
               # Plain build: only the base tree is needed. Shallow is fine -- the
               # build number is baked below, so no git history is needed at build time.
@@ -464,6 +445,39 @@ jobs:
             echo "macos_matrix={\"include\":$MACOS_INCLUDE}"
           } >> "$GITHUB_OUTPUT"
           echo "Resolved $REQ -> $TAG ($COMMIT); prs=$PRS; source_artifact=${SRC_ARTIFACT:-none}; release exists=$EXISTS; only=$ONLY; gfx=$GFX"
+
+      # Every pin merged. Merging cleanly is not the same as merging correctly,
+      # and the two ways it goes wrong both survive a full build, so the compile
+      # legs would not catch either:
+      #
+      #   - an architecture registered twice in a python tensor map. Python
+      #     keeps the last duplicate key silently, so the wrong mapping is used
+      #     and the model converts wrong.
+      #   - an arch arm made unreachable because an earlier fallthrough already
+      #     matches that arch. It compiles, and the model runs without whatever
+      #     that arm was meant to set up.
+      #
+      # Both were made by hand on 08-27. This runs before the source artifact is
+      # uploaded, so a model-affecting mis-resolution stops here rather than
+      # reaching 39 build jobs and shipping.
+      #
+      # A separate step, not more script inside `resolve`, because GitHub caps a
+      # single workflow string at 21000 characters and refuses to compile the
+      # whole file past it. That step is already at 20.5k, so the prose above
+      # alone was enough to break it: the run then reports as a zero-job failure
+      # with no annotation anywhere, and neither yaml parsing nor actionlint nor
+      # GitHub's own published parser sees a problem, because the limit is only
+      # enforced server-side. YAML comments outside a block scalar cost nothing
+      # against it. No step here sets working-directory, so this starts in the
+      # same $GITHUB_WORKSPACE the merge loop left behind.
+      - name: Check the merged tree for silently wrong resolutions
+        if: ${{ env.MERGED_PINS == '1' }}
+        run: |
+          set -euo pipefail
+          if ! python3 "${RUNNER_TEMP}/merge_checks.py" --root . ; then
+            echo "::error::the pinned PRs merged, but merge_checks.py found a resolution that is silently wrong; see the log for file and line" >&2
+            exit 1
+          fi
 
       # The stamped source tree (every build): every build child extracts this
       # instead of cloning, and assemble ships it as the release's source-tarball

--- a/scripts/unsloth/carry_vintage.py
+++ b/scripts/unsloth/carry_vintage.py
@@ -84,6 +84,21 @@ def main() -> int:
     history = [c for c in git("rev-list", f"--max-count={a.max_commits}",
                               f"{fork}..{head}").split("\n") if c]
 
+    # Paths the CARRY changed that the PR never touched at all. Everything
+    # above reasons only about files in the PR's diff, so a carry-only edit is
+    # invisible to it: every PR path can be SUPERSEDED, nothing diverges, and
+    # the summary says a rebuild from the PR head is equivalent while the
+    # rebuild drops that edit. Same failure as OMITTED, arrived at from the
+    # other side. Diffed from --base rather than the fork point because a carry
+    # replays the PR onto the base tag, so that is what its own delta is
+    # against; if a carry is ever based on something else, the extra paths only
+    # ever withhold the rebuild advice, which is the safe direction to be wrong
+    # in.
+    touched = set(files)
+    carry_only = [f for f in git("diff", "--name-only", "--no-renames",
+                                 a.base, a.carry).split("\n")
+                  if f and f not in touched]
+
     superseded, diverged, absent, omitted = [], [], [], []
     for path in files:
         ours = blob(a.carry, path)
@@ -129,6 +144,9 @@ def main() -> int:
               "a rebuild would re-add it")
     for p in absent:
         print(f"  ABSENT      {p}\n              deleted by the PR, not in the carry")
+    for p in carry_only:
+        print(f"  CARRY ONLY  {p}\n              changed by the carry, untouched by the PR; "
+              "a rebuild would drop it")
     print()
     if diverged:
         print(f"{len(diverged)} file(s) genuinely diverge. A refresh has to merge, "
@@ -137,7 +155,11 @@ def main() -> int:
         print(f"{len(omitted)} file(s) the PR head still has are missing from the "
               "carry. Rebuilding would restore them, so it is NOT equivalent to "
               "merging; keep or re-drop each one deliberately.")
-    if not diverged and not omitted:
+    if carry_only:
+        print(f"{len(carry_only)} file(s) the carry changed are outside the "
+              "PR entirely. Rebuilding from the PR head would drop them, so it "
+              "is NOT equivalent to merging; carry each one across deliberately.")
+    if not diverged and not omitted and not carry_only:
         print("Nothing diverges. Rebuilding the carry from the PR head is "
               "equivalent to merging it, without the conflicts.")
 
@@ -145,7 +167,7 @@ def main() -> int:
         with open(a.report, "w") as fh:
             json.dump({"head": head, "superseded": superseded,
                        "diverged": diverged, "omitted": omitted,
-                       "absent": absent}, fh, indent=2)
+                       "absent": absent, "carry_only": carry_only}, fh, indent=2)
     return 0
 
 

--- a/scripts/unsloth/carry_vintage.py
+++ b/scripts/unsloth/carry_vintage.py
@@ -3,32 +3,24 @@
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
 """Report which carry files are an unmodified older copy of the upstream PR.
 
-A carry branch replays an upstream PR onto an aged base tag. When that PR moves,
-the question before every refresh is the same one: have we actually changed this
-file, or are we just holding a stale copy of theirs? Answering it by hand means
-diffing every file the PR touches and reading each hunk, which is what made the
-08-27 GLM-5-Next refresh expensive, and two of those hand answers were wrong.
+A carry branch replays an upstream PR onto an aged base tag.
+When that PR moves, the question before every refresh is the same one: have we actually changed this file, or are we just holding a stale copy of theirs?
+Answering it by hand means diffing every file the PR touches and reading each hunk, which is what made the 08-27 GLM-5-Next refresh expensive, and two of those hand answers were wrong.
 
-The mechanical answer: if our version of a file is byte-identical to the version
-at SOME commit of the upstream PR, then we never edited it, and their newer copy
-supersedes ours with nothing lost. That is a fact about blob hashes, not a
-judgement. Files we really did change match no upstream commit and are reported
-as diverged, which is correct: on 08-27 gguf-py/gguf/tensor_mapping.py did not
-match, because it genuinely carried qwen4exp additions as well.
+The mechanical answer: if our version of a file is byte-identical to the version at SOME commit of the upstream PR, then we never edited it, and their newer copy supersedes ours with nothing lost.
+That is a fact about blob hashes, not a judgement.
+Files we really did change match no upstream commit and are reported as diverged, which is correct: on 08-27 gguf-py/gguf/tensor_mapping.py did not match, because it genuinely carried qwen4exp additions as well.
 
-This only reports. It does not resolve, stage or write anything, because
-"upstream superseded ours" is not the same as "we want upstream's", and holding
-a deliberately older vintage is a legitimate decision this script cannot see.
+This only reports.
+It does not resolve, stage or write anything, because "upstream superseded ours" is not the same as "we want upstream's", and holding a deliberately older vintage is a legitimate decision this script cannot see.
 
 Use it to decide whether a refresh should merge or simply rebuild:
 
     python3 scripts/unsloth/carry_vintage.py \\
         --carry <carry sha> --pr-ref refs/pull/27754/head --base refs/tags/b10639
 
-When every file is SUPERSEDED, rebuilding the carry from the PR head avoids the
-merge, and its conflicts, entirely. A file the PR head still has and the carry
-does not is reported as OMITTED and blocks that advice, because a rebuild would
-restore it; a file the PR DELETED is merely ABSENT and blocks nothing.
+When every file is SUPERSEDED, rebuilding the carry from the PR head avoids the merge, and its conflicts, entirely.
+A file the PR head still has and the carry does not is reported as OMITTED and blocks that advice, because a rebuild would restore it; a file the PR DELETED is merely ABSENT and blocks nothing.
 """
 
 from __future__ import annotations
@@ -49,9 +41,7 @@ def git(*args: str) -> str:
 def blob(rev: str, path: str) -> str | None:
     """The tree entry as "mode oid", or None if the rev has no such path.
 
-    Mode, not just the oid: a carry that only chmods a file it took verbatim
-    has the same content as upstream, so an oid comparison calls it superseded
-    and a rebuild silently drops the mode change.
+    Mode, not just the oid: a carry that only chmods a file it took verbatim has the same content as upstream, so an oid comparison calls it superseded and a rebuild silently drops the mode change.
     """
     r = subprocess.run(["git", "ls-tree", "--full-tree", "-z", rev, "--", path],
                        capture_output=True, text=True)
@@ -74,35 +64,22 @@ def main() -> int:
 
     head = git("rev-parse", a.pr_ref)
     fork = git("merge-base", head, a.base)
-    # --no-renames, because rename detection hides exactly the path that
-    # matters here. `git diff --name-only` prints only the NEW name of a
-    # rename, so a PR moving `old` to `new` never puts `old` in this list. A
-    # carry that deliberately keeps `old` is then never looked at: `new` comes
-    # back SUPERSEDED, nothing diverges, and the summary says a rebuild is
-    # equivalent when a rebuild deletes the file the carry is holding. Without
-    # detection the rename is a delete plus an add, so `old` is classified --
-    # DIVERGED, since our copy is the fork's and matches no upstream vintage.
+    # --no-renames, because rename detection hides exactly the path that matters here.
+    # `git diff --name-only` prints only the NEW name of a rename, so a PR moving `old` to `new` never puts `old` in this list.
+    # A carry that deliberately keeps `old` is then never looked at: `new` comes back SUPERSEDED, nothing diverges, and the summary says a rebuild is equivalent when a rebuild deletes the file the carry is holding.
+    # Without detection the rename is a delete plus an add, so `old` is classified - DIVERGED, since our copy is the fork's and matches no upstream vintage.
     files = [f for f in git("diff", "--name-only", "--no-renames",
                             fork, head).split("\n") if f]
-    # fork..head, not head: `--max-count` caps the output, it does not bound
-    # the walk, so a bare `head` runs straight past the fork point into the
-    # base branch. A file our carry deliberately holds at the BASE version
-    # then matches a pre-fork commit and is called SUPERSEDED, and the summary
-    # says rebuilding from the PR head is equivalent -- it is not, it re-adds
-    # what the carry dropped. Only commits of the PR itself are vintages.
+    # fork..head, not head: `--max-count` caps the output, it does not bound the walk, so a bare `head` runs straight past the fork point into the base branch.
+    # A file our carry deliberately holds at the BASE version then matches a pre-fork commit and is called SUPERSEDED, and the summary says rebuilding from the PR head is equivalent - it is not, it re-adds what the carry dropped.
+    # Only commits of the PR itself are vintages.
     history = [c for c in git("rev-list", f"--max-count={a.max_commits}",
                               f"{fork}..{head}").split("\n") if c]
 
-    # Paths the CARRY changed that the PR never touched at all. Everything
-    # above reasons only about files in the PR's diff, so a carry-only edit is
-    # invisible to it: every PR path can be SUPERSEDED, nothing diverges, and
-    # the summary says a rebuild from the PR head is equivalent while the
-    # rebuild drops that edit. Same failure as OMITTED, arrived at from the
-    # other side. Diffed from --base rather than the fork point because a carry
-    # replays the PR onto the base tag, so that is what its own delta is
-    # against; if a carry is ever based on something else, the extra paths only
-    # ever withhold the rebuild advice, which is the safe direction to be wrong
-    # in.
+    # Paths the CARRY changed that the PR never touched at all.
+    # Everything above reasons only about files in the PR's diff, so a carry-only edit is invisible to it: every PR path can be SUPERSEDED, nothing diverges, and the summary says a rebuild from the PR head is equivalent while the rebuild drops that edit.
+    # Same failure as OMITTED, arrived at from the other side.
+    # Diffed from --base rather than the fork point because a carry replays the PR onto the base tag, so that is what its own delta is against; if a carry is ever based on something else, the extra paths only ever withhold the rebuild advice, which is the safe direction to be wrong in.
     touched = set(files)
     carry_only = [f for f in git("diff", "--name-only", "--no-renames",
                                  a.base, a.carry).split("\n")
@@ -112,26 +89,18 @@ def main() -> int:
     for path in files:
         ours = blob(a.carry, path)
         if ours is None:
-            # Two very different reasons a path is missing from the carry. If
-            # the PR DELETED it, the carry agrees and a rebuild reproduces
-            # that. If it still exists at the PR head, the carry dropped it on
-            # purpose, and a rebuild would re-add it -- the same mistake as
-            # calling a file held at the base version superseded.
+            # Two very different reasons a path is missing from the carry.
+            # If the PR DELETED it, the carry agrees and a rebuild reproduces that.
+            # If it still exists at the PR head, the carry dropped it on purpose, and a rebuild would re-add it - the same mistake as calling a file held at the base version superseded.
             (absent if blob(head, path) is None else omitted).append(path)
             continue
         if ours == blob(head, path):
             superseded.append({"path": path, "vintage": head, "current": True})
             continue
-        # Bounding the walk to fork..head is not enough on its own. A PR with
-        # several commits usually does not touch every file in its first one,
-        # so the commits BEFORE the one that first changed this path still
-        # carry the fork's blob -- inside the range. A carry holding the file
-        # at the base version matches one of those and is called SUPERSEDED
-        # again, and the summary again says a rebuild is equivalent when it
-        # would overwrite exactly what the carry is holding. Our copy being
-        # the fork's copy is not evidence the PR ever produced it, so it is
-        # never a vintage; such a file falls through to DIVERGED, which is
-        # where a file needing a human decision belongs.
+        # Bounding the walk to fork..head is not enough on its own.
+        # A PR with several commits usually does not touch every file in its first one, so the commits BEFORE the one that first changed this path still carry the fork's blob - inside the range.
+        # A carry holding the file at the base version matches one of those and is called SUPERSEDED again, and the summary again says a rebuild is equivalent when it would overwrite exactly what the carry is holding.
+        # Our copy being the fork's copy is not evidence the PR ever produced it, so it is never a vintage; such a file falls through to DIVERGED, which is where a file needing a human decision belongs.
         at_fork = blob(fork, path)
         hit = None if ours == at_fork else \
             next((c for c in history if blob(c, path) == ours), None)
@@ -168,10 +137,8 @@ def main() -> int:
         print(f"{len(carry_only)} file(s) the carry changed are outside the "
               "PR entirely. Rebuilding from the PR head would drop them, so it "
               "is NOT equivalent to merging; carry each one across deliberately.")
-    # Matching an older commit of the PR proves only that we never edited the
-    # file, not that we want the newest one: the carry may be holding that
-    # vintage on purpose, which this cannot see. Rebuilding moves it to head, so
-    # the unqualified "nothing is lost" below has to stand down and say so.
+    # Matching an older commit of the PR proves only that we never edited the file, not that we want the newest one: the carry may be holding that vintage on purpose, which this cannot see.
+    # Rebuilding moves it to head, so the unqualified "nothing is lost" below has to stand down and say so.
     older = [e for e in superseded if not e["current"]]
     if older:
         print(f"{len(older)} file(s) sit at an OLDER vintage than the PR head. "

--- a/scripts/unsloth/carry_vintage.py
+++ b/scripts/unsloth/carry_vintage.py
@@ -168,7 +168,16 @@ def main() -> int:
         print(f"{len(carry_only)} file(s) the carry changed are outside the "
               "PR entirely. Rebuilding from the PR head would drop them, so it "
               "is NOT equivalent to merging; carry each one across deliberately.")
-    if not diverged and not omitted and not carry_only:
+    # Matching an older commit of the PR proves only that we never edited the
+    # file, not that we want the newest one: the carry may be holding that
+    # vintage on purpose, which this cannot see. Rebuilding moves it to head, so
+    # the unqualified "nothing is lost" below has to stand down and say so.
+    older = [e for e in superseded if not e["current"]]
+    if older:
+        print(f"{len(older)} file(s) sit at an OLDER vintage than the PR head. "
+              "We never edited them, but a rebuild still moves them to head; "
+              "confirm no carry is holding one of them deliberately.")
+    if not diverged and not omitted and not carry_only and not older:
         print("Nothing diverges. Rebuilding the carry from the PR head is "
               "equivalent to merging it, without the conflicts.")
 

--- a/scripts/unsloth/carry_vintage.py
+++ b/scripts/unsloth/carry_vintage.py
@@ -64,7 +64,14 @@ def main() -> int:
     head = git("rev-parse", a.pr_ref)
     fork = git("merge-base", head, a.base)
     files = [f for f in git("diff", "--name-only", fork, head).split("\n") if f]
-    history = git("rev-list", f"--max-count={a.max_commits}", head).split("\n")
+    # fork..head, not head: `--max-count` caps the output, it does not bound
+    # the walk, so a bare `head` runs straight past the fork point into the
+    # base branch. A file our carry deliberately holds at the BASE version
+    # then matches a pre-fork commit and is called SUPERSEDED, and the summary
+    # says rebuilding from the PR head is equivalent -- it is not, it re-adds
+    # what the carry dropped. Only commits of the PR itself are vintages.
+    history = [c for c in git("rev-list", f"--max-count={a.max_commits}",
+                              f"{fork}..{head}").split("\n") if c]
 
     superseded, diverged, absent = [], [], []
     for path in files:

--- a/scripts/unsloth/carry_vintage.py
+++ b/scripts/unsloth/carry_vintage.py
@@ -89,7 +89,19 @@ def main() -> int:
         if ours == blob(head, path):
             superseded.append({"path": path, "vintage": head, "current": True})
             continue
-        hit = next((c for c in history if blob(c, path) == ours), None)
+        # Bounding the walk to fork..head is not enough on its own. A PR with
+        # several commits usually does not touch every file in its first one,
+        # so the commits BEFORE the one that first changed this path still
+        # carry the fork's blob -- inside the range. A carry holding the file
+        # at the base version matches one of those and is called SUPERSEDED
+        # again, and the summary again says a rebuild is equivalent when it
+        # would overwrite exactly what the carry is holding. Our copy being
+        # the fork's copy is not evidence the PR ever produced it, so it is
+        # never a vintage; such a file falls through to DIVERGED, which is
+        # where a file needing a human decision belongs.
+        at_fork = blob(fork, path)
+        hit = None if ours == at_fork else \
+            next((c for c in history if blob(c, path) == ours), None)
         if hit:
             superseded.append({"path": path, "vintage": hit, "current": False})
         else:
@@ -101,7 +113,8 @@ def main() -> int:
         note = "already at PR head" if e["current"] else f"our copy is upstream {e['vintage'][:10]}"
         print(f"  SUPERSEDED  {e['path']}\n              {note}")
     for p in diverged:
-        print(f"  DIVERGED    {p}\n              matches no upstream vintage; we changed it, keep it")
+        print(f"  DIVERGED    {p}\n              matches no upstream vintage; we changed it, or we are "
+              "holding the base version on purpose. Keep it")
     for p in omitted:
         print(f"  OMITTED     {p}\n              exists at the PR head, not in the carry; "
               "a rebuild would re-add it")

--- a/scripts/unsloth/carry_vintage.py
+++ b/scripts/unsloth/carry_vintage.py
@@ -65,7 +65,16 @@ def main() -> int:
 
     head = git("rev-parse", a.pr_ref)
     fork = git("merge-base", head, a.base)
-    files = [f for f in git("diff", "--name-only", fork, head).split("\n") if f]
+    # --no-renames, because rename detection hides exactly the path that
+    # matters here. `git diff --name-only` prints only the NEW name of a
+    # rename, so a PR moving `old` to `new` never puts `old` in this list. A
+    # carry that deliberately keeps `old` is then never looked at: `new` comes
+    # back SUPERSEDED, nothing diverges, and the summary says a rebuild is
+    # equivalent when a rebuild deletes the file the carry is holding. Without
+    # detection the rename is a delete plus an add, so `old` is classified --
+    # DIVERGED, since our copy is the fork's and matches no upstream vintage.
+    files = [f for f in git("diff", "--name-only", "--no-renames",
+                            fork, head).split("\n") if f]
     # fork..head, not head: `--max-count` caps the output, it does not bound
     # the walk, so a bare `head` runs straight past the fork point into the
     # base branch. A file our carry deliberately holds at the BASE version

--- a/scripts/unsloth/carry_vintage.py
+++ b/scripts/unsloth/carry_vintage.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+"""Report which carry files are an unmodified older copy of the upstream PR.
+
+A carry branch replays an upstream PR onto an aged base tag. When that PR moves,
+the question before every refresh is the same one: have we actually changed this
+file, or are we just holding a stale copy of theirs? Answering it by hand means
+diffing every file the PR touches and reading each hunk, which is what made the
+08-27 GLM-5-Next refresh expensive, and two of those hand answers were wrong.
+
+The mechanical answer: if our version of a file is byte-identical to the version
+at SOME commit of the upstream PR, then we never edited it, and their newer copy
+supersedes ours with nothing lost. That is a fact about blob hashes, not a
+judgement. Files we really did change match no upstream commit and are reported
+as diverged, which is correct: on 08-27 gguf-py/gguf/tensor_mapping.py did not
+match, because it genuinely carried qwen4exp additions as well.
+
+This only reports. It does not resolve, stage or write anything, because
+"upstream superseded ours" is not the same as "we want upstream's", and holding
+a deliberately older vintage is a legitimate decision this script cannot see.
+
+Use it to decide whether a refresh should merge or simply rebuild:
+
+    python3 scripts/unsloth/carry_vintage.py \\
+        --carry <carry sha> --pr-ref refs/pull/27754/head --base refs/tags/b10639
+
+When every file is SUPERSEDED, rebuilding the carry from the PR head avoids the
+merge, and its conflicts, entirely.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+
+
+def git(*args: str) -> str:
+    r = subprocess.run(["git", *args], capture_output=True, text=True)
+    if r.returncode:
+        raise RuntimeError(" ".join(args) + ": " + r.stderr.strip())
+    return r.stdout.strip()
+
+
+def blob(rev: str, path: str) -> str | None:
+    r = subprocess.run(["git", "rev-parse", f"{rev}:{path}"],
+                       capture_output=True, text=True)
+    return r.stdout.strip() if r.returncode == 0 else None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--carry", required=True, help="carry branch commit")
+    ap.add_argument("--pr-ref", required=True, help="upstream PR head ref or sha")
+    ap.add_argument("--base", required=True, help="base tag the PR forked from")
+    ap.add_argument("--max-commits", type=int, default=60,
+                    help="how far back through the PR to look for a match")
+    ap.add_argument("--report", metavar="PATH", help="write a JSON summary here")
+    a = ap.parse_args()
+
+    head = git("rev-parse", a.pr_ref)
+    fork = git("merge-base", head, a.base)
+    files = [f for f in git("diff", "--name-only", fork, head).split("\n") if f]
+    history = git("rev-list", f"--max-count={a.max_commits}", head).split("\n")
+
+    superseded, diverged, absent = [], [], []
+    for path in files:
+        ours = blob(a.carry, path)
+        if ours is None:
+            absent.append(path)
+            continue
+        if ours == blob(head, path):
+            superseded.append({"path": path, "vintage": head, "current": True})
+            continue
+        hit = next((c for c in history if blob(c, path) == ours), None)
+        if hit:
+            superseded.append({"path": path, "vintage": hit, "current": False})
+        else:
+            diverged.append(path)
+
+    print(f"carry {a.carry[:10]} vs {a.pr_ref} ({head[:10]}), {len(files)} file(s) touched")
+    print()
+    for e in superseded:
+        note = "already at PR head" if e["current"] else f"our copy is upstream {e['vintage'][:10]}"
+        print(f"  SUPERSEDED  {e['path']}\n              {note}")
+    for p in diverged:
+        print(f"  DIVERGED    {p}\n              matches no upstream vintage; we changed it, keep it")
+    for p in absent:
+        print(f"  ABSENT      {p}\n              not in the carry")
+    print()
+    if diverged:
+        print(f"{len(diverged)} file(s) genuinely diverge. A refresh has to merge, "
+              "and those files are the only ones needing judgement.")
+    else:
+        print("Nothing diverges. Rebuilding the carry from the PR head is "
+              "equivalent to merging it, without the conflicts.")
+
+    if a.report:
+        with open(a.report, "w") as fh:
+            json.dump({"head": head, "superseded": superseded,
+                       "diverged": diverged, "absent": absent}, fh, indent=2)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/unsloth/carry_vintage.py
+++ b/scripts/unsloth/carry_vintage.py
@@ -47,9 +47,18 @@ def git(*args: str) -> str:
 
 
 def blob(rev: str, path: str) -> str | None:
-    r = subprocess.run(["git", "rev-parse", f"{rev}:{path}"],
+    """The tree entry as "mode oid", or None if the rev has no such path.
+
+    Mode, not just the oid: a carry that only chmods a file it took verbatim
+    has the same content as upstream, so an oid comparison calls it superseded
+    and a rebuild silently drops the mode change.
+    """
+    r = subprocess.run(["git", "ls-tree", "--full-tree", "-z", rev, "--", path],
                        capture_output=True, text=True)
-    return r.stdout.strip() if r.returncode == 0 else None
+    if r.returncode != 0 or not r.stdout.strip():
+        return None
+    mode, _type, oid = r.stdout.split("\0")[0].split("\t", 1)[0].split()
+    return f"{mode} {oid}"
 
 
 def main() -> int:

--- a/scripts/unsloth/carry_vintage.py
+++ b/scripts/unsloth/carry_vintage.py
@@ -26,7 +26,9 @@ Use it to decide whether a refresh should merge or simply rebuild:
         --carry <carry sha> --pr-ref refs/pull/27754/head --base refs/tags/b10639
 
 When every file is SUPERSEDED, rebuilding the carry from the PR head avoids the
-merge, and its conflicts, entirely.
+merge, and its conflicts, entirely. A file the PR head still has and the carry
+does not is reported as OMITTED and blocks that advice, because a rebuild would
+restore it; a file the PR DELETED is merely ABSENT and blocks nothing.
 """
 
 from __future__ import annotations
@@ -73,11 +75,16 @@ def main() -> int:
     history = [c for c in git("rev-list", f"--max-count={a.max_commits}",
                               f"{fork}..{head}").split("\n") if c]
 
-    superseded, diverged, absent = [], [], []
+    superseded, diverged, absent, omitted = [], [], [], []
     for path in files:
         ours = blob(a.carry, path)
         if ours is None:
-            absent.append(path)
+            # Two very different reasons a path is missing from the carry. If
+            # the PR DELETED it, the carry agrees and a rebuild reproduces
+            # that. If it still exists at the PR head, the carry dropped it on
+            # purpose, and a rebuild would re-add it -- the same mistake as
+            # calling a file held at the base version superseded.
+            (absent if blob(head, path) is None else omitted).append(path)
             continue
         if ours == blob(head, path):
             superseded.append({"path": path, "vintage": head, "current": True})
@@ -95,20 +102,28 @@ def main() -> int:
         print(f"  SUPERSEDED  {e['path']}\n              {note}")
     for p in diverged:
         print(f"  DIVERGED    {p}\n              matches no upstream vintage; we changed it, keep it")
+    for p in omitted:
+        print(f"  OMITTED     {p}\n              exists at the PR head, not in the carry; "
+              "a rebuild would re-add it")
     for p in absent:
-        print(f"  ABSENT      {p}\n              not in the carry")
+        print(f"  ABSENT      {p}\n              deleted by the PR, not in the carry")
     print()
     if diverged:
         print(f"{len(diverged)} file(s) genuinely diverge. A refresh has to merge, "
               "and those files are the only ones needing judgement.")
-    else:
+    if omitted:
+        print(f"{len(omitted)} file(s) the PR head still has are missing from the "
+              "carry. Rebuilding would restore them, so it is NOT equivalent to "
+              "merging; keep or re-drop each one deliberately.")
+    if not diverged and not omitted:
         print("Nothing diverges. Rebuilding the carry from the PR head is "
               "equivalent to merging it, without the conflicts.")
 
     if a.report:
         with open(a.report, "w") as fh:
             json.dump({"head": head, "superseded": superseded,
-                       "diverged": diverged, "absent": absent}, fh, indent=2)
+                       "diverged": diverged, "omitted": omitted,
+                       "absent": absent}, fh, indent=2)
     return 0
 
 

--- a/scripts/unsloth/check_workflow_scalars.py
+++ b/scripts/unsloth/check_workflow_scalars.py
@@ -3,36 +3,24 @@
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
 """Fail when a workflow string is close to GitHub's 21000 character cap.
 
-GitHub's template compiler refuses any single string in a workflow file longer
-than 21000 characters. The whole file then fails to compile, and the failure is
-close to invisible:
+GitHub's template compiler refuses any single string in a workflow file longer than 21000 characters.
+The whole file then fails to compile, and the failure is close to invisible:
 
-  - the run has zero jobs, no annotations and an empty check suite, so there is
-    nothing to click on;
-  - `gh run view` says only "This run likely failed because of a workflow file
-    issue";
-  - the run is reported against whatever event triggered it, even an event the
-    workflow does not subscribe to, because compilation never got as far as
-    reading `on:`;
-  - and nothing local catches it. yaml parses the file, actionlint passes it,
-    and so does GitHub's own published parser (@actions/workflow-parser). The
-    limit is enforced only server-side.
+  - the run has zero jobs, no annotations and an empty check suite, so there is nothing to click on;
+  - `gh run view` says only "This run likely failed because of a workflow file issue";
+  - the run is reported against whatever event triggered it, even an event the workflow does not subscribe to, because compilation never got as far as reading `on:`;
+  - and nothing local catches it. yaml parses the file, actionlint passes it, and so does GitHub's own published parser (@actions/workflow-parser). The limit is enforced only server-side.
 
-On 08-27 a 14-line explanatory comment added inside the `resolve` job's script
-took it from 20503 to 21620 characters and silently disabled the entire release
-workflow for four pushes. The only way to see the real error was to fire a
-workflow_dispatch at the ref, which returns it as a 422:
+On 08-27 a 14-line explanatory comment added inside the `resolve` job's script took it from 20503 to 21620 characters and silently disabled the entire release workflow for four pushes.
+The only way to see the real error was to fire a workflow_dispatch at the ref, which returns it as a 422:
 
     (Line: 125, Col: 14): Exceeded max expression length 21000
 
-Comments inside a `run:` block scalar are part of the string and count against
-the limit. Comments in the YAML around it do not, so prose belongs above a step
-rather than inside it. Past that, the fix is to split the script into more
-steps: a step boundary costs nothing and resets the budget.
+Comments inside a `run:` block scalar are part of the string and count against the limit.
+Comments in the YAML around it do not, so prose belongs above a step rather than inside it.
+Past that, the fix is to split the script into more steps: a step boundary costs nothing and resets the budget.
 
-Measuring the parsed scalar is not exactly what GitHub measures, so the warn
-threshold is deliberately well below the cap rather than a character-perfect
-model of it.
+Measuring the parsed scalar is not exactly what GitHub measures, so the warn threshold is deliberately well below the cap rather than a character-perfect model of it.
 """
 
 from __future__ import annotations
@@ -43,8 +31,7 @@ from pathlib import Path
 
 import yaml
 
-# What GitHub enforces, and the point at which a script is big enough that the
-# next edit to it can cross the line without anyone thinking about size.
+# What GitHub enforces, and the point at which a script is big enough that the next edit to it can cross the line without anyone thinking about size.
 CAP = 21000
 WARN = 20000
 

--- a/scripts/unsloth/check_workflow_scalars.py
+++ b/scripts/unsloth/check_workflow_scalars.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+"""Fail when a workflow string is close to GitHub's 21000 character cap.
+
+GitHub's template compiler refuses any single string in a workflow file longer
+than 21000 characters. The whole file then fails to compile, and the failure is
+close to invisible:
+
+  - the run has zero jobs, no annotations and an empty check suite, so there is
+    nothing to click on;
+  - `gh run view` says only "This run likely failed because of a workflow file
+    issue";
+  - the run is reported against whatever event triggered it, even an event the
+    workflow does not subscribe to, because compilation never got as far as
+    reading `on:`;
+  - and nothing local catches it. yaml parses the file, actionlint passes it,
+    and so does GitHub's own published parser (@actions/workflow-parser). The
+    limit is enforced only server-side.
+
+On 08-27 a 14-line explanatory comment added inside the `resolve` job's script
+took it from 20503 to 21620 characters and silently disabled the entire release
+workflow for four pushes. The only way to see the real error was to fire a
+workflow_dispatch at the ref, which returns it as a 422:
+
+    (Line: 125, Col: 14): Exceeded max expression length 21000
+
+Comments inside a `run:` block scalar are part of the string and count against
+the limit. Comments in the YAML around it do not, so prose belongs above a step
+rather than inside it. Past that, the fix is to split the script into more
+steps: a step boundary costs nothing and resets the budget.
+
+Measuring the parsed scalar is not exactly what GitHub measures, so the warn
+threshold is deliberately well below the cap rather than a character-perfect
+model of it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+# What GitHub enforces, and the point at which a script is big enough that the
+# next edit to it can cross the line without anyone thinking about size.
+CAP = 21000
+WARN = 20000
+
+
+def scalars(node, path: str = ""):
+    """Every string in the document, with a path that names where it lives."""
+    if isinstance(node, str):
+        yield path, node
+    elif isinstance(node, dict):
+        for k, v in node.items():
+            yield from scalars(v, f"{path}.{k}")
+    elif isinstance(node, list):
+        for i, v in enumerate(node):
+            yield from scalars(v, f"{path}[{i}]")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--root", default=".", help="repository root")
+    ap.add_argument("--cap", type=int, default=CAP, help="hard limit, fails")
+    ap.add_argument("--warn", type=int, default=WARN, help="soft limit, warns")
+    a = ap.parse_args()
+
+    files = sorted(Path(a.root, ".github/workflows").glob("*.y*ml"))
+    if not files:
+        print(f"no workflows under {a.root}/.github/workflows", file=sys.stderr)
+        return 1
+
+    over, near = [], []
+    for f in files:
+        try:
+            doc = yaml.safe_load(f.read_text())
+        except yaml.YAMLError as e:
+            print(f"::error file={f}::not valid YAML: {e}", file=sys.stderr)
+            return 1
+        for path, s in scalars(doc):
+            if len(s) > a.cap:
+                over.append((len(s), f, path))
+            elif len(s) > a.warn:
+                near.append((len(s), f, path))
+
+    for n, f, path in sorted(near, reverse=True):
+        print(f"::warning file={f}::{path} is {n} characters, within "
+              f"{a.cap - n} of GitHub's {a.cap} character limit. Move any "
+              "prose out of the block scalar into YAML comments above the "
+              "step, or split the script into another step.")
+    for n, f, path in sorted(over, reverse=True):
+        print(f"::error file={f}::{path} is {n} characters, over GitHub's "
+              f"{a.cap} character limit. GitHub will refuse to compile this "
+              "file and every run of it will fail with no jobs and no "
+              "annotation. Split the script into another step; a step "
+              "boundary resets the budget.", file=sys.stderr)
+
+    biggest = max((len(s) for f in files for _, s in scalars(yaml.safe_load(f.read_text()))),
+                  default=0)
+    print(f"{len(files)} workflow(s), largest string {biggest} of {a.cap}"
+          f"{f', {len(near)} within {a.cap - a.warn} of the limit' if near else ''}")
+    return 1 if over else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/unsloth/merge_checks.py
+++ b/scripts/unsloth/merge_checks.py
@@ -69,15 +69,8 @@ from pathlib import Path
 ARCH = re.compile(r"arch == (LLM_ARCH_\w+)")
 COND = re.compile(r"^\s*(?:\}\s*)?else if \((.*)\)\s*\{\s*$|^\s*if \((.*)\)\s*\{\s*$")
 PURE_TERM = re.compile(r"arch == LLM_ARCH_\w+")
-# Blanked before braces are counted, so a `{` in a comment or a chat template
-# string does not shift the depth for everything after it.
-_BLOCK = re.compile(r"/\*.*?\*/", re.S)
-_LINE = re.compile(r"//.*")
-_STR = re.compile(r'"(?:\\.|[^"\\])*"|\'(?:\\.|[^\'\\])*\'')
-# R"delim(...)delim" ends only at its own delimiter, so it may hold quotes and
-# braces that _STR would misread. Blanked first, and before comments, because a
-# raw string full of `//` is ordinary and a comment holding `R"(` is not.
-_RAW = re.compile(r'R"([^()\\ \t\n]{0,16})\(.*?\)\1"', re.S)
+# Encoding prefixes a raw string may carry: LR"(...)", u8R"(...)" and so on.
+_RAW_PREFIX = ("", "L", "u", "U", "u8")
 
 
 def duplicate_dict_keys(path: Path) -> list[str]:
@@ -106,21 +99,68 @@ def _pure_arch_disjunction(cond: str) -> bool:
     return bool(terms) and all(PURE_TERM.fullmatch(t) for t in terms)
 
 
+def _raw_delim(text: str, i: int) -> str | None:
+    """The delimiter of a raw string starting at `i`, or None if one does not.
+
+    `i` indexes the `R`. The delimiter is what sits between `R"` and `(`, and
+    the literal ends only at `)delim"`, which is the whole reason a raw string
+    cannot be found with a plain regex.
+    """
+    if not text.startswith('R"', i):
+        return None
+    j = text.find("(", i + 2)
+    if j == -1:
+        return None
+    delim = text[i + 2:j]
+    if len(delim) > 16 or any(c in ' ()\\\t\n' for c in delim):
+        return None
+    # An `R` glued to an identifier is part of that identifier, not a prefix.
+    k = i
+    while k > 0 and (text[k - 1].isalnum() or text[k - 1] == "_"):
+        k -= 1
+    return delim if text[k:i] in _RAW_PREFIX else None
+
+
 def _decommented(text: str) -> list[str]:
     """The file with comments and literals blanked, line structure preserved.
 
     Braces inside a string literal or a comment are not braces. src/ is full of
     both (llama-chat.cpp alone embeds dozens of `{` in template strings), so
     counting them raw would desynchronise the depth for the rest of the file.
+
+    Scanned once, left to right, rather than by substituting one construct at a
+    time. Order cannot fix a substitution pass: blanking raw strings first lets
+    an `R"(` written inside a comment swallow everything to the next `)"`, and
+    blanking comments first lets a `//` inside a raw string end the line. Only
+    position decides which construct is real, and a scan is what knows it.
     """
-    blank = lambda m: re.sub(r"[^\n]", " ", m.group(0))   # noqa: E731
-    text = _RAW.sub(blank, text)
-    text = _BLOCK.sub(blank, text)
-    out = []
-    for line in text.split("\n"):
-        line = _STR.sub(lambda m: " " * len(m.group(0)), line)
-        out.append(_LINE.sub(lambda m: " " * len(m.group(0)), line))
-    return out
+    blank = lambda s: re.sub(r"[^\n]", " ", s)            # noqa: E731
+    out: list[str] = []
+    i, n = 0, len(text)
+    while i < n:
+        delim = _raw_delim(text, i)
+        if delim is not None:
+            close = f'){delim}"'
+            k = text.find(close, i + 2 + len(delim) + 1)
+            end = n if k == -1 else k + len(close)
+        elif text.startswith("//", i):
+            k = text.find("\n", i)
+            end = n if k == -1 else k
+        elif text.startswith("/*", i):
+            k = text.find("*/", i + 2)
+            end = n if k == -1 else k + 2
+        elif text[i] in "\"'":
+            q, j = text[i], i + 1
+            while j < n and text[j] != q and text[j] != "\n":
+                j += 2 if text[j] == "\\" else 1
+            end = min(j + 1, n)
+        else:
+            out.append(text[i])
+            i += 1
+            continue
+        out.append(blank(text[i:end]))
+        i = end
+    return "".join(out).split("\n")
 
 
 def _depths(line: str, start: int) -> tuple[int, int]:

--- a/scripts/unsloth/merge_checks.py
+++ b/scripts/unsloth/merge_checks.py
@@ -155,6 +155,15 @@ def if_else_chains(text: str) -> list[list[tuple[int, str]]]:
         if c and len(c) > 1:
             done.append(c)
 
+    # A chain's closing brace and its `else if` are often on separate lines,
+    # which llama.cpp does in src/llama-quant.cpp:461 among others. Closing the
+    # chain the moment the brace line dedents would end it one line before the
+    # arm that continues it, and the duplicate arch arm after it would then be
+    # a fresh chain with nothing taken yet, so the gate passes it. Ending a
+    # chain is therefore deferred one line: the next line either continues it,
+    # or it really is over. Blank lines do not decide either way.
+    pending: set[int] = set()
+
     depth = 0
     for i, (line, cline) in enumerate(zip(raw, clean)):
         after, lo = _depths(cline, depth)
@@ -167,11 +176,17 @@ def if_else_chains(text: str) -> list[list[tuple[int, str]]]:
         # to; a plain `if` opens one at the depth it starts from.
         cont = bool(m) and (stripped.startswith("}") or stripped.startswith("else"))
         key = lo if cont else depth
-        # Any chain whose closing brace this line just passed is over, except
-        # the one this very line continues.
+        if stripped:
+            if cont:
+                pending.discard(key)       # this line continues it after all
+            for k in sorted(pending, reverse=True):
+                flush(k)
+            pending.clear()
+        # Any chain whose closing brace this line just passed is over, unless
+        # the next line turns out to continue it.
         for k in [k for k in sorted(open_chains, reverse=True) if k >= lo]:
             if not (cont and k == key):
-                flush(k)
+                pending.add(k)
         if m:
             cond = m.group(1) or m.group(2) or ""
             if cont and key in open_chains:
@@ -179,6 +194,10 @@ def if_else_chains(text: str) -> list[list[tuple[int, str]]]:
             else:
                 flush(key)
                 open_chains[key] = [(i + 1, cond)]
+            # A line that both dedents and opens a chain at the same key would
+            # otherwise leave that key pending and flush the chain it just
+            # opened on the next line.
+            pending.discard(key)
         depth = after
     for k in sorted(open_chains, reverse=True):
         flush(k)

--- a/scripts/unsloth/merge_checks.py
+++ b/scripts/unsloth/merge_checks.py
@@ -31,6 +31,8 @@ Both are deliberately narrow, because a check that fires wrongly blocks a releas
     This is an accuracy fix, not a widening: measured over all 181 src/**/*.cpp, depth and indentation report the same zero findings, so nothing new fires and the good tree stays clean, but depth keeps 339 arms in chains against 260 and is right in both directions where they differ.
     Indentation drops the enclosing chain at any nested `if`, which silences the check on the exact 08-27 shape, and it glues two unrelated `if`s at one indent into a single chain whenever the second opener is a skipped multiline condition, which reports a reachable arm as dead and blocks a release on good code.
 
+  - The duplicate-key check compares keys by their source text, so it only looks at keys whose value cannot change between evaluations: literals, names, attributes and tuples of those. `{fresh(): 1, fresh(): 2}` reads as one key twice and is really two entries, and a finding here stops the nightly.
+
   - There is deliberately NO duplicate-C++-definition check.
     The obvious version keys on function name and flags legitimate overloads: it reported `llama_model_base::create_tensor`, which is two different signatures.
     A real duplicate is an ODR violation the compiler already rejects, so the only gain would be failing sooner, which does not justify a false positive on the release path.
@@ -56,6 +58,24 @@ PURE_TERM = re.compile(r"arch == LLM_ARCH_\w+")
 _RAW_PREFIX = ("", "L", "u", "U", "u8")
 
 
+# Node types whose value does not depend on when the expression is evaluated.
+# An allowlist, not a denylist, so an expression shape nobody thought about is
+# treated as unstable and simply not checked, rather than blocking a release.
+_STABLE = (ast.Constant, ast.Name, ast.Attribute, ast.Tuple, ast.Load,
+           ast.UnaryOp, ast.USub, ast.UAdd, ast.Invert)
+
+
+def _stable_key(node: ast.AST) -> bool:
+    """True when this key expression names the same object every evaluation.
+
+    `{fresh(): 1, fresh(): 2}` unparses to the same text twice and is still two
+    entries, so a call anywhere in the key means the two are not comparable by
+    text. The keys this check exists for, `MODEL_ARCH.GLM5NEXT` and plain
+    literals, are all stable.
+    """
+    return all(isinstance(n, _STABLE) for n in ast.walk(node))
+
+
 def duplicate_dict_keys(path: Path) -> list[str]:
     """Keys defined twice in one dict literal. Always at best dead code."""
     try:
@@ -66,7 +86,8 @@ def duplicate_dict_keys(path: Path) -> list[str]:
     for node in ast.walk(tree):
         if not isinstance(node, ast.Dict):
             continue
-        keys = [ast.unparse(k) for k in node.keys if k is not None]
+        keys = [ast.unparse(k) for k in node.keys
+                if k is not None and _stable_key(k)]
         for key, n in collections.Counter(keys).items():
             if n > 1:
                 out.append(f"{path}:{node.lineno}: key {key} defined {n} times "

--- a/scripts/unsloth/merge_checks.py
+++ b/scripts/unsloth/merge_checks.py
@@ -74,6 +74,10 @@ PURE_TERM = re.compile(r"arch == LLM_ARCH_\w+")
 _BLOCK = re.compile(r"/\*.*?\*/", re.S)
 _LINE = re.compile(r"//.*")
 _STR = re.compile(r'"(?:\\.|[^"\\])*"|\'(?:\\.|[^\'\\])*\'')
+# R"delim(...)delim" ends only at its own delimiter, so it may hold quotes and
+# braces that _STR would misread. Blanked first, and before comments, because a
+# raw string full of `//` is ordinary and a comment holding `R"(` is not.
+_RAW = re.compile(r'R"([^()\\ \t\n]{0,16})\(.*?\)\1"', re.S)
 
 
 def duplicate_dict_keys(path: Path) -> list[str]:
@@ -109,7 +113,9 @@ def _decommented(text: str) -> list[str]:
     both (llama-chat.cpp alone embeds dozens of `{` in template strings), so
     counting them raw would desynchronise the depth for the rest of the file.
     """
-    text = _BLOCK.sub(lambda m: re.sub(r"[^\n]", " ", m.group(0)), text)
+    blank = lambda m: re.sub(r"[^\n]", " ", m.group(0))   # noqa: E731
+    text = _RAW.sub(blank, text)
+    text = _BLOCK.sub(blank, text)
     out = []
     for line in text.split("\n"):
         line = _STR.sub(lambda m: " " * len(m.group(0)), line)

--- a/scripts/unsloth/merge_checks.py
+++ b/scripts/unsloth/merge_checks.py
@@ -3,59 +3,40 @@
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
 """Post-merge checks for the two mistakes a clean build does not catch.
 
-Both of these were made for real on 08-27, resolving GLM-5-Next against the
-qwen4exp carry, and both survived compilation:
+Both of these were made for real on 08-27, resolving GLM-5-Next against the qwen4exp carry, and both survived compilation:
 
-  1. A resolver unioned two byte-identical additions and produced the same
-     `MODEL_ARCH.GLM5NEXT` key twice in the tensor map. Python keeps the last
-     definition of a duplicate key, silently, so the file imports, the build
-     passes, and the converter reads the wrong mapping.
+  1. A resolver unioned two byte-identical additions and produced the same `MODEL_ARCH.GLM5NEXT` key twice in the tensor map.
+     Python keeps the last definition of a duplicate key, silently, so the file imports, the build passes, and the converter reads the wrong mapping.
 
-  2. The same union kept both an arch in a shared fallthrough condition AND a
-     dedicated `else if (arch == LLM_ARCH_GLM5NEXT)` arm below it. The shared
-     condition matches first, so the dedicated arm is dead. It compiles, and the
-     model runs with the indexer cache that arm was supposed to build.
+  2. The same union kept both an arch in a shared fallthrough condition AND a dedicated `else if (arch == LLM_ARCH_GLM5NEXT)` arm below it.
+     The shared condition matches first, so the dedicated arm is dead.
+     It compiles, and the model runs with the indexer cache that arm was supposed to build.
 
-Neither is a merge resolver. They decide nothing and rewrite nothing. They turn
-a silent wrong answer into a loud one, which is the property that was missing.
+Neither is a merge resolver.
+They decide nothing and rewrite nothing.
+They turn a silent wrong answer into a loud one, which is the property that was missing.
 
-Both are deliberately narrow, because a check that fires wrongly blocks a
-release just as effectively as a bad merge:
+Both are deliberately narrow, because a check that fires wrongly blocks a release just as effectively as a bad merge:
 
-  - An arch is only consumed by an EARLIER arm that is a pure disjunction of
-    `arch == LLM_ARCH_*` terms. A conditional arm may not run, so what follows
-    it stays reachable. The later arm is then dead if it is a disjunction whose
-    alternatives are all consumed, or a plain conjunction requiring a consumed
-    arch, since its other conditions can only narrow it further. Anything
-    mixing `||` and `&&` is left alone, and only a term that is exactly
-    `arch == X` counts, so `arch != X` is never read as requiring that arch.
+  - An arch is only consumed by an EARLIER arm that is a pure disjunction of `arch == LLM_ARCH_*` terms.
+    A conditional arm may not run, so what follows it stays reachable.
+    The later arm is then dead if it is a disjunction whose alternatives are all consumed, or a plain conjunction requiring a consumed arch, since its other conditions can only narrow it further.
+    Anything mixing `||` and `&&` is left alone, and only a term that is exactly `arch == X` counts, so `arch != X` is never read as requiring that arch.
 
-  - The unreachable-arm check reads one physical line, so a condition split
-    across lines is skipped rather than analysed. Checked against the whole of
-    src/: a line-joining variant finds exactly the same zero findings, because
-    every multiline arch condition there is a standalone `if` with no `else if`
-    chain below it. Widening the regex would add false-positive surface on the
-    release path and buy nothing today, so it stays narrow and this is recorded
-    as a known limitation rather than fixed.
+  - The unreachable-arm check reads one physical line, so a condition split across lines is skipped rather than analysed.
+    Checked against the whole of src/: a line-joining variant finds exactly the same zero findings, because every multiline arch condition there is a standalone `if` with no `else if` chain below it.
+    Widening the regex would add false-positive surface on the release path and buy nothing today, so it stays narrow and this is recorded as a known limitation rather than fixed.
 
-  - Chains are grouped by BRACE DEPTH, not by indentation. This is an accuracy
-    fix, not a widening: measured over all 181 src/**/*.cpp, depth and
-    indentation report the same zero findings, so nothing new fires and the
-    good tree stays clean, but depth keeps 339 arms in chains against 260 and
-    is right in both directions where they differ. Indentation drops the
-    enclosing chain at any nested `if`, which silences the check on the exact
-    08-27 shape, and it glues two unrelated `if`s at one indent into a single
-    chain whenever the second opener is a skipped multiline condition, which
-    reports a reachable arm as dead and blocks a release on good code.
+  - Chains are grouped by BRACE DEPTH, not by indentation.
+    This is an accuracy fix, not a widening: measured over all 181 src/**/*.cpp, depth and indentation report the same zero findings, so nothing new fires and the good tree stays clean, but depth keeps 339 arms in chains against 260 and is right in both directions where they differ.
+    Indentation drops the enclosing chain at any nested `if`, which silences the check on the exact 08-27 shape, and it glues two unrelated `if`s at one indent into a single chain whenever the second opener is a skipped multiline condition, which reports a reachable arm as dead and blocks a release on good code.
 
-  - There is deliberately NO duplicate-C++-definition check. The obvious version
-    keys on function name and flags legitimate overloads: it reported
-    `llama_model_base::create_tensor`, which is two different signatures. A real
-    duplicate is an ODR violation the compiler already rejects, so the only gain
-    would be failing sooner, which does not justify a false positive on the
-    release path.
+  - There is deliberately NO duplicate-C++-definition check.
+    The obvious version keys on function name and flags legitimate overloads: it reported `llama_model_base::create_tensor`, which is two different signatures.
+    A real duplicate is an ODR violation the compiler already rejects, so the only gain would be failing sooner, which does not justify a false positive on the release path.
 
-Exits 0 when clean, 1 when anything is found. `--report` emits JSON.
+Exits 0 when clean, 1 when anything is found.
+`--report` emits JSON.
 """
 
 from __future__ import annotations
@@ -104,9 +85,8 @@ def _pure_arch_disjunction(cond: str) -> bool:
 def _raw_delim(text: str, i: int) -> str | None:
     """The delimiter of a raw string starting at `i`, or None if one does not.
 
-    `i` indexes the `R`. The delimiter is what sits between `R"` and `(`, and
-    the literal ends only at `)delim"`, which is the whole reason a raw string
-    cannot be found with a plain regex.
+    `i` indexes the `R`.
+    The delimiter is what sits between `R"` and `(`, and the literal ends only at `)delim"`, which is the whole reason a raw string cannot be found with a plain regex.
     """
     if not text.startswith('R"', i):
         return None
@@ -126,15 +106,12 @@ def _raw_delim(text: str, i: int) -> str | None:
 def _decommented(text: str) -> list[str]:
     """The file with comments and literals blanked, line structure preserved.
 
-    Braces inside a string literal or a comment are not braces. src/ is full of
-    both (llama-chat.cpp alone embeds dozens of `{` in template strings), so
-    counting them raw would desynchronise the depth for the rest of the file.
+    Braces inside a string literal or a comment are not braces.
+    src/ is full of both (llama-chat.cpp alone embeds dozens of `{` in template strings), so counting them raw would desynchronise the depth for the rest of the file.
 
-    Scanned once, left to right, rather than by substituting one construct at a
-    time. Order cannot fix a substitution pass: blanking raw strings first lets
-    an `R"(` written inside a comment swallow everything to the next `)"`, and
-    blanking comments first lets a `//` inside a raw string end the line. Only
-    position decides which construct is real, and a scan is what knows it.
+    Scanned once, left to right, rather than by substituting one construct at a time.
+    Order cannot fix a substitution pass: blanking raw strings first lets an `R"(` written inside a comment swallow everything to the next `)"`, and blanking comments first lets a `//` inside a raw string end the line.
+    Only position decides which construct is real, and a scan is what knows it.
     """
     blank = lambda s: re.sub(r"[^\n]", " ", s)            # noqa: E731
     out: list[str] = []
@@ -180,18 +157,13 @@ def _depths(line: str, start: int) -> tuple[int, int]:
 def if_else_chains(text: str) -> list[list[tuple[int, str]]]:
     """Group `if` / `else if` conditions into chains by BRACE DEPTH.
 
-    Indentation is not the structure. Keying chains on it, and resetting on any
-    change, means a nested `if` inside an arm replaces the enclosing chain, so
-    the outer arms after it are analysed as a fresh chain and an arch the outer
-    chain already matched looks unmatched. That is a gate that stops gating on
-    a shape that is ordinary C++: the arch dispatch at llama-model.cpp:2434 is
-    exactly one nested `if` away from it.
+    Indentation is not the structure.
+    Keying chains on it, and resetting on any change, means a nested `if` inside an arm replaces the enclosing chain, so the outer arms after it are analysed as a fresh chain and an arch the outer chain already matched looks unmatched.
+    That is a gate that stops gating on a shape that is ordinary C++: the arch dispatch at llama-model.cpp:2434 is exactly one nested `if` away from it.
 
-    The same key also mis-JOINS. Two unrelated `if`s at the same indentation
-    become one chain whenever the second one's opener is a condition the regex
-    skips, and then a perfectly reachable arm is reported unreachable, which
-    blocks a release on good code. Depth gets both right: a chain lives at the
-    depth its `if` opened at, and ends when a brace takes the file back past it.
+    The same key also mis-JOINS.
+    Two unrelated `if`s at the same indentation become one chain whenever the second one's opener is a condition the regex skips, and then a perfectly reachable arm is reported unreachable, which blocks a release on good code.
+    Depth gets both right: a chain lives at the depth its `if` opened at, and ends when a brace takes the file back past it.
     """
     raw = text.split("\n")
     clean = _decommented(text)
@@ -203,29 +175,21 @@ def if_else_chains(text: str) -> list[list[tuple[int, str]]]:
         if c and len(c) > 1:
             done.append(c)
 
-    # A chain's closing brace and its `else if` are often on separate lines,
-    # which llama.cpp does in src/llama-quant.cpp:461 among others. Closing the
-    # chain the moment the brace line dedents would end it one line before the
-    # arm that continues it, and the duplicate arch arm after it would then be
-    # a fresh chain with nothing taken yet, so the gate passes it. Ending a
-    # chain is therefore deferred one line: the next line either continues it,
-    # or it really is over. Blank lines do not decide either way.
+    # A chain's closing brace and its `else if` are often on separate lines, which llama.cpp does in src/llama-quant.cpp:461 among others.
+    # Closing the chain the moment the brace line dedents would end it one line before the arm that continues it, and the duplicate arch arm after it would then be a fresh chain with nothing taken yet, so the gate passes it.
+    # Ending a chain is therefore deferred one line: the next line either continues it, or it really is over.
+    # Blank lines do not decide either way.
     pending: set[int] = set()
 
     depth = 0
     for i, (line, cline) in enumerate(zip(raw, clean)):
         after, lo = _depths(cline, depth)
         stripped = cline.lstrip()
-        # Matched on the decommented line: COND anchors on the `{` ending the
-        # line, so `if (arch == X) { // shared` matched nothing on the raw line
-        # and the arm vanished from the chain. _decommented blanks in place, so
-        # the spans still index the raw line and the condition text below is
-        # taken from there, intact. A line that blanked away entirely is
-        # commented-out code and opens nothing.
+        # Matched on the decommented line: COND anchors on the `{` ending the line, so `if (arch == X) { // shared` matched nothing on the raw line and the arm vanished from the chain.
+        # _decommented blanks in place, so the spans still index the raw line and the condition text below is taken from there, intact.
+        # A line that blanked away entirely is commented-out code and opens nothing.
         m = COND.search(cline) if stripped else None
-        # `} else if (...) {` and a bare `else if (...) {` after its own `}`
-        # line both continue the chain that lives at the depth this line dips
-        # to; a plain `if` opens one at the depth it starts from.
+        # `} else if (...) {` and a bare `else if (...) {` after its own `}` line both continue the chain that lives at the depth this line dips to; a plain `if` opens one at the depth it starts from.
         cont = bool(m) and (stripped.startswith("}") or stripped.startswith("else"))
         key = lo if cont else depth
         if stripped:
@@ -234,8 +198,7 @@ def if_else_chains(text: str) -> list[list[tuple[int, str]]]:
             for k in sorted(pending, reverse=True):
                 flush(k)
             pending.clear()
-        # Any chain whose closing brace this line just passed is over, unless
-        # the next line turns out to continue it.
+        # Any chain whose closing brace this line just passed is over, unless the next line turns out to continue it.
         for k in [k for k in sorted(open_chains, reverse=True) if k >= lo]:
             if not (cont and k == key):
                 pending.add(k)
@@ -247,9 +210,7 @@ def if_else_chains(text: str) -> list[list[tuple[int, str]]]:
             else:
                 flush(key)
                 open_chains[key] = [(i + 1, cond)]
-            # A line that both dedents and opens a chain at the same key would
-            # otherwise leave that key pending and flush the chain it just
-            # opened on the next line.
+            # A line that both dedents and opens a chain at the same key would otherwise leave that key pending and flush the chain it just opened on the next line.
             pending.discard(key)
         depth = after
     for k in sorted(open_chains, reverse=True):
@@ -260,15 +221,10 @@ def if_else_chains(text: str) -> list[list[tuple[int, str]]]:
 def _blocked_by(cond: str, taken: set[str]) -> set[str]:
     """Arches that make this arm dead, given what earlier arms already took.
 
-    A pure disjunction is dead only when EVERY alternative is taken. A plain
-    conjunction is dead as soon as ONE of its `arch == X` conjuncts is, since
-    the other conditions can only narrow it further: an earlier unconditional
-    `arch == X` arm makes a later `arch == X && enabled` unreachable, and that
-    arm is not a pure disjunction so it used to be skipped entirely.
+    A pure disjunction is dead only when EVERY alternative is taken.
+    A plain conjunction is dead as soon as ONE of its `arch == X` conjuncts is, since the other conditions can only narrow it further: an earlier unconditional `arch == X` arm makes a later `arch == X && enabled` unreachable, and that arm is not a pure disjunction so it used to be skipped entirely.
 
-    Anything mixing `||` and `&&` is left alone rather than guessed at, and only
-    a term that is exactly `arch == X` counts, so `!(arch == X)` and `arch != X`
-    cannot be read as requiring that arch.
+    Anything mixing `||` and `&&` is left alone rather than guessed at, and only a term that is exactly `arch == X` counts, so `!(arch == X)` and `arch != X` cannot be read as requiring that arch.
     """
     archs = set(ARCH.findall(cond))
     if not archs:
@@ -296,8 +252,8 @@ def unreachable_arch_arms(path: Path) -> list[str]:
                 out.append(f"{path}:{lineno}: unreachable, "
                            f"{', '.join(sorted(dead))} already matched earlier "
                            "in this if/else chain")
-            # Only an unconditional arm consumes an arch. A conditional one may
-            # not run, so what follows it can still be reached.
+            # Only an unconditional arm consumes an arch.
+            # A conditional one may not run, so what follows it can still be reached.
             if _pure_arch_disjunction(cond):
                 taken |= set(ARCH.findall(cond))
     return out

--- a/scripts/unsloth/merge_checks.py
+++ b/scripts/unsloth/merge_checks.py
@@ -168,9 +168,13 @@ def if_else_chains(text: str) -> list[list[tuple[int, str]]]:
     for i, (line, cline) in enumerate(zip(raw, clean)):
         after, lo = _depths(cline, depth)
         stripped = cline.lstrip()
-        # Matched on the raw line, so the condition text is intact, but a line
-        # that blanked away entirely is commented-out code and opens nothing.
-        m = COND.search(line) if stripped else None
+        # Matched on the decommented line: COND anchors on the `{` ending the
+        # line, so `if (arch == X) { // shared` matched nothing on the raw line
+        # and the arm vanished from the chain. _decommented blanks in place, so
+        # the spans still index the raw line and the condition text below is
+        # taken from there, intact. A line that blanked away entirely is
+        # commented-out code and opens nothing.
+        m = COND.search(cline) if stripped else None
         # `} else if (...) {` and a bare `else if (...) {` after its own `}`
         # line both continue the chain that lives at the depth this line dips
         # to; a plain `if` opens one at the depth it starts from.
@@ -188,7 +192,8 @@ def if_else_chains(text: str) -> list[list[tuple[int, str]]]:
             if not (cont and k == key):
                 pending.add(k)
         if m:
-            cond = m.group(1) or m.group(2) or ""
+            g = 1 if m.group(1) is not None else 2
+            cond = line[m.start(g):m.end(g)]
             if cont and key in open_chains:
                 open_chains[key].append((i + 1, cond))
             else:

--- a/scripts/unsloth/merge_checks.py
+++ b/scripts/unsloth/merge_checks.py
@@ -28,6 +28,14 @@ release just as effectively as a bad merge:
     chain is skipped. With that restriction the verdict follows from the code:
     matching that arch always takes the earlier branch.
 
+  - The unreachable-arm check reads one physical line, so a condition split
+    across lines is skipped rather than analysed. Checked against the whole of
+    src/: a line-joining variant finds exactly the same zero findings, because
+    every multiline arch condition there is a standalone `if` with no `else if`
+    chain below it. Widening the regex would add false-positive surface on the
+    release path and buy nothing today, so it stays narrow and this is recorded
+    as a known limitation rather than fixed.
+
   - There is deliberately NO duplicate-C++-definition check. The obvious version
     keys on function name and flags legitimate overloads: it reported
     `llama_model_base::create_tensor`, which is two different signatures. A real

--- a/scripts/unsloth/merge_checks.py
+++ b/scripts/unsloth/merge_checks.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+"""Post-merge checks for the two mistakes a clean build does not catch.
+
+Both of these were made for real on 08-27, resolving GLM-5-Next against the
+qwen4exp carry, and both survived compilation:
+
+  1. A resolver unioned two byte-identical additions and produced the same
+     `MODEL_ARCH.GLM5NEXT` key twice in the tensor map. Python keeps the last
+     definition of a duplicate key, silently, so the file imports, the build
+     passes, and the converter reads the wrong mapping.
+
+  2. The same union kept both an arch in a shared fallthrough condition AND a
+     dedicated `else if (arch == LLM_ARCH_GLM5NEXT)` arm below it. The shared
+     condition matches first, so the dedicated arm is dead. It compiles, and the
+     model runs with the indexer cache that arm was supposed to build.
+
+Neither is a merge resolver. They decide nothing and rewrite nothing. They turn
+a silent wrong answer into a loud one, which is the property that was missing.
+
+Both are deliberately narrow, because a check that fires wrongly blocks a
+release just as effectively as a bad merge:
+
+  - The unreachable-arm check only fires when the EARLIER condition is a pure
+    disjunction of `arch == LLM_ARCH_*` terms. If it contains `&&` or anything
+    else, a later arm testing the same arch can genuinely be reachable, so the
+    chain is skipped. With that restriction the verdict follows from the code:
+    matching that arch always takes the earlier branch.
+
+  - There is deliberately NO duplicate-C++-definition check. The obvious version
+    keys on function name and flags legitimate overloads: it reported
+    `llama_model_base::create_tensor`, which is two different signatures. A real
+    duplicate is an ODR violation the compiler already rejects, so the only gain
+    would be failing sooner, which does not justify a false positive on the
+    release path.
+
+Exits 0 when clean, 1 when anything is found. `--report` emits JSON.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import collections
+import json
+import re
+import sys
+from pathlib import Path
+
+ARCH = re.compile(r"arch == (LLM_ARCH_\w+)")
+COND = re.compile(r"^\s*(?:\}\s*)?else if \((.*)\)\s*\{\s*$|^\s*if \((.*)\)\s*\{\s*$")
+PURE_TERM = re.compile(r"arch == LLM_ARCH_\w+")
+
+
+def duplicate_dict_keys(path: Path) -> list[str]:
+    """Keys defined twice in one dict literal. Always at best dead code."""
+    try:
+        tree = ast.parse(path.read_text())
+    except SyntaxError as e:
+        return [f"{path}:{e.lineno}: does not parse: {e.msg}"]
+    out = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Dict):
+            continue
+        keys = [ast.unparse(k) for k in node.keys if k is not None]
+        for key, n in collections.Counter(keys).items():
+            if n > 1:
+                out.append(f"{path}:{node.lineno}: key {key} defined {n} times "
+                           "in one dict; Python keeps only the last")
+    return out
+
+
+def _pure_arch_disjunction(cond: str) -> bool:
+    """True when the condition is only `arch == X` terms joined by `||`."""
+    if "&&" in cond:
+        return False
+    terms = [t.strip() for t in cond.split("||")]
+    return bool(terms) and all(PURE_TERM.fullmatch(t) for t in terms)
+
+
+def unreachable_arch_arms(path: Path) -> list[str]:
+    """`else if` arms whose arch a preceding pure-disjunction arm already took."""
+    lines = path.read_text().split("\n")
+    chains: list[list[tuple[int, str]]] = []
+    cur: list[tuple[int, str]] = []
+    cur_indent = None
+    for i, line in enumerate(lines):
+        m = COND.search(line)
+        if not m:
+            continue
+        indent = len(line) - len(line.lstrip())
+        cond = m.group(1) or m.group(2) or ""
+        if line.lstrip().startswith("}") and cur_indent == indent:
+            cur.append((i + 1, cond))
+        else:
+            if len(cur) > 1:
+                chains.append(cur)
+            cur, cur_indent = [(i + 1, cond)], indent
+    if len(cur) > 1:
+        chains.append(cur)
+
+    out = []
+    for chain in chains:
+        taken: set[str] = set()
+        for lineno, cond in chain:
+            archs = set(ARCH.findall(cond))
+            if archs and _pure_arch_disjunction(cond) and archs <= taken:
+                out.append(f"{path}:{lineno}: unreachable, "
+                           f"{', '.join(sorted(archs))} already matched earlier "
+                           "in this if/else chain")
+            if _pure_arch_disjunction(cond):
+                taken |= archs
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--root", default=".", help="tree to check")
+    ap.add_argument("--report", metavar="PATH", help="write a JSON summary here")
+    a = ap.parse_args()
+    root = Path(a.root)
+
+    findings: list[str] = []
+    scanned = {"python": 0, "cpp": 0}
+    for p in sorted(root.glob("gguf-py/**/*.py")):
+        scanned["python"] += 1
+        findings += duplicate_dict_keys(p)
+    for p in sorted(root.glob("src/**/*.cpp")):
+        scanned["cpp"] += 1
+        findings += unreachable_arch_arms(p)
+
+    print(f"merge_checks: scanned {scanned['python']} python and {scanned['cpp']} c++ files")
+    for f in findings:
+        print(f"  {f}")
+    if a.report:
+        Path(a.report).write_text(json.dumps(
+            {"ok": not findings, "scanned": scanned, "findings": findings}, indent=2))
+    if findings:
+        print(f"merge_checks: {len(findings)} problem(s)", file=sys.stderr)
+        return 1
+    print("merge_checks: clean")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/unsloth/merge_checks.py
+++ b/scripts/unsloth/merge_checks.py
@@ -22,11 +22,13 @@ a silent wrong answer into a loud one, which is the property that was missing.
 Both are deliberately narrow, because a check that fires wrongly blocks a
 release just as effectively as a bad merge:
 
-  - The unreachable-arm check only fires when the EARLIER condition is a pure
-    disjunction of `arch == LLM_ARCH_*` terms. If it contains `&&` or anything
-    else, a later arm testing the same arch can genuinely be reachable, so the
-    chain is skipped. With that restriction the verdict follows from the code:
-    matching that arch always takes the earlier branch.
+  - An arch is only consumed by an EARLIER arm that is a pure disjunction of
+    `arch == LLM_ARCH_*` terms. A conditional arm may not run, so what follows
+    it stays reachable. The later arm is then dead if it is a disjunction whose
+    alternatives are all consumed, or a plain conjunction requiring a consumed
+    arch, since its other conditions can only narrow it further. Anything
+    mixing `||` and `&&` is left alone, and only a term that is exactly
+    `arch == X` counts, so `arch != X` is never read as requiring that arch.
 
   - The unreachable-arm check reads one physical line, so a condition split
     across lines is skipped rather than analysed. Checked against the whole of
@@ -255,19 +257,49 @@ def if_else_chains(text: str) -> list[list[tuple[int, str]]]:
     return done
 
 
+def _blocked_by(cond: str, taken: set[str]) -> set[str]:
+    """Arches that make this arm dead, given what earlier arms already took.
+
+    A pure disjunction is dead only when EVERY alternative is taken. A plain
+    conjunction is dead as soon as ONE of its `arch == X` conjuncts is, since
+    the other conditions can only narrow it further: an earlier unconditional
+    `arch == X` arm makes a later `arch == X && enabled` unreachable, and that
+    arm is not a pure disjunction so it used to be skipped entirely.
+
+    Anything mixing `||` and `&&` is left alone rather than guessed at, and only
+    a term that is exactly `arch == X` counts, so `!(arch == X)` and `arch != X`
+    cannot be read as requiring that arch.
+    """
+    archs = set(ARCH.findall(cond))
+    if not archs:
+        return set()
+    if _pure_arch_disjunction(cond):
+        return archs if archs <= taken else set()
+    if "||" in cond:
+        return set()
+    hit = set()
+    for term in cond.split("&&"):
+        m = ARCH.fullmatch(term.strip().strip("()").strip())
+        if m and m.group(1) in taken:
+            hit.add(m.group(1))
+    return hit
+
+
 def unreachable_arch_arms(path: Path) -> list[str]:
     """`else if` arms whose arch a preceding pure-disjunction arm already took."""
     out = []
     for chain in if_else_chains(path.read_text()):
         taken: set[str] = set()
         for lineno, cond in chain:
-            archs = set(ARCH.findall(cond))
-            if archs and _pure_arch_disjunction(cond) and archs <= taken:
+            dead = _blocked_by(cond, taken)
+            if dead:
                 out.append(f"{path}:{lineno}: unreachable, "
-                           f"{', '.join(sorted(archs))} already matched earlier "
+                           f"{', '.join(sorted(dead))} already matched earlier "
                            "in this if/else chain")
+            # Only an unconditional arm consumes an arch. A conditional one may
+            # not run, so what follows it can still be reached.
             if _pure_arch_disjunction(cond):
-                taken |= archs
+                taken |= set(ARCH.findall(cond))
     return out
 
 

--- a/scripts/unsloth/merge_checks.py
+++ b/scripts/unsloth/merge_checks.py
@@ -36,6 +36,16 @@ release just as effectively as a bad merge:
     release path and buy nothing today, so it stays narrow and this is recorded
     as a known limitation rather than fixed.
 
+  - Chains are grouped by BRACE DEPTH, not by indentation. This is an accuracy
+    fix, not a widening: measured over all 181 src/**/*.cpp, depth and
+    indentation report the same zero findings, so nothing new fires and the
+    good tree stays clean, but depth keeps 339 arms in chains against 260 and
+    is right in both directions where they differ. Indentation drops the
+    enclosing chain at any nested `if`, which silences the check on the exact
+    08-27 shape, and it glues two unrelated `if`s at one indent into a single
+    chain whenever the second opener is a skipped multiline condition, which
+    reports a reachable arm as dead and blocks a release on good code.
+
   - There is deliberately NO duplicate-C++-definition check. The obvious version
     keys on function name and flags legitimate overloads: it reported
     `llama_model_base::create_tensor`, which is two different signatures. A real
@@ -59,6 +69,11 @@ from pathlib import Path
 ARCH = re.compile(r"arch == (LLM_ARCH_\w+)")
 COND = re.compile(r"^\s*(?:\}\s*)?else if \((.*)\)\s*\{\s*$|^\s*if \((.*)\)\s*\{\s*$")
 PURE_TERM = re.compile(r"arch == LLM_ARCH_\w+")
+# Blanked before braces are counted, so a `{` in a comment or a chat template
+# string does not shift the depth for everything after it.
+_BLOCK = re.compile(r"/\*.*?\*/", re.S)
+_LINE = re.compile(r"//.*")
+_STR = re.compile(r'"(?:\\.|[^"\\])*"|\'(?:\\.|[^\'\\])*\'')
 
 
 def duplicate_dict_keys(path: Path) -> list[str]:
@@ -87,29 +102,93 @@ def _pure_arch_disjunction(cond: str) -> bool:
     return bool(terms) and all(PURE_TERM.fullmatch(t) for t in terms)
 
 
+def _decommented(text: str) -> list[str]:
+    """The file with comments and literals blanked, line structure preserved.
+
+    Braces inside a string literal or a comment are not braces. src/ is full of
+    both (llama-chat.cpp alone embeds dozens of `{` in template strings), so
+    counting them raw would desynchronise the depth for the rest of the file.
+    """
+    text = _BLOCK.sub(lambda m: re.sub(r"[^\n]", " ", m.group(0)), text)
+    out = []
+    for line in text.split("\n"):
+        line = _STR.sub(lambda m: " " * len(m.group(0)), line)
+        out.append(_LINE.sub(lambda m: " " * len(m.group(0)), line))
+    return out
+
+
+def _depths(line: str, start: int) -> tuple[int, int]:
+    """(brace depth after this line, lowest depth reached inside it)."""
+    d = lo = start
+    for ch in line:
+        if ch == "{":
+            d += 1
+        elif ch == "}":
+            d -= 1
+            lo = min(lo, d)
+    return d, lo
+
+
+def if_else_chains(text: str) -> list[list[tuple[int, str]]]:
+    """Group `if` / `else if` conditions into chains by BRACE DEPTH.
+
+    Indentation is not the structure. Keying chains on it, and resetting on any
+    change, means a nested `if` inside an arm replaces the enclosing chain, so
+    the outer arms after it are analysed as a fresh chain and an arch the outer
+    chain already matched looks unmatched. That is a gate that stops gating on
+    a shape that is ordinary C++: the arch dispatch at llama-model.cpp:2434 is
+    exactly one nested `if` away from it.
+
+    The same key also mis-JOINS. Two unrelated `if`s at the same indentation
+    become one chain whenever the second one's opener is a condition the regex
+    skips, and then a perfectly reachable arm is reported unreachable, which
+    blocks a release on good code. Depth gets both right: a chain lives at the
+    depth its `if` opened at, and ends when a brace takes the file back past it.
+    """
+    raw = text.split("\n")
+    clean = _decommented(text)
+    open_chains: dict[int, list[tuple[int, str]]] = {}
+    done: list[list[tuple[int, str]]] = []
+
+    def flush(key: int) -> None:
+        c = open_chains.pop(key, None)
+        if c and len(c) > 1:
+            done.append(c)
+
+    depth = 0
+    for i, (line, cline) in enumerate(zip(raw, clean)):
+        after, lo = _depths(cline, depth)
+        stripped = cline.lstrip()
+        # Matched on the raw line, so the condition text is intact, but a line
+        # that blanked away entirely is commented-out code and opens nothing.
+        m = COND.search(line) if stripped else None
+        # `} else if (...) {` and a bare `else if (...) {` after its own `}`
+        # line both continue the chain that lives at the depth this line dips
+        # to; a plain `if` opens one at the depth it starts from.
+        cont = bool(m) and (stripped.startswith("}") or stripped.startswith("else"))
+        key = lo if cont else depth
+        # Any chain whose closing brace this line just passed is over, except
+        # the one this very line continues.
+        for k in [k for k in sorted(open_chains, reverse=True) if k >= lo]:
+            if not (cont and k == key):
+                flush(k)
+        if m:
+            cond = m.group(1) or m.group(2) or ""
+            if cont and key in open_chains:
+                open_chains[key].append((i + 1, cond))
+            else:
+                flush(key)
+                open_chains[key] = [(i + 1, cond)]
+        depth = after
+    for k in sorted(open_chains, reverse=True):
+        flush(k)
+    return done
+
+
 def unreachable_arch_arms(path: Path) -> list[str]:
     """`else if` arms whose arch a preceding pure-disjunction arm already took."""
-    lines = path.read_text().split("\n")
-    chains: list[list[tuple[int, str]]] = []
-    cur: list[tuple[int, str]] = []
-    cur_indent = None
-    for i, line in enumerate(lines):
-        m = COND.search(line)
-        if not m:
-            continue
-        indent = len(line) - len(line.lstrip())
-        cond = m.group(1) or m.group(2) or ""
-        if line.lstrip().startswith("}") and cur_indent == indent:
-            cur.append((i + 1, cond))
-        else:
-            if len(cur) > 1:
-                chains.append(cur)
-            cur, cur_indent = [(i + 1, cond)], indent
-    if len(cur) > 1:
-        chains.append(cur)
-
     out = []
-    for chain in chains:
+    for chain in if_else_chains(path.read_text()):
         taken: set[str] = set()
         for lineno, cond in chain:
             archs = set(ARCH.findall(cond))

--- a/scripts/unsloth/pin_merge.py
+++ b/scripts/unsloth/pin_merge.py
@@ -3,22 +3,15 @@
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
 """Three-way merge pr-set.json one pin at a time, and refuse anything ambiguous.
 
-Two repins in flight always collide. Both edit adjacent lines of the same JSON
-list, so git merges them as text and reports a conflict over lines that have
-nothing to do with each other. On 08-27 that happened twice in one hour, while
-landing the qwen4exp, Inkling and GLM-5-Next repins: each merge invalidated the
-next, and each one was resolved by hand into exactly what a per-element merge
-would have produced.
+Two repins in flight always collide.
+Both edit adjacent lines of the same JSON list, so git merges them as text and reports a conflict over lines that have nothing to do with each other.
+On 08-27 that happened twice in one hour, while landing the qwen4exp, Inkling and GLM-5-Next repins: each merge invalidated the next, and each one was resolved by hand into exactly what a per-element merge would have produced.
 
-Pin ORDER is load-bearing. resolve merges pins sequentially, so a later pin sees
-the tree the earlier ones produced, and reordering the list silently changes the
-composition. This never reorders: it walks the base list positionally and takes
-whichever side moved each entry. That also means a pin added or removed on one
-side is refused rather than aligned, because guessing where an inserted pin
-belongs is exactly the kind of guess that would change composition order. A
-side that REORDERS the list is refused for the same reason, and for a sharper
-one: position i would no longer name the same pin on both sides, so merging it
-field-wise would splice one PR's `required` onto another PR's url.
+Pin ORDER is load-bearing.
+resolve merges pins sequentially, so a later pin sees the tree the earlier ones produced, and reordering the list silently changes the composition.
+This never reorders: it walks the base list positionally and takes whichever side moved each entry.
+That also means a pin added or removed on one side is refused rather than aligned, because guessing where an inserted pin belongs is exactly the kind of guess that would change composition order.
+A side that REORDERS the list is refused for the same reason, and for a sharper one: position i would no longer name the same pin on both sides, so merging it field-wise would splice one PR's `required` onto another PR's url.
 
 Usable as a git merge driver:
 
@@ -26,10 +19,8 @@ Usable as a git merge driver:
     git config merge.pinset.driver 'python3 scripts/unsloth/pin_merge.py %O %A %B'
     echo 'scripts/unsloth/pr-set.json merge=pinset' >> .gitattributes
 
-The driver contract is to write the result over %A (ours) and exit 0, or leave
-it alone and exit non-zero to fall back to a normal conflict. That fallback is
-the whole safety story: a refusal costs a hand resolution, which is the status
-quo, and never a wrong pin set.
+The driver contract is to write the result over %A (ours) and exit 0, or leave it alone and exit non-zero to fall back to a normal conflict.
+That fallback is the whole safety story: a refusal costs a hand resolution, which is the status quo, and never a wrong pin set.
 """
 
 from __future__ import annotations
@@ -47,8 +38,8 @@ class Ambiguous(Exception):
 
 MISSING = object()
 
-# The pin url shape repin.py already enforces. The owner matters: ggml-org#125
-# and unslothai#125 are different PRs.
+# The pin url shape repin.py already enforces.
+# The owner matters: ggml-org#125 and unslothai#125 are different PRs.
 PIN_ID = re.compile(r"^https://github\.com/([^/]+)/llama\.cpp/pull/(\d+)/commits/")
 
 
@@ -66,8 +57,7 @@ def ident(entry: str | dict) -> str:
     """What a pin IS, independent of which commit it currently points at.
 
     A repin changes only the sha, so (owner, PR number) is the stable identity.
-    Anything that does not look like a pin url is its own identity, which is the
-    conservative reading: an unrecognised url can only ever cause a refusal.
+    Anything that does not look like a pin url is its own identity, which is the conservative reading: an unrecognised url can only ever cause a refusal.
     """
     url = fields(entry).get("url")
     m = PIN_ID.match(url) if isinstance(url, str) else None
@@ -77,17 +67,12 @@ def ident(entry: str | dict) -> str:
 def refuse_reorder(b: list, o: list, t: list) -> None:
     """Refuse if either side moved an entry that base holds somewhere else.
 
-    Merging by position assumes position i means the same pin on all three
-    sides. A reorder breaks that assumption silently: base [A, B] with ours
-    making A optional and theirs reordering to [B, A] merges position 0 as
-    "url moved to B, required moved to false" and produces B(required=false),
-    so the release skips the wrong PR and the driver still exits 0.
+    Merging by position assumes position i means the same pin on all three sides.
+    A reorder breaks that assumption silently: base [A, B] with ours making A optional and theirs reordering to [B, A] merges position 0 as "url moved to B, required moved to false" and produces B(required=false), so the release skips the wrong PR and the driver still exits 0.
 
-    Realigning by identity instead is not safe. A duplicated entry, or a
-    reorder combined with a repin, leaves more than one alignment consistent
-    with the diff, and choosing one is a guess about composition order, which
-    is load-bearing here. Refusing costs the hand resolution that was the
-    status quo; guessing costs a wrong build nothing downstream can see.
+    Realigning by identity instead is not safe.
+    A duplicated entry, or a reorder combined with a repin, leaves more than one alignment consistent with the diff, and choosing one is a guess about composition order, which is load-bearing here.
+    Refusing costs the hand resolution that was the status quo; guessing costs a wrong build nothing downstream can see.
     """
     bid = [ident(e) for e in b]
     for side, entries in (("ours", o), ("theirs", t)):
@@ -115,8 +100,7 @@ def refuse_duplicates(what: str, entries: list) -> None:
 def merge_keys(what: str, bd: dict, od: dict, td: dict) -> dict:
     """Three-way merge a mapping key by key, refusing only a real clash.
 
-    A key missing on a side is MISSING rather than absent, so "theirs deleted
-    it, ours left it alone" is a deletion both sides agree on, not a no-op.
+    A key missing on a side is MISSING rather than absent, so "theirs deleted it, ours left it alone" is a deletion both sides agree on, not a no-op.
     Ours' key order is kept, then keys only theirs or only base has.
     """
     out: dict = {}
@@ -140,9 +124,7 @@ def merge_keys(what: str, bd: dict, od: dict, td: dict) -> dict:
 def merge_entry(i: int, b, o, t):
     """Three-way merge one pin ENTRY, not just its url.
 
-    Comparing whole entries matters: an entry carries `required` as well as
-    `url`, and comparing only urls makes a `required` flip on one side look
-    like "no change", so rebuilding the list from ours drops it silently.
+    Comparing whole entries matters: an entry carries `required` as well as `url`, and comparing only urls makes a `required` flip on one side look like "no change", so rebuilding the list from ours drops it silently.
     """
     if o == t:
         return o                       # same on both sides, including untouched
@@ -150,17 +132,12 @@ def merge_entry(i: int, b, o, t):
         return t                       # only theirs touched this entry
     if t == b:
         return o                       # only ours touched this entry
-    # Both sides touched it. Merging field-wise is only meaningful while all
-    # three sides name the SAME PR. A repin moves the sha and keeps the
-    # identity, which is the case this is for. REPLACING the pin with another
-    # PR while the other side edits a field is not: base PR100(required=true),
-    # ours PR200, theirs PR100 required=false merges url from ours and
-    # required from theirs and yields PR200(required=false), so the release
-    # skips a PR nobody made optional and the driver still exits 0.
+    # Both sides touched it.
+    # Merging field-wise is only meaningful while all three sides name the SAME PR.
+    # A repin moves the sha and keeps the identity, which is the case this is for.
+    # REPLACING the pin with another PR while the other side edits a field is not: base PR100(required=true), ours PR200, theirs PR100 required=false merges url from ours and required from theirs and yields PR200(required=false), so the release skips a PR nobody made optional and the driver still exits 0.
     #
-    # Refused rather than resolved even when both sides agree on the
-    # replacement, because base then describes a different PR and every field
-    # comparison below is against settings that were never PR200's.
+    # Refused rather than resolved even when both sides agree on the replacement, because base then describes a different PR and every field comparison below is against settings that were never PR200's.
     named = {ident(b), ident(o), ident(t)}
     if len(named) != 1:
         raise Ambiguous(
@@ -170,8 +147,7 @@ def merge_entry(i: int, b, o, t):
     out = merge_keys(f"pin {i}", fields(b), fields(o), fields(t))
     if "url" not in out:
         raise Ambiguous(f"pin {i} lost its url")
-    # Keep the bare-string form when nothing but the url is present, so the
-    # file's shape is not rewritten by merging it.
+    # Keep the bare-string form when nothing but the url is present, so the file's shape is not rewritten by merging it.
     return out["url"] if list(out) == ["url"] else out
 
 
@@ -182,21 +158,17 @@ def merge_pins(base: dict, ours: dict, theirs: dict) -> dict:
             f"pin count differs (base={len(b)} ours={len(o)} theirs={len(t)}); "
             "a pin was added or removed, and placing it is an ordering decision"
         )
-    # Every side, and the result. A duplicate on one input defeats the reorder
-    # guard below; a duplicate only in the RESULT is made here, by the two
-    # sides adding the same PR at different positions.
+    # Every side, and the result.
+    # A duplicate on one input defeats the reorder guard below; a duplicate only in the RESULT is made here, by the two sides adding the same PR at different positions.
     for what, side in (("base", b), ("ours", o), ("theirs", t)):
         refuse_duplicates(what, side)
     refuse_reorder(b, o, t)
     merged = [merge_entry(i, bx, ox, tx)
               for i, (bx, ox, tx) in enumerate(zip(b, o, t))]
     refuse_duplicates("the merged pin set", merged)
-    # Everything outside .prs is three-way merged the same way. Rebuilding the
-    # document from ours instead would silently drop a change theirs made to a
-    # top-level field -- `_doc`, or any schema field added later -- and this
-    # driver REPLACES git's text merge rather than running after it, so nothing
-    # downstream would ever notice the loss. A real two-sided clash refuses,
-    # which costs a hand resolution and never a wrong document.
+    # Everything outside .prs is three-way merged the same way.
+    # Rebuilding the document from ours instead would silently drop a change theirs made to a top-level field - `_doc`, or any schema field added later - and this driver REPLACES git's text merge rather than running after it, so nothing downstream would ever notice the loss.
+    # A real two-sided clash refuses, which costs a hand resolution and never a wrong document.
     skel = [{k: (None if k == "prs" else v) for k, v in d.items()}
             for d in (base, ours, theirs)]     # .prs is merged positionally
     out = merge_keys("document", *skel)

--- a/scripts/unsloth/pin_merge.py
+++ b/scripts/unsloth/pin_merge.py
@@ -41,36 +41,70 @@ class Ambiguous(Exception):
     """A pin set difference this script is not allowed to decide."""
 
 
+MISSING = object()
+
+
 def pins(doc: dict) -> list[str]:
     """The pin URLs, in order. Entries are a bare string or {url, required}."""
     return [p if isinstance(p, str) else p["url"] for p in doc["prs"]]
 
 
+def fields(entry: str | dict) -> dict:
+    """An entry in dict form. A bare url string is just {"url": url}."""
+    return {"url": entry} if isinstance(entry, str) else dict(entry)
+
+
+def merge_entry(i: int, b, o, t):
+    """Three-way merge one pin ENTRY, not just its url.
+
+    Comparing whole entries matters: an entry carries `required` as well as
+    `url`, and comparing only urls makes a `required` flip on one side look
+    like "no change", so rebuilding the list from ours drops it silently.
+    """
+    if o == t:
+        return o                       # same on both sides, including untouched
+    if o == b:
+        return t                       # only theirs touched this entry
+    if t == b:
+        return o                       # only ours touched this entry
+    # Both sides touched it. Merge field-wise, so a repin on one side and a
+    # flag change on the other both survive, and refuse only the real clash.
+    bd, od, td = fields(b), fields(o), fields(t)
+    out: dict = {}
+    for k in list(od) + [k for k in td if k not in od] + \
+             [k for k in bd if k not in od and k not in td]:
+        bv, ov, tv = bd.get(k, MISSING), od.get(k, MISSING), td.get(k, MISSING)
+        if ov == tv:
+            v = ov
+        elif ov == bv:
+            v = tv
+        elif tv == bv:
+            v = ov
+        else:
+            raise Ambiguous(f"pin {i} field {k!r} changed differently on both "
+                            f"sides:\n  ours:   {ov}\n  theirs: {tv}")
+        if v is not MISSING:
+            out[k] = v
+    if "url" not in out:
+        raise Ambiguous(f"pin {i} lost its url")
+    # Keep the bare-string form when nothing but the url is present, so the
+    # file's shape is not rewritten by merging it.
+    return out["url"] if list(out) == ["url"] else out
+
+
 def merge_pins(base: dict, ours: dict, theirs: dict) -> dict:
-    b, o, t = pins(base), pins(ours), pins(theirs)
+    b, o, t = base["prs"], ours["prs"], theirs["prs"]
     if not len(b) == len(o) == len(t):
         raise Ambiguous(
             f"pin count differs (base={len(b)} ours={len(o)} theirs={len(t)}); "
             "a pin was added or removed, and placing it is an ordering decision"
         )
-    merged = []
-    for i, (bx, ox, tx) in enumerate(zip(b, o, t)):
-        if ox == tx:
-            merged.append(ox)          # same on both sides, including untouched
-        elif ox == bx:
-            merged.append(tx)          # only theirs moved this pin
-        elif tx == bx:
-            merged.append(ox)          # only ours moved this pin
-        else:
-            raise Ambiguous(f"pin {i} was repinned differently on both sides:\n"
-                            f"  ours:   {ox}\n  theirs: {tx}")
+    merged = [merge_entry(i, bx, ox, tx)
+              for i, (bx, ox, tx) in enumerate(zip(b, o, t))]
     # Keep ours' surrounding document (comments, schema fields) and swap the
     # list, so nothing outside .prs is silently rewritten by this script.
     out = json.loads(json.dumps(ours))
-    out["prs"] = [
-        p if isinstance(src, str) else {**src, "url": p}
-        for p, src in zip(merged, ours["prs"])
-    ]
+    out["prs"] = merged
     return out
 
 
@@ -81,9 +115,10 @@ def load(path: str) -> dict:
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("base", help="%O, the merge base")
-    ap.add_argument("ours", help="%A, our version; the result is written here")
-    ap.add_argument("theirs", help="%B, their version")
+    # argparse %-formats help strings, so a literal percent must be doubled.
+    ap.add_argument("base", help="%%O, the merge base")
+    ap.add_argument("ours", help="%%A, our version; the result is written here")
+    ap.add_argument("theirs", help="%%B, their version")
     ap.add_argument("--stdout", action="store_true",
                     help="print the result instead of writing over `ours`")
     ap.add_argument("--report", metavar="PATH", help="write a JSON summary here")

--- a/scripts/unsloth/pin_merge.py
+++ b/scripts/unsloth/pin_merge.py
@@ -90,6 +90,17 @@ def refuse_reorder(b: list, o: list, t: list) -> None:
     status quo; guessing costs a wrong build nothing downstream can see.
     """
     bid = [ident(e) for e in b]
+    # Identity is (owner, PR number), so two entries pinning two commits of the
+    # SAME PR share one. Swapping those two then satisfies nothing below and
+    # goes undetected, and a field the other side changed on the first lands on
+    # the second. pr-set.json has never held a duplicate and the lint does not
+    # forbid one, so refuse rather than rely on that holding.
+    dupes = {k for k in bid if bid.count(k) > 1}
+    if dupes:
+        raise Ambiguous(
+            f"pin set names {', '.join(sorted(dupes))} more than once: two "
+            "entries of one PR are indistinguishable here, so a swap between "
+            "them cannot be told from no change at all")
     for side, entries in (("ours", o), ("theirs", t)):
         for i, e in enumerate(entries):
             k = ident(e)

--- a/scripts/unsloth/pin_merge.py
+++ b/scripts/unsloth/pin_merge.py
@@ -90,17 +90,6 @@ def refuse_reorder(b: list, o: list, t: list) -> None:
     status quo; guessing costs a wrong build nothing downstream can see.
     """
     bid = [ident(e) for e in b]
-    # Identity is (owner, PR number), so two entries pinning two commits of the
-    # SAME PR share one. Swapping those two then satisfies nothing below and
-    # goes undetected, and a field the other side changed on the first lands on
-    # the second. pr-set.json has never held a duplicate and the lint does not
-    # forbid one, so refuse rather than rely on that holding.
-    dupes = {k for k in bid if bid.count(k) > 1}
-    if dupes:
-        raise Ambiguous(
-            f"pin set names {', '.join(sorted(dupes))} more than once: two "
-            "entries of one PR are indistinguishable here, so a swap between "
-            "them cannot be told from no change at all")
     for side, entries in (("ours", o), ("theirs", t)):
         for i, e in enumerate(entries):
             k = ident(e)
@@ -110,6 +99,17 @@ def refuse_reorder(b: list, o: list, t: list) -> None:
                     f"{bid.index(k)}: the list was reordered, and merging "
                     "reordered entries by position would take fields from "
                     "different PRs")
+
+
+def refuse_duplicates(what: str, entries: list) -> None:
+    """Two entries of one PR are indistinguishable, so nothing can align them."""
+    ids = [ident(e) for e in entries]
+    dupes = sorted({k for k in ids if ids.count(k) > 1})
+    if dupes:
+        raise Ambiguous(
+            f"{what} names {', '.join(dupes)} more than once; two entries of "
+            "one PR cannot be told apart, so a swap between them reads as no "
+            "change and a later merge would splice their fields together")
 
 
 def merge_keys(what: str, bd: dict, od: dict, td: dict) -> dict:
@@ -182,9 +182,15 @@ def merge_pins(base: dict, ours: dict, theirs: dict) -> dict:
             f"pin count differs (base={len(b)} ours={len(o)} theirs={len(t)}); "
             "a pin was added or removed, and placing it is an ordering decision"
         )
+    # Every side, and the result. A duplicate on one input defeats the reorder
+    # guard below; a duplicate only in the RESULT is made here, by the two
+    # sides adding the same PR at different positions.
+    for what, side in (("base", b), ("ours", o), ("theirs", t)):
+        refuse_duplicates(what, side)
     refuse_reorder(b, o, t)
     merged = [merge_entry(i, bx, ox, tx)
               for i, (bx, ox, tx) in enumerate(zip(b, o, t))]
+    refuse_duplicates("the merged pin set", merged)
     # Everything outside .prs is three-way merged the same way. Rebuilding the
     # document from ours instead would silently drop a change theirs made to a
     # top-level field -- `_doc`, or any schema field added later -- and this

--- a/scripts/unsloth/pin_merge.py
+++ b/scripts/unsloth/pin_merge.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+"""Three-way merge pr-set.json one pin at a time, and refuse anything ambiguous.
+
+Two repins in flight always collide. Both edit adjacent lines of the same JSON
+list, so git merges them as text and reports a conflict over lines that have
+nothing to do with each other. On 08-27 that happened twice in one hour, while
+landing the qwen4exp, Inkling and GLM-5-Next repins: each merge invalidated the
+next, and each one was resolved by hand into exactly what a per-element merge
+would have produced.
+
+Pin ORDER is load-bearing. resolve merges pins sequentially, so a later pin sees
+the tree the earlier ones produced, and reordering the list silently changes the
+composition. This never reorders: it walks the base list positionally and takes
+whichever side moved each entry. That also means a pin added or removed on one
+side is refused rather than aligned, because guessing where an inserted pin
+belongs is exactly the kind of guess that would change composition order.
+
+Usable as a git merge driver:
+
+    git config merge.pinset.name  'pr-set.json pin-wise merge'
+    git config merge.pinset.driver 'python3 scripts/unsloth/pin_merge.py %O %A %B'
+    echo 'scripts/unsloth/pr-set.json merge=pinset' >> .gitattributes
+
+The driver contract is to write the result over %A (ours) and exit 0, or leave
+it alone and exit non-zero to fall back to a normal conflict. That fallback is
+the whole safety story: a refusal costs a hand resolution, which is the status
+quo, and never a wrong pin set.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+class Ambiguous(Exception):
+    """A pin set difference this script is not allowed to decide."""
+
+
+def pins(doc: dict) -> list[str]:
+    """The pin URLs, in order. Entries are a bare string or {url, required}."""
+    return [p if isinstance(p, str) else p["url"] for p in doc["prs"]]
+
+
+def merge_pins(base: dict, ours: dict, theirs: dict) -> dict:
+    b, o, t = pins(base), pins(ours), pins(theirs)
+    if not len(b) == len(o) == len(t):
+        raise Ambiguous(
+            f"pin count differs (base={len(b)} ours={len(o)} theirs={len(t)}); "
+            "a pin was added or removed, and placing it is an ordering decision"
+        )
+    merged = []
+    for i, (bx, ox, tx) in enumerate(zip(b, o, t)):
+        if ox == tx:
+            merged.append(ox)          # same on both sides, including untouched
+        elif ox == bx:
+            merged.append(tx)          # only theirs moved this pin
+        elif tx == bx:
+            merged.append(ox)          # only ours moved this pin
+        else:
+            raise Ambiguous(f"pin {i} was repinned differently on both sides:\n"
+                            f"  ours:   {ox}\n  theirs: {tx}")
+    # Keep ours' surrounding document (comments, schema fields) and swap the
+    # list, so nothing outside .prs is silently rewritten by this script.
+    out = json.loads(json.dumps(ours))
+    out["prs"] = [
+        p if isinstance(src, str) else {**src, "url": p}
+        for p, src in zip(merged, ours["prs"])
+    ]
+    return out
+
+
+def load(path: str) -> dict:
+    return json.loads(Path(path).read_text())
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("base", help="%O, the merge base")
+    ap.add_argument("ours", help="%A, our version; the result is written here")
+    ap.add_argument("theirs", help="%B, their version")
+    ap.add_argument("--stdout", action="store_true",
+                    help="print the result instead of writing over `ours`")
+    ap.add_argument("--report", metavar="PATH", help="write a JSON summary here")
+    a = ap.parse_args()
+
+    report: dict = {"ok": False, "reason": None}
+    try:
+        merged = merge_pins(load(a.base), load(a.ours), load(a.theirs))
+    except (Ambiguous, KeyError, json.JSONDecodeError) as e:
+        report["reason"] = str(e)
+        if a.report:
+            Path(a.report).write_text(json.dumps(report, indent=2))
+        print(f"pin_merge: refused: {e}", file=sys.stderr)
+        return 1
+
+    text = json.dumps(merged, indent=2) + "\n"
+    if a.stdout:
+        sys.stdout.write(text)
+    else:
+        Path(a.ours).write_text(text)
+    report["ok"] = True
+    report["pins"] = pins(merged)
+    if a.report:
+        Path(a.report).write_text(json.dumps(report, indent=2))
+    # stderr, so --stdout emits nothing but the merged document
+    print(f"pin_merge: merged {len(pins(merged))} pins", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/unsloth/pin_merge.py
+++ b/scripts/unsloth/pin_merge.py
@@ -15,7 +15,10 @@ the tree the earlier ones produced, and reordering the list silently changes the
 composition. This never reorders: it walks the base list positionally and takes
 whichever side moved each entry. That also means a pin added or removed on one
 side is refused rather than aligned, because guessing where an inserted pin
-belongs is exactly the kind of guess that would change composition order.
+belongs is exactly the kind of guess that would change composition order. A
+side that REORDERS the list is refused for the same reason, and for a sharper
+one: position i would no longer name the same pin on both sides, so merging it
+field-wise would splice one PR's `required` onto another PR's url.
 
 Usable as a git merge driver:
 
@@ -33,6 +36,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -43,6 +47,10 @@ class Ambiguous(Exception):
 
 MISSING = object()
 
+# The pin url shape repin.py already enforces. The owner matters: ggml-org#125
+# and unslothai#125 are different PRs.
+PIN_ID = re.compile(r"^https://github\.com/([^/]+)/llama\.cpp/pull/(\d+)/commits/")
+
 
 def pins(doc: dict) -> list[str]:
     """The pin URLs, in order. Entries are a bare string or {url, required}."""
@@ -52,6 +60,45 @@ def pins(doc: dict) -> list[str]:
 def fields(entry: str | dict) -> dict:
     """An entry in dict form. A bare url string is just {"url": url}."""
     return {"url": entry} if isinstance(entry, str) else dict(entry)
+
+
+def ident(entry: str | dict) -> str:
+    """What a pin IS, independent of which commit it currently points at.
+
+    A repin changes only the sha, so (owner, PR number) is the stable identity.
+    Anything that does not look like a pin url is its own identity, which is the
+    conservative reading: an unrecognised url can only ever cause a refusal.
+    """
+    url = fields(entry).get("url")
+    m = PIN_ID.match(url) if isinstance(url, str) else None
+    return f"{m.group(1)}#{m.group(2)}" if m else repr(url)
+
+
+def refuse_reorder(b: list, o: list, t: list) -> None:
+    """Refuse if either side moved an entry that base holds somewhere else.
+
+    Merging by position assumes position i means the same pin on all three
+    sides. A reorder breaks that assumption silently: base [A, B] with ours
+    making A optional and theirs reordering to [B, A] merges position 0 as
+    "url moved to B, required moved to false" and produces B(required=false),
+    so the release skips the wrong PR and the driver still exits 0.
+
+    Realigning by identity instead is not safe. A duplicated entry, or a
+    reorder combined with a repin, leaves more than one alignment consistent
+    with the diff, and choosing one is a guess about composition order, which
+    is load-bearing here. Refusing costs the hand resolution that was the
+    status quo; guessing costs a wrong build nothing downstream can see.
+    """
+    bid = [ident(e) for e in b]
+    for side, entries in (("ours", o), ("theirs", t)):
+        for i, e in enumerate(entries):
+            k = ident(e)
+            if k != bid[i] and k in bid:
+                raise Ambiguous(
+                    f"pin {i} on {side} is {k}, which base holds at position "
+                    f"{bid.index(k)}: the list was reordered, and merging "
+                    "reordered entries by position would take fields from "
+                    "different PRs")
 
 
 def merge_keys(what: str, bd: dict, od: dict, td: dict) -> dict:
@@ -109,6 +156,7 @@ def merge_pins(base: dict, ours: dict, theirs: dict) -> dict:
             f"pin count differs (base={len(b)} ours={len(o)} theirs={len(t)}); "
             "a pin was added or removed, and placing it is an ordering decision"
         )
+    refuse_reorder(b, o, t)
     merged = [merge_entry(i, bx, ox, tx)
               for i, (bx, ox, tx) in enumerate(zip(b, o, t))]
     # Everything outside .prs is three-way merged the same way. Rebuilding the

--- a/scripts/unsloth/pin_merge.py
+++ b/scripts/unsloth/pin_merge.py
@@ -139,8 +139,23 @@ def merge_entry(i: int, b, o, t):
         return t                       # only theirs touched this entry
     if t == b:
         return o                       # only ours touched this entry
-    # Both sides touched it. Merge field-wise, so a repin on one side and a
-    # flag change on the other both survive, and refuse only the real clash.
+    # Both sides touched it. Merging field-wise is only meaningful while all
+    # three sides name the SAME PR. A repin moves the sha and keeps the
+    # identity, which is the case this is for. REPLACING the pin with another
+    # PR while the other side edits a field is not: base PR100(required=true),
+    # ours PR200, theirs PR100 required=false merges url from ours and
+    # required from theirs and yields PR200(required=false), so the release
+    # skips a PR nobody made optional and the driver still exits 0.
+    #
+    # Refused rather than resolved even when both sides agree on the
+    # replacement, because base then describes a different PR and every field
+    # comparison below is against settings that were never PR200's.
+    named = {ident(b), ident(o), ident(t)}
+    if len(named) != 1:
+        raise Ambiguous(
+            f"pin {i} names different PRs across the sides (base {ident(b)}, "
+            f"ours {ident(o)}, theirs {ident(t)}) and both sides edited it: "
+            "merging their fields would attach one PR's settings to another")
     out = merge_keys(f"pin {i}", fields(b), fields(o), fields(t))
     if "url" not in out:
         raise Ambiguous(f"pin {i} lost its url")

--- a/scripts/unsloth/pin_merge.py
+++ b/scripts/unsloth/pin_merge.py
@@ -54,6 +54,31 @@ def fields(entry: str | dict) -> dict:
     return {"url": entry} if isinstance(entry, str) else dict(entry)
 
 
+def merge_keys(what: str, bd: dict, od: dict, td: dict) -> dict:
+    """Three-way merge a mapping key by key, refusing only a real clash.
+
+    A key missing on a side is MISSING rather than absent, so "theirs deleted
+    it, ours left it alone" is a deletion both sides agree on, not a no-op.
+    Ours' key order is kept, then keys only theirs or only base has.
+    """
+    out: dict = {}
+    for k in list(od) + [k for k in td if k not in od] + \
+             [k for k in bd if k not in od and k not in td]:
+        bv, ov, tv = bd.get(k, MISSING), od.get(k, MISSING), td.get(k, MISSING)
+        if ov == tv:
+            v = ov
+        elif ov == bv:
+            v = tv
+        elif tv == bv:
+            v = ov
+        else:
+            raise Ambiguous(f"{what} field {k!r} changed differently on both "
+                            f"sides:\n  ours:   {ov}\n  theirs: {tv}")
+        if v is not MISSING:
+            out[k] = v
+    return out
+
+
 def merge_entry(i: int, b, o, t):
     """Three-way merge one pin ENTRY, not just its url.
 
@@ -69,22 +94,7 @@ def merge_entry(i: int, b, o, t):
         return o                       # only ours touched this entry
     # Both sides touched it. Merge field-wise, so a repin on one side and a
     # flag change on the other both survive, and refuse only the real clash.
-    bd, od, td = fields(b), fields(o), fields(t)
-    out: dict = {}
-    for k in list(od) + [k for k in td if k not in od] + \
-             [k for k in bd if k not in od and k not in td]:
-        bv, ov, tv = bd.get(k, MISSING), od.get(k, MISSING), td.get(k, MISSING)
-        if ov == tv:
-            v = ov
-        elif ov == bv:
-            v = tv
-        elif tv == bv:
-            v = ov
-        else:
-            raise Ambiguous(f"pin {i} field {k!r} changed differently on both "
-                            f"sides:\n  ours:   {ov}\n  theirs: {tv}")
-        if v is not MISSING:
-            out[k] = v
+    out = merge_keys(f"pin {i}", fields(b), fields(o), fields(t))
     if "url" not in out:
         raise Ambiguous(f"pin {i} lost its url")
     # Keep the bare-string form when nothing but the url is present, so the
@@ -101,10 +111,16 @@ def merge_pins(base: dict, ours: dict, theirs: dict) -> dict:
         )
     merged = [merge_entry(i, bx, ox, tx)
               for i, (bx, ox, tx) in enumerate(zip(b, o, t))]
-    # Keep ours' surrounding document (comments, schema fields) and swap the
-    # list, so nothing outside .prs is silently rewritten by this script.
-    out = json.loads(json.dumps(ours))
-    out["prs"] = merged
+    # Everything outside .prs is three-way merged the same way. Rebuilding the
+    # document from ours instead would silently drop a change theirs made to a
+    # top-level field -- `_doc`, or any schema field added later -- and this
+    # driver REPLACES git's text merge rather than running after it, so nothing
+    # downstream would ever notice the loss. A real two-sided clash refuses,
+    # which costs a hand resolution and never a wrong document.
+    skel = [{k: (None if k == "prs" else v) for k, v in d.items()}
+            for d in (base, ours, theirs)]     # .prs is merged positionally
+    out = merge_keys("document", *skel)
+    out["prs"] = merged                        # keeps ours' key position
     return out
 
 

--- a/scripts/unsloth/sync_deletes.py
+++ b/scripts/unsloth/sync_deletes.py
@@ -100,15 +100,30 @@ def main() -> int:
         # the merge result and finds nothing.
         r = git("diff", "--name-status", "--diff-filter=A", a.merge_base,
                 "--", PREFIX, cwd=a.repo)
-        for line in r.stdout.split("\n"):
-            if not line.strip():
-                continue
-            path = line.split("\t", 1)[1].strip()
-            name = path.rsplit("/", 1)[-1]
-            if name.startswith(OURS):
-                continue
-            if git("rm", "-q", "--force", "--", path, cwd=a.repo).returncode == 0:
-                added.append(path)
+        if r.returncode != 0:
+            # An unusable --merge-base produces empty stdout, which is
+            # indistinguishable from "upstream added nothing" if the exit code
+            # is ignored. This script reporting success is what tells a sync it
+            # can proceed, so a listing that never ran has to be a failure, not
+            # a quiet zero: otherwise the sync carries every newly added
+            # upstream workflow in and they start firing on the fork.
+            left.append(f"{a.merge_base}: could not list workflows added since "
+                        f"it: {r.stderr.strip()}")
+        else:
+            for line in r.stdout.split("\n"):
+                if not line.strip():
+                    continue
+                path = line.split("\t", 1)[1].strip()
+                name = path.rsplit("/", 1)[-1]
+                if name.startswith(OURS):
+                    continue
+                rm = git("rm", "-q", "--force", "--", path, cwd=a.repo)
+                if rm.returncode == 0:
+                    added.append(path)
+                else:
+                    # Same reasoning as the resolve loop above: a removal that
+                    # did not happen is reported, never dropped.
+                    left.append(f"{path}: git rm failed: {rm.stderr.strip()}")
 
     for p in resolved:
         print(f"resolved  {p}: kept the fork's deletion")

--- a/scripts/unsloth/sync_deletes.py
+++ b/scripts/unsloth/sync_deletes.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+"""Resolve the modify/delete conflicts a fork sync produces, and only those.
+
+Measured over every merge commit in this fork: 149 file-level conflicts, of
+which 68 (45 percent) are the same one. Upstream edits a workflow this fork
+deleted on purpose, git cannot know which side wins, and a human keeps the
+deletion. Every single time: 68 of 68 historical instances resolved by keeping
+the deletion, with no exceptions.
+
+That is not a heuristic, it is the fork's stated invariant. This fork owns no
+upstream CI. scripts/unsloth/upstream-sync.json requires the diff from the sync
+point to master to touch only .github/ and scripts/unsloth/, and
+verify_upstream_sync.py already treats these deletions as legitimate. The
+deletions are policy, so re-applying them is bookkeeping.
+
+Scope is deliberately tight, because the cost of being wrong is a workflow
+silently reappearing and firing on the fork:
+
+  - only paths under .github/workflows/
+  - only modify/delete conflicts, never content conflicts
+  - never a file named unsloth-*.yml, which is ours; if one of those is ever in
+    a modify/delete conflict, something is wrong and a human should look
+  - the delete must be on our side; upstream deleting a file we modified is the
+    opposite situation and is left alone
+
+The same policy covers a workflow upstream ADDED since the last sync. That is
+not a conflict at all, so git merges it in silently and the fork acquires a
+workflow that starts firing on it. Replaying sync e8735f35d3 caught exactly
+this: resolving only the conflicts left .github/workflows/build-wasm.yml in the
+tree, where the recorded human resolution had deleted it. With --added handled
+too, the replay reproduces that tree exactly.
+
+Anything else is left conflicted. Exits 0 if it resolved everything it was
+asked about, 1 if any conflict remains.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+PREFIX = ".github/workflows/"
+OURS = "unsloth-"
+
+
+def git(*args: str, cwd: str = ".") -> subprocess.CompletedProcess:
+    return subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True)
+
+
+def unmerged(cwd: str) -> dict[str, set[int]]:
+    """path -> set of stages present (1 base, 2 ours, 3 theirs)."""
+    out: dict[str, set[int]] = {}
+    r = git("ls-files", "-u", cwd=cwd)
+    for line in r.stdout.split("\n"):
+        if not line.strip():
+            continue
+        meta, path = line.split("\t", 1)
+        stage = int(meta.split()[2])
+        out.setdefault(path.strip(), set()).add(stage)
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--repo", default=".")
+    ap.add_argument("--merge-base", help="also drop upstream workflows added since this rev")
+    ap.add_argument("--report", metavar="PATH")
+    a = ap.parse_args()
+
+    stages = unmerged(a.repo)
+    resolved, left, added = [], [], []
+    for path, st in sorted(stages.items()):
+        name = path.rsplit("/", 1)[-1]
+        # stage 2 missing means our side deleted it; stage 3 present means
+        # upstream still has it. That is the sync case, and only that.
+        ours_deleted = 2 not in st and 3 in st
+        if (path.startswith(PREFIX) and not name.startswith(OURS) and ours_deleted):
+            r = git("rm", "-q", "--force", "--", path, cwd=a.repo)
+            if r.returncode == 0:
+                resolved.append(path)
+            else:
+                left.append(f"{path}: git rm failed: {r.stderr.strip()}")
+        else:
+            why = ("we own this workflow" if name.startswith(OURS)
+                   else "not an upstream workflow path" if not path.startswith(PREFIX)
+                   else "not a delete on our side")
+            left.append(f"{path}: {why}")
+
+    # Workflows upstream added since the merge base. No conflict, so nothing
+    # above sees them, and the fork silently gains CI that fires on its own repo.
+    if a.merge_base:
+        # Against the WORKING TREE, not HEAD: mid-merge, HEAD is still our
+        # pre-merge commit, so merge_base..HEAD describes our side rather than
+        # the merge result and finds nothing.
+        r = git("diff", "--name-status", "--diff-filter=A", a.merge_base,
+                "--", PREFIX, cwd=a.repo)
+        for line in r.stdout.split("\n"):
+            if not line.strip():
+                continue
+            path = line.split("\t", 1)[1].strip()
+            name = path.rsplit("/", 1)[-1]
+            if name.startswith(OURS):
+                continue
+            if git("rm", "-q", "--force", "--", path, cwd=a.repo).returncode == 0:
+                added.append(path)
+
+    for p in resolved:
+        print(f"resolved  {p}: kept the fork's deletion")
+    for p in added:
+        print(f"removed   {p}: upstream added it; this fork carries no upstream workflows")
+    for p in left:
+        print(f"left      {p}", file=sys.stderr)
+    if a.report:
+        Path(a.report).write_text(json.dumps(
+            {"ok": not left, "resolved": resolved,
+             "removed_added": added, "left": left}, indent=2))
+    return 1 if left else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/unsloth/sync_deletes.py
+++ b/scripts/unsloth/sync_deletes.py
@@ -98,8 +98,12 @@ def main() -> int:
         # Against the WORKING TREE, not HEAD: mid-merge, HEAD is still our
         # pre-merge commit, so merge_base..HEAD describes our side rather than
         # the merge result and finds nothing.
-        r = git("diff", "--name-status", "--diff-filter=A", a.merge_base,
-                "--", PREFIX, cwd=a.repo)
+        # --no-renames, or an upstream workflow that was RENAMED reads as R
+        # rather than A and this filter drops it. The fork would then carry the
+        # renamed workflow and it would start firing here, which is the exact
+        # thing this block exists to stop.
+        r = git("diff", "--name-status", "--diff-filter=A", "--no-renames",
+                a.merge_base, "--", PREFIX, cwd=a.repo)
         if r.returncode != 0:
             # An unusable --merge-base produces empty stdout, which is
             # indistinguishable from "upstream added nothing" if the exit code

--- a/scripts/unsloth/sync_deletes.py
+++ b/scripts/unsloth/sync_deletes.py
@@ -48,6 +48,11 @@ def unmerged(cwd: str) -> dict[str, set[int]]:
     """path -> set of stages present (1 base, 2 ours, 3 theirs)."""
     out: dict[str, set[int]] = {}
     r = git("ls-files", "-u", cwd=cwd)
+    # A listing that could not run gives empty stdout, which reads as "no
+    # conflicts" and makes this script report that it resolved everything it
+    # was asked to. Not a repo, or an unreadable index, has to be an error.
+    if r.returncode != 0:
+        raise RuntimeError(f"git ls-files -u in {cwd}: {r.stderr.strip()}")
     for line in r.stdout.split("\n"):
         if not line.strip():
             continue
@@ -65,7 +70,15 @@ def main() -> int:
     ap.add_argument("--report", metavar="PATH")
     a = ap.parse_args()
 
-    stages = unmerged(a.repo)
+    try:
+        stages = unmerged(a.repo)
+    except RuntimeError as e:
+        print(f"sync_deletes: {e}", file=sys.stderr)
+        if a.report:
+            Path(a.report).write_text(json.dumps(
+                {"ok": False, "resolved": [], "removed_added": [],
+                 "left": [str(e)]}, indent=2))
+        return 1
     resolved, left, added = [], [], []
     for path, st in sorted(stages.items()):
         name = path.rsplit("/", 1)[-1]

--- a/scripts/unsloth/sync_deletes.py
+++ b/scripts/unsloth/sync_deletes.py
@@ -3,37 +3,29 @@
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
 """Resolve the modify/delete conflicts a fork sync produces, and only those.
 
-Measured over every merge commit in this fork: 149 file-level conflicts, of
-which 68 (45 percent) are the same one. Upstream edits a workflow this fork
-deleted on purpose, git cannot know which side wins, and a human keeps the
-deletion. Every single time: 68 of 68 historical instances resolved by keeping
-the deletion, with no exceptions.
+Measured over every merge commit in this fork: 149 file-level conflicts, of which 68 (45 percent) are the same one.
+Upstream edits a workflow this fork deleted on purpose, git cannot know which side wins, and a human keeps the deletion.
+Every single time: 68 of 68 historical instances resolved by keeping the deletion, with no exceptions.
 
-That is not a heuristic, it is the fork's stated invariant. This fork owns no
-upstream CI. scripts/unsloth/upstream-sync.json requires the diff from the sync
-point to master to touch only .github/ and scripts/unsloth/, and
-verify_upstream_sync.py already treats these deletions as legitimate. The
-deletions are policy, so re-applying them is bookkeeping.
+That is not a heuristic, it is the fork's stated invariant.
+This fork owns no upstream CI.
+scripts/unsloth/upstream-sync.json requires the diff from the sync point to master to touch only .github/ and scripts/unsloth/, and verify_upstream_sync.py already treats these deletions as legitimate.
+The deletions are policy, so re-applying them is bookkeeping.
 
-Scope is deliberately tight, because the cost of being wrong is a workflow
-silently reappearing and firing on the fork:
+Scope is deliberately tight, because the cost of being wrong is a workflow silently reappearing and firing on the fork:
 
   - only paths under .github/workflows/
   - only modify/delete conflicts, never content conflicts
-  - never a file named unsloth-*.yml, which is ours; if one of those is ever in
-    a modify/delete conflict, something is wrong and a human should look
-  - the delete must be on our side; upstream deleting a file we modified is the
-    opposite situation and is left alone
+  - never a file named unsloth-*.yml, which is ours; if one of those is ever in a modify/delete conflict, something is wrong and a human should look
+  - the delete must be on our side; upstream deleting a file we modified is the opposite situation and is left alone
 
-The same policy covers a workflow upstream ADDED since the last sync. That is
-not a conflict at all, so git merges it in silently and the fork acquires a
-workflow that starts firing on it. Replaying sync e8735f35d3 caught exactly
-this: resolving only the conflicts left .github/workflows/build-wasm.yml in the
-tree, where the recorded human resolution had deleted it. With --added handled
-too, the replay reproduces that tree exactly.
+The same policy covers a workflow upstream ADDED since the last sync.
+That is not a conflict at all, so git merges it in silently and the fork acquires a workflow that starts firing on it.
+Replaying sync e8735f35d3 caught exactly this: resolving only the conflicts left .github/workflows/build-wasm.yml in the tree, where the recorded human resolution had deleted it.
+With --added handled too, the replay reproduces that tree exactly.
 
-Anything else is left conflicted. Exits 0 if it resolved everything it was
-asked about, 1 if any conflict remains.
+Anything else is left conflicted.
+Exits 0 if it resolved everything it was asked about, 1 if any conflict remains.
 """
 
 from __future__ import annotations
@@ -77,8 +69,8 @@ def main() -> int:
     resolved, left, added = [], [], []
     for path, st in sorted(stages.items()):
         name = path.rsplit("/", 1)[-1]
-        # stage 2 missing means our side deleted it; stage 3 present means
-        # upstream still has it. That is the sync case, and only that.
+        # stage 2 missing means our side deleted it; stage 3 present means upstream still has it.
+        # That is the sync case, and only that.
         ours_deleted = 2 not in st and 3 in st
         if (path.startswith(PREFIX) and not name.startswith(OURS) and ours_deleted):
             r = git("rm", "-q", "--force", "--", path, cwd=a.repo)
@@ -92,25 +84,17 @@ def main() -> int:
                    else "not a delete on our side")
             left.append(f"{path}: {why}")
 
-    # Workflows upstream added since the merge base. No conflict, so nothing
-    # above sees them, and the fork silently gains CI that fires on its own repo.
+    # Workflows upstream added since the merge base.
+    # No conflict, so nothing above sees them, and the fork silently gains CI that fires on its own repo.
     if a.merge_base:
-        # Against the WORKING TREE, not HEAD: mid-merge, HEAD is still our
-        # pre-merge commit, so merge_base..HEAD describes our side rather than
-        # the merge result and finds nothing.
-        # --no-renames, or an upstream workflow that was RENAMED reads as R
-        # rather than A and this filter drops it. The fork would then carry the
-        # renamed workflow and it would start firing here, which is the exact
-        # thing this block exists to stop.
+        # Against the WORKING TREE, not HEAD: mid-merge, HEAD is still our pre-merge commit, so merge_base..HEAD describes our side rather than the merge result and finds nothing.
+        # --no-renames, or an upstream workflow that was RENAMED reads as R rather than A and this filter drops it.
+        # The fork would then carry the renamed workflow and it would start firing here, which is the exact thing this block exists to stop.
         r = git("diff", "--name-status", "--diff-filter=A", "--no-renames",
                 a.merge_base, "--", PREFIX, cwd=a.repo)
         if r.returncode != 0:
-            # An unusable --merge-base produces empty stdout, which is
-            # indistinguishable from "upstream added nothing" if the exit code
-            # is ignored. This script reporting success is what tells a sync it
-            # can proceed, so a listing that never ran has to be a failure, not
-            # a quiet zero: otherwise the sync carries every newly added
-            # upstream workflow in and they start firing on the fork.
+            # An unusable --merge-base produces empty stdout, which is indistinguishable from "upstream added nothing" if the exit code is ignored.
+            # This script reporting success is what tells a sync it can proceed, so a listing that never ran has to be a failure, not a quiet zero: otherwise the sync carries every newly added upstream workflow in and they start firing on the fork.
             left.append(f"{a.merge_base}: could not list workflows added since "
                         f"it: {r.stderr.strip()}")
         else:
@@ -125,8 +109,7 @@ def main() -> int:
                 if rm.returncode == 0:
                     added.append(path)
                 else:
-                    # Same reasoning as the resolve loop above: a removal that
-                    # did not happen is reported, never dropped.
+                    # Same reasoning as the resolve loop above: a removal that did not happen is reported, never dropped.
                     left.append(f"{path}: git rm failed: {rm.stderr.strip()}")
 
     for p in resolved:

--- a/scripts/unsloth/test_carry_vintage.py
+++ b/scripts/unsloth/test_carry_vintage.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+"""Tests for carry_vintage.py. Run: python3 scripts/unsloth/test_carry_vintage.py
+
+Builds a throwaway repo shaped like a real carry: an upstream base tag, an
+upstream PR branch with two commits on top of it, and a carry branch that
+replayed the PR onto the base while deliberately dropping one file's change.
+
+The case that matters is that dropped file. Its content equals the BASE
+version, which is reachable from the PR head, so a vintage search that walks
+the PR head's whole ancestry finds a "match" in a commit that is not part of
+the PR at all, calls the file SUPERSEDED, and concludes that rebuilding from
+the PR head is equivalent to merging -- which would re-add exactly what the
+carry dropped.
+"""
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent / "carry_vintage.py"
+FAILS = []
+
+
+def check(name, cond, extra=""):
+    print(f"{'PASS' if cond else 'FAIL'}  {name}" + (f"  :: {extra}" if extra and not cond else ""))
+    if not cond:
+        FAILS.append(name)
+
+
+def git(d, *args):
+    r = subprocess.run(["git", *args], cwd=d, capture_output=True, text=True)
+    if r.returncode:
+        raise RuntimeError(" ".join(args) + ": " + r.stderr)
+    return r.stdout.strip()
+
+
+def write(d, name, text):
+    (Path(d) / name).write_text(text)
+
+
+def fixture():
+    d = tempfile.mkdtemp(prefix="cv_")
+    git(d, "init", "-q", "-b", "main")
+    git(d, "config", "user.email", "t@t")
+    git(d, "config", "user.name", "t")
+    write(d, "dropped.txt", "base version\n")
+    write(d, "taken.txt", "base version\n")
+    write(d, "edited.txt", "base version\n")
+    git(d, "add", "-A")
+    git(d, "commit", "-qm", "base")
+    base = git(d, "rev-parse", "HEAD")
+
+    # Upstream PR: two commits, touching all three files.
+    git(d, "checkout", "-q", "-b", "pr")
+    write(d, "dropped.txt", "upstream v1\n")
+    write(d, "taken.txt", "upstream v1\n")
+    write(d, "edited.txt", "upstream v1\n")
+    git(d, "commit", "-qam", "pr c1")
+    mid = git(d, "rev-parse", "HEAD")
+    write(d, "taken.txt", "upstream v2\n")
+    write(d, "edited.txt", "upstream v2\n")
+    git(d, "commit", "-qam", "pr c2")
+    head = git(d, "rev-parse", "HEAD")
+
+    # The carry: PR replayed onto base, with dropped.txt held at the base
+    # version on purpose, edited.txt at an older PR vintage, and taken.txt
+    # already at the PR head.
+    git(d, "checkout", "-q", "-b", "carry", base)
+    write(d, "dropped.txt", "base version\n")
+    write(d, "taken.txt", "upstream v2\n")
+    write(d, "edited.txt", "upstream v1\n")
+    git(d, "commit", "-qam", "carry")
+    carry = git(d, "rev-parse", "HEAD")
+    return d, base, mid, head, carry
+
+
+d, base, mid, head, carry = fixture()
+report = str(Path(d) / "report.json")
+r = subprocess.run([sys.executable, str(SCRIPT), "--carry", carry, "--pr-ref", head,
+                    "--base", base, "--report", report],
+                   cwd=d, capture_output=True, text=True)
+check("runs clean", r.returncode == 0, r.stderr)
+out = json.loads(Path(report).read_text())
+sup = {e["path"]: e["vintage"] for e in out["superseded"]}
+
+check("a file held at the BASE version is not called superseded",
+      "dropped.txt" in out["diverged"], json.dumps(out, indent=1))
+check("no vintage is a commit outside the PR",
+      all(v in (mid, head) for v in sup.values()), json.dumps(sup, indent=1))
+check("a file already at the PR head is superseded",
+      sup.get("taken.txt") == head, json.dumps(sup, indent=1))
+check("a file at an older PR commit is superseded at that vintage",
+      sup.get("edited.txt") == mid, json.dumps(sup, indent=1))
+check("a real divergence still forces a merge",
+      "has to merge" in r.stdout, r.stdout[-300:])
+
+# With the deliberately dropped file removed from the picture, everything the
+# PR touched really is superseded and the rebuild advice is correct.
+git(d, "checkout", "-q", "carry")
+write(d, "dropped.txt", "upstream v1\n")
+git(d, "commit", "-qam", "take it after all")
+carry2 = git(d, "rev-parse", "HEAD")
+r2 = subprocess.run([sys.executable, str(SCRIPT), "--carry", carry2, "--pr-ref", head,
+                     "--base", base], cwd=d, capture_output=True, text=True)
+check("still recommends a rebuild when nothing diverges",
+      r2.returncode == 0 and "Nothing diverges" in r2.stdout, r2.stdout[-300:])
+
+print()
+print(f"{len(FAILS)} failure(s)" if FAILS else "all carry_vintage tests passed")
+sys.exit(1 if FAILS else 0)

--- a/scripts/unsloth/test_carry_vintage.py
+++ b/scripts/unsloth/test_carry_vintage.py
@@ -171,6 +171,57 @@ r4 = subprocess.run([sys.executable, str(SCRIPT), "--carry", git(d2, "rev-parse"
 check("a PR deletion alone still allows the rebuild",
       r4.returncode == 0 and "Nothing diverges" in r4.stdout, r4.stdout[-400:])
 
+# A multi-commit PR that does not touch every file in its FIRST commit. The
+# commits before the one that first changed a path still carry the fork's blob,
+# and they are inside fork..head, so a carry deliberately holding that file at
+# the base version matches one of them and is called SUPERSEDED -- the same
+# wrong "rebuilding is equivalent" answer the fork bound was meant to end, one
+# commit further in.
+def late_touch_fixture():
+    d = tempfile.mkdtemp(prefix="cv_")
+    git(d, "init", "-q", "-b", "main")
+    git(d, "config", "user.email", "t@t")
+    git(d, "config", "user.name", "t")
+    write(d, "held.txt", "base version\n")
+    write(d, "early.txt", "base version\n")
+    git(d, "add", "-A")
+    git(d, "commit", "-qm", "base")
+    base = git(d, "rev-parse", "HEAD")
+
+    # c1 touches early.txt only, so held.txt is still the base blob AT c1.
+    git(d, "checkout", "-q", "-b", "pr")
+    write(d, "early.txt", "upstream v1\n")
+    git(d, "commit", "-qam", "pr c1")
+    # c2 is the first commit to touch held.txt.
+    write(d, "held.txt", "upstream v2\n")
+    git(d, "commit", "-qam", "pr c2")
+    head = git(d, "rev-parse", "HEAD")
+
+    # The carry took early.txt and holds held.txt at the base version.
+    git(d, "checkout", "-q", "-b", "carry", base)
+    write(d, "early.txt", "upstream v1\n")
+    git(d, "commit", "-qam", "carry")
+    return d, base, head, git(d, "rev-parse", "HEAD")
+
+
+d3, base3, head3, carry4 = late_touch_fixture()
+report3 = str(Path(tempfile.mkdtemp(prefix="cvr_")) / "report.json")
+r5 = subprocess.run([sys.executable, str(SCRIPT), "--carry", carry4, "--pr-ref", head3,
+                     "--base", base3, "--report", report3],
+                    cwd=d3, capture_output=True, text=True)
+check("runs clean on a late-touch PR", r5.returncode == 0, r5.stderr)
+out3 = json.loads(Path(report3).read_text())
+check("a file held at base is not superseded by a PR commit that predates its first change",
+      "held.txt" in out3["diverged"], json.dumps(out3, indent=1))
+check("no in-range commit before the first change counts as a vintage",
+      all(e["path"] != "held.txt" for e in out3["superseded"]), json.dumps(out3, indent=1))
+check("and the rebuild advice is withheld",
+      "Nothing diverges" not in r5.stdout, r5.stdout[-400:])
+check("a file the carry really did take is still superseded",
+      any(e["path"] == "early.txt" for e in out3["superseded"]), json.dumps(out3, indent=1))
+check("the late-touch run still writes nothing",
+      git(d3, "status", "--porcelain") == "", git(d3, "status", "--porcelain"))
+
 print()
 print(f"{len(FAILS)} failure(s)" if FAILS else "all carry_vintage tests passed")
 sys.exit(1 if FAILS else 0)

--- a/scripts/unsloth/test_carry_vintage.py
+++ b/scripts/unsloth/test_carry_vintage.py
@@ -222,6 +222,53 @@ check("a file the carry really did take is still superseded",
 check("the late-touch run still writes nothing",
       git(d3, "status", "--porcelain") == "", git(d3, "status", "--porcelain"))
 
+# A PR that RENAMES a file while the carry deliberately keeps the old path.
+# `git diff --name-only` prints only the new name of a detected rename, so the
+# old path never entered the file list at all: the new path came back
+# SUPERSEDED, nothing diverged, and the summary recommended a rebuild -- which
+# deletes the path the carry is holding, unreported.
+def rename_fixture():
+    d = tempfile.mkdtemp(prefix="cv_")
+    git(d, "init", "-q", "-b", "main")
+    git(d, "config", "user.email", "t@t")
+    git(d, "config", "user.name", "t")
+    # Long enough that git scores the move as a rename rather than add+delete.
+    write(d, "old.py", "".join(f"line {i}\n" for i in range(40)))
+    git(d, "add", "-A")
+    git(d, "commit", "-qm", "base")
+    base = git(d, "rev-parse", "HEAD")
+
+    git(d, "checkout", "-q", "-b", "pr")
+    git(d, "mv", "old.py", "new.py")
+    git(d, "commit", "-qm", "pr renames it")
+    head = git(d, "rev-parse", "HEAD")
+
+    # The carry takes the new path AND keeps the old one, on purpose.
+    git(d, "checkout", "-q", "-b", "carry", base)
+    write(d, "new.py", "".join(f"line {i}\n" for i in range(40)))
+    git(d, "add", "-A")
+    git(d, "commit", "-qm", "carry keeps both")
+    return d, base, head, git(d, "rev-parse", "HEAD")
+
+
+d4, base4, head4, carry5 = rename_fixture()
+report4 = str(Path(tempfile.mkdtemp(prefix="cvr_")) / "report.json")
+r6 = subprocess.run([sys.executable, str(SCRIPT), "--carry", carry5, "--pr-ref", head4,
+                     "--base", base4, "--report", report4],
+                    cwd=d4, capture_output=True, text=True)
+check("runs clean on a renaming PR", r6.returncode == 0, r6.stderr)
+out4 = json.loads(Path(report4).read_text())
+check("the old side of a rename is scanned at all",
+      "old.py" in out4["diverged"] + out4["absent"] + out4["omitted"]
+      or any(e["path"] == "old.py" for e in out4["superseded"]),
+      json.dumps(out4, indent=1))
+check("a retained old path is reported as diverged, not silently dropped",
+      "old.py" in out4["diverged"], json.dumps(out4, indent=1))
+check("a rename does not license the rebuild advice",
+      "Nothing diverges" not in r6.stdout, r6.stdout[-400:])
+check("the renaming run still writes nothing",
+      git(d4, "status", "--porcelain") == "", git(d4, "status", "--porcelain"))
+
 print()
 print(f"{len(FAILS)} failure(s)" if FAILS else "all carry_vintage tests passed")
 sys.exit(1 if FAILS else 0)

--- a/scripts/unsloth/test_carry_vintage.py
+++ b/scripts/unsloth/test_carry_vintage.py
@@ -3,16 +3,10 @@
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
 """Tests for carry_vintage.py. Run: python3 scripts/unsloth/test_carry_vintage.py
 
-Builds a throwaway repo shaped like a real carry: an upstream base tag, an
-upstream PR branch with two commits on top of it, and a carry branch that
-replayed the PR onto the base while deliberately dropping one file's change.
+Builds a throwaway repo shaped like a real carry: an upstream base tag, an upstream PR branch with two commits on top of it, and a carry branch that replayed the PR onto the base while deliberately dropping one file's change.
 
-The case that matters is that dropped file. Its content equals the BASE
-version, which is reachable from the PR head, so a vintage search that walks
-the PR head's whole ancestry finds a "match" in a commit that is not part of
-the PR at all, calls the file SUPERSEDED, and concludes that rebuilding from
-the PR head is equivalent to merging -- which would re-add exactly what the
-carry dropped.
+The case that matters is that dropped file.
+Its content equals the BASE version, which is reachable from the PR head, so a vintage search that walks the PR head's whole ancestry finds a "match" in a commit that is not part of the PR at all, calls the file SUPERSEDED, and concludes that rebuilding from the PR head is equivalent to merging - which would re-add exactly what the carry dropped.
 """
 import json
 import subprocess
@@ -65,9 +59,7 @@ def fixture():
     git(d, "commit", "-qam", "pr c2")
     head = git(d, "rev-parse", "HEAD")
 
-    # The carry: PR replayed onto base, with dropped.txt held at the base
-    # version on purpose, edited.txt at an older PR vintage, and taken.txt
-    # already at the PR head.
+    # The carry: PR replayed onto base, with dropped.txt held at the base version on purpose, edited.txt at an older PR vintage, and taken.txt already at the PR head.
     git(d, "checkout", "-q", "-b", "carry", base)
     write(d, "dropped.txt", "base version\n")
     write(d, "taken.txt", "upstream v2\n")
@@ -97,10 +89,8 @@ check("a file at an older PR commit is superseded at that vintage",
 check("a real divergence still forces a merge",
       "has to merge" in r.stdout, r.stdout[-300:])
 
-# With the deliberately dropped file removed from the picture, nothing diverges
-# any more. edited.txt is still at an older vintage than the PR head, though, so
-# the advice stays qualified: we never edited that file, but a rebuild moves it
-# to head, and only a person knows whether the carry meant to hold it.
+# With the deliberately dropped file removed from the picture, nothing diverges any more.
+# edited.txt is still at an older vintage than the PR head, though, so the advice stays qualified: we never edited that file, but a rebuild moves it to head, and only a person knows whether the carry meant to hold it.
 git(d, "checkout", "-q", "carry")
 write(d, "dropped.txt", "upstream v1\n")
 git(d, "commit", "-qam", "take it after all")
@@ -113,11 +103,9 @@ check("an older vintage still qualifies the advice",
       "OLDER vintage" in r2.stdout and "Nothing diverges" not in r2.stdout,
       r2.stdout[-300:])
 
-# A carry that deliberately OMITS a file the PR head still has. Nothing
-# diverges, every file the carry does have is superseded, and the naive answer
-# is "rebuild from the PR head" -- which restores the omitted file and loses
-# the omission. A file the PR DELETED is a different case: the carry not having
-# it is agreement, and a rebuild reproduces it exactly.
+# A carry that deliberately OMITS a file the PR head still has.
+# Nothing diverges, every file the carry does have is superseded, and the naive answer is "rebuild from the PR head" - which restores the omitted file and loses the omission.
+# A file the PR DELETED is a different case: the carry not having it is agreement, and a rebuild reproduces it exactly.
 def omission_fixture():
     d = tempfile.mkdtemp(prefix="cv_")
     git(d, "init", "-q", "-b", "main")
@@ -176,12 +164,8 @@ r4 = subprocess.run([sys.executable, str(SCRIPT), "--carry", git(d2, "rev-parse"
 check("a PR deletion alone still allows the rebuild",
       r4.returncode == 0 and "Nothing diverges" in r4.stdout, r4.stdout[-400:])
 
-# A multi-commit PR that does not touch every file in its FIRST commit. The
-# commits before the one that first changed a path still carry the fork's blob,
-# and they are inside fork..head, so a carry deliberately holding that file at
-# the base version matches one of them and is called SUPERSEDED -- the same
-# wrong "rebuilding is equivalent" answer the fork bound was meant to end, one
-# commit further in.
+# A multi-commit PR that does not touch every file in its FIRST commit.
+# The commits before the one that first changed a path still carry the fork's blob, and they are inside fork..head, so a carry deliberately holding that file at the base version matches one of them and is called SUPERSEDED - the same wrong "rebuilding is equivalent" answer the fork bound was meant to end, one commit further in.
 def late_touch_fixture():
     d = tempfile.mkdtemp(prefix="cv_")
     git(d, "init", "-q", "-b", "main")
@@ -228,10 +212,7 @@ check("the late-touch run still writes nothing",
       git(d3, "status", "--porcelain") == "", git(d3, "status", "--porcelain"))
 
 # A PR that RENAMES a file while the carry deliberately keeps the old path.
-# `git diff --name-only` prints only the new name of a detected rename, so the
-# old path never entered the file list at all: the new path came back
-# SUPERSEDED, nothing diverged, and the summary recommended a rebuild -- which
-# deletes the path the carry is holding, unreported.
+# `git diff --name-only` prints only the new name of a detected rename, so the old path never entered the file list at all: the new path came back SUPERSEDED, nothing diverged, and the summary recommended a rebuild - which deletes the path the carry is holding, unreported.
 def rename_fixture():
     d = tempfile.mkdtemp(prefix="cv_")
     git(d, "init", "-q", "-b", "main")
@@ -274,10 +255,8 @@ check("a rename does not license the rebuild advice",
 check("the renaming run still writes nothing",
       git(d4, "status", "--porcelain") == "", git(d4, "status", "--porcelain"))
 
-# A carry that changes a file the PR never touched. Everything the PR did touch
-# is superseded, so nothing diverges and nothing is omitted, and the rebuild
-# advice was given anyway -- while a rebuild from the PR head drops the
-# carry-only change, which is invisible to a scan of the PR's own file list.
+# A carry that changes a file the PR never touched.
+# Everything the PR did touch is superseded, so nothing diverges and nothing is omitted, and the rebuild advice was given anyway - while a rebuild from the PR head drops the carry-only change, which is invisible to a scan of the PR's own file list.
 def carry_only_fixture():
     d = tempfile.mkdtemp(prefix="cv_")
     git(d, "init", "-q", "-b", "main")
@@ -319,9 +298,8 @@ check("and the PR's own file is still superseded",
 check("the carry-only run still writes nothing",
       git(d5, "status", "--porcelain") == "", git(d5, "status", "--porcelain"))
 
-# A carry that takes the PR's content but changes the file mode. Content is
-# identical, so an oid-only comparison called it superseded and recommended a
-# rebuild, which drops the mode change.
+# A carry that takes the PR's content but changes the file mode.
+# Content is identical, so an oid-only comparison called it superseded and recommended a rebuild, which drops the mode change.
 def mode_fixture():
     d = tempfile.mkdtemp(prefix="cv_")
     git(d, "init", "-q", "-b", "main")
@@ -358,10 +336,8 @@ check("a mode-only difference is not a vintage match",
 check("a mode-only difference withholds the rebuild advice",
       "Nothing diverges" not in r8.stdout, r8.stdout[-400:])
 
-# A carry holding a file at an older commit of the PR. Nothing diverges, so the
-# advice used to be an unqualified "rebuilding is equivalent" -- but a rebuild
-# moves that file to head, and the carry may be holding the older vintage on
-# purpose, which is a decision this script cannot see.
+# A carry holding a file at an older commit of the PR.
+# Nothing diverges, so the advice used to be an unqualified "rebuilding is equivalent" - but a rebuild moves that file to head, and the carry may be holding the older vintage on purpose, which is a decision this script cannot see.
 def older_vintage_fixture():
     d = tempfile.mkdtemp(prefix="cv_")
     git(d, "init", "-q", "-b", "main")

--- a/scripts/unsloth/test_carry_vintage.py
+++ b/scripts/unsloth/test_carry_vintage.py
@@ -269,6 +269,51 @@ check("a rename does not license the rebuild advice",
 check("the renaming run still writes nothing",
       git(d4, "status", "--porcelain") == "", git(d4, "status", "--porcelain"))
 
+# A carry that changes a file the PR never touched. Everything the PR did touch
+# is superseded, so nothing diverges and nothing is omitted, and the rebuild
+# advice was given anyway -- while a rebuild from the PR head drops the
+# carry-only change, which is invisible to a scan of the PR's own file list.
+def carry_only_fixture():
+    d = tempfile.mkdtemp(prefix="cv_")
+    git(d, "init", "-q", "-b", "main")
+    git(d, "config", "user.email", "t@t")
+    git(d, "config", "user.name", "t")
+    write(d, "theirs.txt", "base version\n")
+    write(d, "ours_only.txt", "base version\n")
+    git(d, "add", "-A")
+    git(d, "commit", "-qm", "base")
+    base = git(d, "rev-parse", "HEAD")
+
+    # The PR touches theirs.txt and nothing else.
+    git(d, "checkout", "-q", "-b", "pr")
+    write(d, "theirs.txt", "upstream v1\n")
+    git(d, "commit", "-qam", "pr c1")
+    head = git(d, "rev-parse", "HEAD")
+
+    # The carry takes the PR's change AND makes one of its own, off the PR.
+    git(d, "checkout", "-q", "-b", "carry", base)
+    write(d, "theirs.txt", "upstream v1\n")
+    write(d, "ours_only.txt", "a fix we carry ourselves\n")
+    git(d, "commit", "-qam", "carry plus our own fix")
+    return d, base, head, git(d, "rev-parse", "HEAD")
+
+
+d5, base5, head5, carry6 = carry_only_fixture()
+report5 = str(Path(tempfile.mkdtemp(prefix="cvr_")) / "report.json")
+r7 = subprocess.run([sys.executable, str(SCRIPT), "--carry", carry6, "--pr-ref", head5,
+                     "--base", base5, "--report", report5],
+                    cwd=d5, capture_output=True, text=True)
+check("runs clean on a carry with its own change", r7.returncode == 0, r7.stderr)
+out5 = json.loads(Path(report5).read_text())
+check("a file only the carry changed is reported",
+      out5.get("carry_only") == ["ours_only.txt"], json.dumps(out5, indent=1))
+check("a carry-only change withholds the rebuild advice",
+      "Nothing diverges" not in r7.stdout, r7.stdout[-400:])
+check("and the PR's own file is still superseded",
+      any(e["path"] == "theirs.txt" for e in out5["superseded"]), json.dumps(out5, indent=1))
+check("the carry-only run still writes nothing",
+      git(d5, "status", "--porcelain") == "", git(d5, "status", "--porcelain"))
+
 print()
 print(f"{len(FAILS)} failure(s)" if FAILS else "all carry_vintage tests passed")
 sys.exit(1 if FAILS else 0)

--- a/scripts/unsloth/test_carry_vintage.py
+++ b/scripts/unsloth/test_carry_vintage.py
@@ -97,16 +97,21 @@ check("a file at an older PR commit is superseded at that vintage",
 check("a real divergence still forces a merge",
       "has to merge" in r.stdout, r.stdout[-300:])
 
-# With the deliberately dropped file removed from the picture, everything the
-# PR touched really is superseded and the rebuild advice is correct.
+# With the deliberately dropped file removed from the picture, nothing diverges
+# any more. edited.txt is still at an older vintage than the PR head, though, so
+# the advice stays qualified: we never edited that file, but a rebuild moves it
+# to head, and only a person knows whether the carry meant to hold it.
 git(d, "checkout", "-q", "carry")
 write(d, "dropped.txt", "upstream v1\n")
 git(d, "commit", "-qam", "take it after all")
 carry2 = git(d, "rev-parse", "HEAD")
 r2 = subprocess.run([sys.executable, str(SCRIPT), "--carry", carry2, "--pr-ref", head,
                      "--base", base], cwd=d, capture_output=True, text=True)
-check("still recommends a rebuild when nothing diverges",
-      r2.returncode == 0 and "Nothing diverges" in r2.stdout, r2.stdout[-300:])
+check("nothing diverges once the dropped file is taken",
+      r2.returncode == 0 and "has to merge" not in r2.stdout, r2.stdout[-300:])
+check("an older vintage still qualifies the advice",
+      "OLDER vintage" in r2.stdout and "Nothing diverges" not in r2.stdout,
+      r2.stdout[-300:])
 
 # A carry that deliberately OMITS a file the PR head still has. Nothing
 # diverges, every file the carry does have is superseded, and the naive answer
@@ -352,6 +357,45 @@ check("a mode-only difference is not a vintage match",
       "tool.sh" in out6["diverged"], json.dumps(out6, indent=1))
 check("a mode-only difference withholds the rebuild advice",
       "Nothing diverges" not in r8.stdout, r8.stdout[-400:])
+
+# A carry holding a file at an older commit of the PR. Nothing diverges, so the
+# advice used to be an unqualified "rebuilding is equivalent" -- but a rebuild
+# moves that file to head, and the carry may be holding the older vintage on
+# purpose, which is a decision this script cannot see.
+def older_vintage_fixture():
+    d = tempfile.mkdtemp(prefix="cv_")
+    git(d, "init", "-q", "-b", "main")
+    git(d, "config", "user.email", "t@t")
+    git(d, "config", "user.name", "t")
+    write(d, "f.txt", "base\n")
+    git(d, "add", "-A")
+    git(d, "commit", "-qm", "base")
+    base = git(d, "rev-parse", "HEAD")
+
+    git(d, "checkout", "-q", "-b", "pr")
+    write(d, "f.txt", "upstream v1\n")
+    git(d, "commit", "-qam", "pr c1")
+    write(d, "f.txt", "upstream v2\n")
+    git(d, "commit", "-qam", "pr c2")
+    head = git(d, "rev-parse", "HEAD")
+
+    # The carry stopped at v1.
+    git(d, "checkout", "-q", "-b", "carry", base)
+    write(d, "f.txt", "upstream v1\n")
+    git(d, "commit", "-qam", "carry holds v1")
+    return d, base, head, git(d, "rev-parse", "HEAD")
+
+
+d7, base7, head7, carry8 = older_vintage_fixture()
+r9 = subprocess.run([sys.executable, str(SCRIPT), "--carry", carry8, "--pr-ref", head7,
+                     "--base", base7], cwd=d7, capture_output=True, text=True)
+check("runs clean on an older-vintage carry", r9.returncode == 0, r9.stderr)
+check("an older vintage is still recognised as superseded",
+      "SUPERSEDED" in r9.stdout, r9.stdout[-400:])
+check("an older vintage withholds the unqualified rebuild advice",
+      "Nothing diverges" not in r9.stdout, r9.stdout[-400:])
+check("and says a rebuild would move it to head",
+      "OLDER vintage" in r9.stdout, r9.stdout[-400:])
 
 print()
 print(f"{len(FAILS)} failure(s)" if FAILS else "all carry_vintage tests passed")

--- a/scripts/unsloth/test_carry_vintage.py
+++ b/scripts/unsloth/test_carry_vintage.py
@@ -108,6 +108,69 @@ r2 = subprocess.run([sys.executable, str(SCRIPT), "--carry", carry2, "--pr-ref",
 check("still recommends a rebuild when nothing diverges",
       r2.returncode == 0 and "Nothing diverges" in r2.stdout, r2.stdout[-300:])
 
+# A carry that deliberately OMITS a file the PR head still has. Nothing
+# diverges, every file the carry does have is superseded, and the naive answer
+# is "rebuild from the PR head" -- which restores the omitted file and loses
+# the omission. A file the PR DELETED is a different case: the carry not having
+# it is agreement, and a rebuild reproduces it exactly.
+def omission_fixture():
+    d = tempfile.mkdtemp(prefix="cv_")
+    git(d, "init", "-q", "-b", "main")
+    git(d, "config", "user.email", "t@t")
+    git(d, "config", "user.name", "t")
+    write(d, "keep.txt", "base version\n")
+    write(d, "doomed.txt", "base version\n")
+    git(d, "add", "-A")
+    git(d, "commit", "-qm", "base")
+    base = git(d, "rev-parse", "HEAD")
+
+    # The PR edits keep.txt, adds win.cmake, and deletes doomed.txt.
+    git(d, "checkout", "-q", "-b", "pr")
+    write(d, "keep.txt", "upstream v1\n")
+    write(d, "win.cmake", "windows-only build tweak\n")
+    git(d, "rm", "-q", "doomed.txt")
+    git(d, "add", "-A")
+    git(d, "commit", "-qm", "pr c1")
+    head = git(d, "rev-parse", "HEAD")
+
+    # The carry replays it but never took win.cmake.
+    git(d, "checkout", "-q", "-b", "carry", base)
+    write(d, "keep.txt", "upstream v1\n")
+    git(d, "rm", "-q", "doomed.txt")
+    git(d, "add", "-A")
+    git(d, "commit", "-qm", "carry without win.cmake")
+    return d, base, head, git(d, "rev-parse", "HEAD")
+
+
+d2, base2, head2, carry3 = omission_fixture()
+# outside the repo, so the "writes nothing" check below sees a clean tree
+report2 = str(Path(tempfile.mkdtemp(prefix="cvr_")) / "report.json")
+r3 = subprocess.run([sys.executable, str(SCRIPT), "--carry", carry3, "--pr-ref", head2,
+                     "--base", base2, "--report", report2],
+                    cwd=d2, capture_output=True, text=True)
+check("runs clean on an omitting carry", r3.returncode == 0, r3.stderr)
+out2 = json.loads(Path(report2).read_text())
+check("a file present at the PR head but not in the carry is OMITTED, not absent",
+      out2.get("omitted") == ["win.cmake"] and "win.cmake" not in out2.get("absent", []),
+      json.dumps(out2, indent=1))
+check("a file the PR deleted stays merely ABSENT",
+      out2.get("absent") == ["doomed.txt"], json.dumps(out2, indent=1))
+check("an omitted file suppresses the rebuild recommendation",
+      "Nothing diverges" not in r3.stdout, r3.stdout[-400:])
+check("and says why rebuilding is not equivalent",
+      "NOT equivalent" in r3.stdout, r3.stdout[-400:])
+check("the omitting carry still writes nothing",
+      git(d2, "status", "--porcelain") == "", git(d2, "status", "--porcelain"))
+
+# Take the omitted file, and the rebuild advice is correct again.
+write(d2, "win.cmake", "windows-only build tweak\n")
+git(d2, "add", "-A")
+git(d2, "commit", "-qm", "take win.cmake after all")
+r4 = subprocess.run([sys.executable, str(SCRIPT), "--carry", git(d2, "rev-parse", "HEAD"),
+                     "--pr-ref", head2, "--base", base2], cwd=d2, capture_output=True, text=True)
+check("a PR deletion alone still allows the rebuild",
+      r4.returncode == 0 and "Nothing diverges" in r4.stdout, r4.stdout[-400:])
+
 print()
 print(f"{len(FAILS)} failure(s)" if FAILS else "all carry_vintage tests passed")
 sys.exit(1 if FAILS else 0)

--- a/scripts/unsloth/test_carry_vintage.py
+++ b/scripts/unsloth/test_carry_vintage.py
@@ -314,6 +314,45 @@ check("and the PR's own file is still superseded",
 check("the carry-only run still writes nothing",
       git(d5, "status", "--porcelain") == "", git(d5, "status", "--porcelain"))
 
+# A carry that takes the PR's content but changes the file mode. Content is
+# identical, so an oid-only comparison called it superseded and recommended a
+# rebuild, which drops the mode change.
+def mode_fixture():
+    d = tempfile.mkdtemp(prefix="cv_")
+    git(d, "init", "-q", "-b", "main")
+    git(d, "config", "user.email", "t@t")
+    git(d, "config", "user.name", "t")
+    write(d, "tool.sh", "#!/bin/sh\necho base\n")
+    git(d, "add", "-A")
+    git(d, "commit", "-qm", "base")
+    base = git(d, "rev-parse", "HEAD")
+
+    git(d, "checkout", "-q", "-b", "pr")
+    write(d, "tool.sh", "#!/bin/sh\necho upstream v1\n")
+    git(d, "commit", "-qam", "pr c1")
+    head = git(d, "rev-parse", "HEAD")
+
+    # The carry takes that content verbatim and makes it executable.
+    git(d, "checkout", "-q", "-b", "carry", base)
+    write(d, "tool.sh", "#!/bin/sh\necho upstream v1\n")
+    git(d, "add", "-A")
+    git(d, "update-index", "--chmod=+x", "tool.sh")
+    git(d, "commit", "-qm", "carry makes it executable")
+    return d, base, head, git(d, "rev-parse", "HEAD")
+
+
+d6, base6, head6, carry7 = mode_fixture()
+report6 = str(Path(tempfile.mkdtemp(prefix="cvr_")) / "report.json")
+r8 = subprocess.run([sys.executable, str(SCRIPT), "--carry", carry7, "--pr-ref", head6,
+                     "--base", base6, "--report", report6],
+                    cwd=d6, capture_output=True, text=True)
+check("runs clean on a mode-only carry change", r8.returncode == 0, r8.stderr)
+out6 = json.loads(Path(report6).read_text())
+check("a mode-only difference is not a vintage match",
+      "tool.sh" in out6["diverged"], json.dumps(out6, indent=1))
+check("a mode-only difference withholds the rebuild advice",
+      "Nothing diverges" not in r8.stdout, r8.stdout[-400:])
+
 print()
 print(f"{len(FAILS)} failure(s)" if FAILS else "all carry_vintage tests passed")
 sys.exit(1 if FAILS else 0)

--- a/scripts/unsloth/test_merge_checks.py
+++ b/scripts/unsloth/test_merge_checks.py
@@ -301,6 +301,29 @@ void f() {
 }
 """
 
+# A key that is a CALL is a different object each evaluation, so repeating it is
+# two entries, not one. ast.unparse renders both the same, and a finding here
+# blocks the nightly, so an unstable key must not be compared by text at all.
+DYNAMIC_KEY = """
+MAP = {fresh(): 1, fresh(): 2}
+"""
+# A walrus rebinds between elements, so the same name is not the same value.
+WALRUS_KEY = """
+MAP = {(n := 1): "a", (n := 2): "b"}
+"""
+# Stable keys that are not enum attributes still have to be caught.
+DUP_LITERAL_KEY = """
+MAP = {"a": 1, "b": 2, "a": 3}
+"""
+
+rc, out = run(py=DYNAMIC_KEY)
+check("a repeated call key is not reported as a duplicate", rc == 0, out)
+rc, out = run(py=WALRUS_KEY)
+check("a walrus key is not reported as a duplicate", rc == 0, out)
+rc, out = run(py=DUP_LITERAL_KEY)
+check("a duplicate literal key is still caught",
+      rc == 1 and "defined 2 times" in out, out)
+
 rc, out = run(cpp=CONJUNCTION_AFTER_PLAIN)
 check("catches a conditioned arm after an unconditional match of the same arch",
       rc == 1 and "unreachable" in out, out)

--- a/scripts/unsloth/test_merge_checks.py
+++ b/scripts/unsloth/test_merge_checks.py
@@ -149,6 +149,59 @@ rc, out = run(cpp=BRACES_IN_LITERALS)
 check("still analyses a chain after braces in a string or comment",
       rc == 1 and "unreachable" in out, out)
 
+# llama.cpp puts `else if` on its own line as often as not, src/llama-quant.cpp
+# among them. Ending the chain on the brace line loses the arm that follows, so
+# the duplicate arch started a fresh chain with nothing taken and passed.
+NEXT_LINE_ELSE = """
+void f() {
+    if (arch == LLM_ARCH_QWEN3NEXT || arch == LLM_ARCH_GLM5NEXT) {
+        a();
+    }
+    else if (arch == LLM_ARCH_GLM5NEXT) {
+        c();
+    }
+}
+"""
+# Same, with a blank line in between: still one chain.
+NEXT_LINE_ELSE_BLANK = """
+void f() {
+    if (arch == LLM_ARCH_GLM5NEXT) {
+        a();
+    }
+
+    else if (arch == LLM_ARCH_GLM5NEXT) {
+        c();
+    }
+}
+"""
+# The other direction, which deferring the close could break: a chain that
+# really has ended, followed by an unrelated chain at the same depth. Joining
+# them reports a reachable arm as dead and blocks a release on good code.
+CLOSED_THEN_NEW = """
+void f() {
+    if (arch == LLM_ARCH_GLM5NEXT) {
+        a();
+    } else {
+        b();
+    }
+    g();
+    if (arch == LLM_ARCH_GLM5NEXT) {
+        c();
+    } else if (arch == LLM_ARCH_QWEN3NEXT) {
+        d();
+    }
+}
+"""
+
+rc, out = run(cpp=NEXT_LINE_ELSE)
+check("catches a dead arm when else if starts on the next line",
+      rc == 1 and "unreachable" in out, out)
+rc, out = run(cpp=NEXT_LINE_ELSE_BLANK)
+check("a blank line between } and else does not end the chain",
+      rc == 1 and "unreachable" in out, out)
+rc, out = run(cpp=CLOSED_THEN_NEW)
+check("a genuinely closed chain does not absorb the next one", rc == 0, out)
+
 print()
 print(f"{len(FAILS)} failure(s)" if FAILS else "all merge_checks tests passed")
 sys.exit(1 if FAILS else 0)

--- a/scripts/unsloth/test_merge_checks.py
+++ b/scripts/unsloth/test_merge_checks.py
@@ -91,6 +91,64 @@ check("does NOT fire on distinct arches", rc == 0, out)
 rc, out = run()
 check("clean tree exits 0", rc == 0, out)
 
+# A nested `if` inside an arm must not end the enclosing chain. Tracking chains
+# by indentation resets on the nested arm and analyses the outer `else if` as a
+# fresh chain, so the dedicated GLM5NEXT arm below a shared fallthrough -- the
+# exact 08-27 mistake -- stops being reported.
+NESTED_DEAD_ARM = """
+void f() {
+    if (arch == LLM_ARCH_QWEN3NEXT || arch == LLM_ARCH_GLM5NEXT) {
+        if (hparams.indexer_head_size > 0) {
+            a();
+        } else if (hparams.n_expert > 0) {
+            b();
+        }
+    } else if (arch == LLM_ARCH_GLM5NEXT) {
+        c();
+    }
+}
+"""
+# Two unrelated chains at the same indentation. The second one's opener is a
+# multiline condition, which the regex deliberately skips, so an indentation
+# key appends the reachable GLM5NEXT arm to the FIRST chain and calls it dead.
+# Nothing here is unreachable, and firing would block a release on good code.
+SEPARATE_CHAINS = """
+void f() {
+    if (arch == LLM_ARCH_GLM5NEXT) {
+        a();
+    }
+    unrelated();
+    if (hparams.moe_every_n_layers > 0 &&
+        il % hparams.moe_every_n_layers == 1) {
+        b();
+    } else if (arch == LLM_ARCH_GLM5NEXT) {
+        c();
+    }
+}
+"""
+# A brace inside a string literal or a comment is not a brace. Miscounting one
+# shifts the depth for the rest of the file, which would silence every chain
+# after it.
+BRACES_IN_LITERALS = """
+void f() {
+    const char * tmpl = "{% if x %}{{ y }}{% endif %}";
+    // a stray } in a comment {
+    if (arch == LLM_ARCH_QWEN3NEXT || arch == LLM_ARCH_GLM5NEXT) {
+        a();
+    } else if (arch == LLM_ARCH_GLM5NEXT) {
+        c();
+    }
+}
+"""
+
+rc, out = run(cpp=NESTED_DEAD_ARM)
+check("catches a dead arm across a nested if", rc == 1 and "unreachable" in out, out)
+rc, out = run(cpp=SEPARATE_CHAINS)
+check("does NOT glue two chains at the same indentation", rc == 0, out)
+rc, out = run(cpp=BRACES_IN_LITERALS)
+check("still analyses a chain after braces in a string or comment",
+      rc == 1 and "unreachable" in out, out)
+
 print()
 print(f"{len(FAILS)} failure(s)" if FAILS else "all merge_checks tests passed")
 sys.exit(1 if FAILS else 0)

--- a/scripts/unsloth/test_merge_checks.py
+++ b/scripts/unsloth/test_merge_checks.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+"""Tests for merge_checks.py. Run: python3 scripts/unsloth/test_merge_checks.py
+
+The positive cases are reduced from the two real 08-27 mistakes. The negative
+cases are the shapes that must NOT fire, because a check that blocks a good
+merge costs a release just as surely as a bad merge does.
+"""
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent / "merge_checks.py"
+FAILS = []
+
+
+def check(name, cond, extra=""):
+    print(f"{'PASS' if cond else 'FAIL'}  {name}" + (f"  :: {extra}" if extra and not cond else ""))
+    if not cond:
+        FAILS.append(name)
+
+
+def run(py=None, cpp=None):
+    d = Path(tempfile.mkdtemp(prefix="mc_"))
+    (d / "gguf-py" / "gguf").mkdir(parents=True)
+    (d / "src" / "models").mkdir(parents=True)
+    (d / "gguf-py" / "gguf" / "t.py").write_text(py or "x = {}\n")
+    (d / "src" / "t.cpp").write_text(cpp or "int main() { return 0; }\n")
+    r = subprocess.run([sys.executable, str(SCRIPT), "--root", str(d)],
+                       capture_output=True, text=True)
+    return r.returncode, r.stdout + r.stderr
+
+
+DUP_KEY = """
+MAP = {
+    ARCH.QWEN4EXP: {"a": 1},
+    ARCH.GLM5NEXT: {"b": 2},
+    ARCH.GLM5NEXT: {"b": 2},
+}
+"""
+OK_KEYS = """
+MAP = {
+    ARCH.QWEN4EXP: {"a": 1},
+    ARCH.GLM5NEXT: {"b": 2},
+}
+"""
+DEAD_ARM = """
+void f() {
+    if (arch == LLM_ARCH_FALCON_H1) {
+        a();
+    } else if (arch == LLM_ARCH_QWEN3NEXT || arch == LLM_ARCH_GLM5NEXT) {
+        b();
+    } else if (arch == LLM_ARCH_GLM5NEXT) {
+        c();
+    }
+}
+"""
+LIVE_ARM = """
+void f() {
+    if (arch == LLM_ARCH_GLM5NEXT && hparams.indexer_head_size > 0) {
+        a();
+    } else if (arch == LLM_ARCH_GLM5NEXT) {
+        b();
+    }
+}
+"""
+DISTINCT_ARMS = """
+void f() {
+    if (arch == LLM_ARCH_QWEN3NEXT || arch == LLM_ARCH_QWEN35) {
+        a();
+    } else if (arch == LLM_ARCH_GLM5NEXT) {
+        b();
+    }
+}
+"""
+
+rc, out = run(py=DUP_KEY)
+check("catches a duplicate dict key", rc == 1 and "GLM5NEXT" in out, out)
+rc, out = run(py=OK_KEYS)
+check("clean on distinct dict keys", rc == 0, out)
+
+rc, out = run(cpp=DEAD_ARM)
+check("catches an unreachable arch arm", rc == 1 and "unreachable" in out, out)
+rc, out = run(cpp=LIVE_ARM)
+check("does NOT fire when the earlier arm has &&", rc == 0, out)
+rc, out = run(cpp=DISTINCT_ARMS)
+check("does NOT fire on distinct arches", rc == 0, out)
+
+rc, out = run()
+check("clean tree exits 0", rc == 0, out)
+
+print()
+print(f"{len(FAILS)} failure(s)" if FAILS else "all merge_checks tests passed")
+sys.exit(1 if FAILS else 0)

--- a/scripts/unsloth/test_merge_checks.py
+++ b/scripts/unsloth/test_merge_checks.py
@@ -193,6 +193,37 @@ void f() {
 }
 """
 
+# COND anchors on the `{` that ends the line, so a trailing comment after the
+# brace stopped the arm matching at all and it left the chain silently.
+TRAILING_COMMENT = """
+void f() {
+    if (arch == LLM_ARCH_QWEN3NEXT || arch == LLM_ARCH_GLM5NEXT) { // shared setup
+        a();
+    } else if (arch == LLM_ARCH_GLM5NEXT) { /* dedicated */
+        c();
+    }
+}
+"""
+# The condition text must survive the comment stripping, since a mangled one
+# would fail to parse as a pure disjunction and quietly stop being checked.
+COMMENTED_OUT_ARM = """
+void f() {
+    if (arch == LLM_ARCH_GLM5NEXT) {
+        a();
+    //} else if (arch == LLM_ARCH_GLM5NEXT) {
+    } else if (arch == LLM_ARCH_QWEN3NEXT) {
+        c();
+    }
+}
+"""
+
+rc, out = run(cpp=TRAILING_COMMENT)
+check("catches a dead arm despite a comment after the brace",
+      rc == 1 and "unreachable" in out, out)
+check("and reports the arm that is actually dead", ":5:" in out, out)
+rc, out = run(cpp=COMMENTED_OUT_ARM)
+check("a commented-out arm is not treated as a live one", rc == 0, out)
+
 rc, out = run(cpp=NEXT_LINE_ELSE)
 check("catches a dead arm when else if starts on the next line",
       rc == 1 and "unreachable" in out, out)

--- a/scripts/unsloth/test_merge_checks.py
+++ b/scripts/unsloth/test_merge_checks.py
@@ -3,9 +3,8 @@
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
 """Tests for merge_checks.py. Run: python3 scripts/unsloth/test_merge_checks.py
 
-The positive cases are reduced from the two real 08-27 mistakes. The negative
-cases are the shapes that must NOT fire, because a check that blocks a good
-merge costs a release just as surely as a bad merge does.
+The positive cases are reduced from the two real 08-27 mistakes.
+The negative cases are the shapes that must NOT fire, because a check that blocks a good merge costs a release just as surely as a bad merge does.
 """
 import subprocess
 import sys
@@ -91,10 +90,8 @@ check("does NOT fire on distinct arches", rc == 0, out)
 rc, out = run()
 check("clean tree exits 0", rc == 0, out)
 
-# A nested `if` inside an arm must not end the enclosing chain. Tracking chains
-# by indentation resets on the nested arm and analyses the outer `else if` as a
-# fresh chain, so the dedicated GLM5NEXT arm below a shared fallthrough -- the
-# exact 08-27 mistake -- stops being reported.
+# A nested `if` inside an arm must not end the enclosing chain.
+# Tracking chains by indentation resets on the nested arm and analyses the outer `else if` as a fresh chain, so the dedicated GLM5NEXT arm below a shared fallthrough - the exact 08-27 mistake - stops being reported.
 NESTED_DEAD_ARM = """
 void f() {
     if (arch == LLM_ARCH_QWEN3NEXT || arch == LLM_ARCH_GLM5NEXT) {
@@ -108,9 +105,8 @@ void f() {
     }
 }
 """
-# Two unrelated chains at the same indentation. The second one's opener is a
-# multiline condition, which the regex deliberately skips, so an indentation
-# key appends the reachable GLM5NEXT arm to the FIRST chain and calls it dead.
+# Two unrelated chains at the same indentation.
+# The second one's opener is a multiline condition, which the regex deliberately skips, so an indentation key appends the reachable GLM5NEXT arm to the FIRST chain and calls it dead.
 # Nothing here is unreachable, and firing would block a release on good code.
 SEPARATE_CHAINS = """
 void f() {
@@ -126,9 +122,8 @@ void f() {
     }
 }
 """
-# A brace inside a string literal or a comment is not a brace. Miscounting one
-# shifts the depth for the rest of the file, which would silence every chain
-# after it.
+# A brace inside a string literal or a comment is not a brace.
+# Miscounting one shifts the depth for the rest of the file, which would silence every chain after it.
 BRACES_IN_LITERALS = """
 void f() {
     const char * tmpl = "{% if x %}{{ y }}{% endif %}";
@@ -149,9 +144,8 @@ rc, out = run(cpp=BRACES_IN_LITERALS)
 check("still analyses a chain after braces in a string or comment",
       rc == 1 and "unreachable" in out, out)
 
-# llama.cpp puts `else if` on its own line as often as not, src/llama-quant.cpp
-# among them. Ending the chain on the brace line loses the arm that follows, so
-# the duplicate arch started a fresh chain with nothing taken and passed.
+# llama.cpp puts `else if` on its own line as often as not, src/llama-quant.cpp among them.
+# Ending the chain on the brace line loses the arm that follows, so the duplicate arch started a fresh chain with nothing taken and passed.
 NEXT_LINE_ELSE = """
 void f() {
     if (arch == LLM_ARCH_QWEN3NEXT || arch == LLM_ARCH_GLM5NEXT) {
@@ -174,9 +168,8 @@ void f() {
     }
 }
 """
-# The other direction, which deferring the close could break: a chain that
-# really has ended, followed by an unrelated chain at the same depth. Joining
-# them reports a reachable arm as dead and blocks a release on good code.
+# The other direction, which deferring the close could break: a chain that really has ended, followed by an unrelated chain at the same depth.
+# Joining them reports a reachable arm as dead and blocks a release on good code.
 CLOSED_THEN_NEW = """
 void f() {
     if (arch == LLM_ARCH_GLM5NEXT) {
@@ -193,8 +186,7 @@ void f() {
 }
 """
 
-# COND anchors on the `{` that ends the line, so a trailing comment after the
-# brace stopped the arm matching at all and it left the chain silently.
+# COND anchors on the `{` that ends the line, so a trailing comment after the brace stopped the arm matching at all and it left the chain silently.
 TRAILING_COMMENT = """
 void f() {
     if (arch == LLM_ARCH_QWEN3NEXT || arch == LLM_ARCH_GLM5NEXT) { // shared setup
@@ -204,8 +196,7 @@ void f() {
     }
 }
 """
-# The condition text must survive the comment stripping, since a mangled one
-# would fail to parse as a pure disjunction and quietly stop being checked.
+# The condition text must survive the comment stripping, since a mangled one would fail to parse as a pure disjunction and quietly stop being checked.
 COMMENTED_OUT_ARM = """
 void f() {
     if (arch == LLM_ARCH_GLM5NEXT) {
@@ -217,9 +208,8 @@ void f() {
 }
 """
 
-# A raw string ends only at its own delimiter, so it can hold a quote and a
-# brace that the ordinary string regex misreads. The stray `}` closed the chain
-# early and the duplicate arm after it passed as clean.
+# A raw string ends only at its own delimiter, so it can hold a quote and a brace that the ordinary string regex misreads.
+# The stray `}` closed the chain early and the duplicate arm after it passed as clean.
 RAW_STRING = """
 void f() {
     if (arch == LLM_ARCH_QWEN3NEXT || arch == LLM_ARCH_GLM5NEXT) {
@@ -230,8 +220,7 @@ void f() {
     }
 }
 """
-# A raw string is blanked before comments, so the `//` inside one is text, not
-# the start of a comment, and the brace after it still counts.
+# A raw string is blanked before comments, so the `//` inside one is text, not the start of a comment, and the brace after it still counts.
 RAW_WITH_SLASHES = """
 void f() {
     const char * u = R"(https://example.com/{x})";
@@ -243,11 +232,9 @@ void f() {
 }
 """
 
-# The other ordering. Blanking raw strings before comments let an `R"(` written
-# inside a comment open a literal that ran to the next `)"`, swallowing the
-# duplicate arm in between. Neither order fixes this, which is why the scan is
-# positional: whichever construct starts first wins, and here that is the
-# comment.
+# The other ordering.
+# Blanking raw strings before comments let an `R"(` written inside a comment open a literal that ran to the next `)"`, swallowing the duplicate arm in between.
+# Neither order fixes this, which is why the scan is positional: whichever construct starts first wins, and here that is the comment.
 RAW_INSIDE_COMMENT = """
 void f() {
     if (arch == LLM_ARCH_QWEN3NEXT || arch == LLM_ARCH_GLM5NEXT) {
@@ -259,8 +246,8 @@ void f() {
     }
 }
 """
-# An R glued to an identifier is part of it, not a raw-string prefix. Reading
-# CHAR"( as a literal would blank the rest of the chain.
+# An R glued to an identifier is part of it, not a raw-string prefix.
+# Reading CHAR"( as a literal would blank the rest of the chain.
 IDENT_ENDING_IN_R = """
 void f() {
     if (arch == LLM_ARCH_GLM5NEXT) {
@@ -272,9 +259,8 @@ void f() {
 }
 """
 
-# An unconditional arm takes the arch outright, so a later arm testing the same
-# arch with an extra condition can never run. It is not a pure disjunction, so
-# it was skipped and the dead arm passed.
+# An unconditional arm takes the arch outright, so a later arm testing the same arch with an extra condition can never run.
+# It is not a pure disjunction, so it was skipped and the dead arm passed.
 CONJUNCTION_AFTER_PLAIN = """
 void f() {
     if (arch == LLM_ARCH_QWEN3NEXT || arch == LLM_ARCH_GLM5NEXT) {
@@ -284,8 +270,7 @@ void f() {
     }
 }
 """
-# The reverse must stay clean: a CONDITIONAL arm does not consume the arch, so
-# a later arm testing it is genuinely reachable.
+# The reverse must stay clean: a CONDITIONAL arm does not consume the arch, so a later arm testing it is genuinely reachable.
 PLAIN_AFTER_CONJUNCTION = """
 void f() {
     if (arch == LLM_ARCH_GLM5NEXT && hparams.n_expert > 0) {

--- a/scripts/unsloth/test_merge_checks.py
+++ b/scripts/unsloth/test_merge_checks.py
@@ -243,6 +243,42 @@ void f() {
 }
 """
 
+# The other ordering. Blanking raw strings before comments let an `R"(` written
+# inside a comment open a literal that ran to the next `)"`, swallowing the
+# duplicate arm in between. Neither order fixes this, which is why the scan is
+# positional: whichever construct starts first wins, and here that is the
+# comment.
+RAW_INSIDE_COMMENT = """
+void f() {
+    if (arch == LLM_ARCH_QWEN3NEXT || arch == LLM_ARCH_GLM5NEXT) {
+        // see R"( for the delimiter rules
+        a();
+    } else if (arch == LLM_ARCH_GLM5NEXT) {
+        const char * s = R"(text)";
+        c();
+    }
+}
+"""
+# An R glued to an identifier is part of it, not a raw-string prefix. Reading
+# CHAR"( as a literal would blank the rest of the chain.
+IDENT_ENDING_IN_R = """
+void f() {
+    if (arch == LLM_ARCH_GLM5NEXT) {
+        int n = FOOR;
+        a();
+    } else if (arch == LLM_ARCH_GLM5NEXT) {
+        c();
+    }
+}
+"""
+
+rc, out = run(cpp=RAW_INSIDE_COMMENT)
+check("an R\"( inside a comment does not open a raw string",
+      rc == 1 and "unreachable" in out, out)
+rc, out = run(cpp=IDENT_ENDING_IN_R)
+check("an identifier ending in R is not a raw-string prefix",
+      rc == 1 and "unreachable" in out, out)
+
 rc, out = run(cpp=RAW_STRING)
 check("a brace inside a raw string does not close the chain",
       rc == 1 and "unreachable" in out, out)

--- a/scripts/unsloth/test_merge_checks.py
+++ b/scripts/unsloth/test_merge_checks.py
@@ -217,6 +217,39 @@ void f() {
 }
 """
 
+# A raw string ends only at its own delimiter, so it can hold a quote and a
+# brace that the ordinary string regex misreads. The stray `}` closed the chain
+# early and the duplicate arm after it passed as clean.
+RAW_STRING = """
+void f() {
+    if (arch == LLM_ARCH_QWEN3NEXT || arch == LLM_ARCH_GLM5NEXT) {
+        const char * s = R"foo("})foo";
+        a();
+    } else if (arch == LLM_ARCH_GLM5NEXT) {
+        c();
+    }
+}
+"""
+# A raw string is blanked before comments, so the `//` inside one is text, not
+# the start of a comment, and the brace after it still counts.
+RAW_WITH_SLASHES = """
+void f() {
+    const char * u = R"(https://example.com/{x})";
+    if (arch == LLM_ARCH_GLM5NEXT) {
+        a();
+    } else if (arch == LLM_ARCH_GLM5NEXT) {
+        c();
+    }
+}
+"""
+
+rc, out = run(cpp=RAW_STRING)
+check("a brace inside a raw string does not close the chain",
+      rc == 1 and "unreachable" in out, out)
+rc, out = run(cpp=RAW_WITH_SLASHES)
+check("a raw string holding // is not treated as a comment",
+      rc == 1 and "unreachable" in out, out)
+
 rc, out = run(cpp=TRAILING_COMMENT)
 check("catches a dead arm despite a comment after the brace",
       rc == 1 and "unreachable" in out, out)

--- a/scripts/unsloth/test_merge_checks.py
+++ b/scripts/unsloth/test_merge_checks.py
@@ -272,6 +272,61 @@ void f() {
 }
 """
 
+# An unconditional arm takes the arch outright, so a later arm testing the same
+# arch with an extra condition can never run. It is not a pure disjunction, so
+# it was skipped and the dead arm passed.
+CONJUNCTION_AFTER_PLAIN = """
+void f() {
+    if (arch == LLM_ARCH_QWEN3NEXT || arch == LLM_ARCH_GLM5NEXT) {
+        a();
+    } else if (arch == LLM_ARCH_GLM5NEXT && hparams.n_expert > 0) {
+        c();
+    }
+}
+"""
+# The reverse must stay clean: a CONDITIONAL arm does not consume the arch, so
+# a later arm testing it is genuinely reachable.
+PLAIN_AFTER_CONJUNCTION = """
+void f() {
+    if (arch == LLM_ARCH_GLM5NEXT && hparams.n_expert > 0) {
+        a();
+    } else if (arch == LLM_ARCH_GLM5NEXT) {
+        c();
+    }
+}
+"""
+# A negated test names the arch but does not require it, so it is reachable.
+NEGATED_ARM = """
+void f() {
+    if (arch == LLM_ARCH_GLM5NEXT) {
+        a();
+    } else if (arch != LLM_ARCH_GLM5NEXT && n > 0) {
+        c();
+    }
+}
+"""
+# Only one alternative of a disjunction was taken, so the arm can still run.
+PARTIAL_DISJUNCTION = """
+void f() {
+    if (arch == LLM_ARCH_GLM5NEXT) {
+        a();
+    } else if (arch == LLM_ARCH_GLM5NEXT || arch == LLM_ARCH_QWEN3NEXT) {
+        c();
+    }
+}
+"""
+
+rc, out = run(cpp=CONJUNCTION_AFTER_PLAIN)
+check("catches a conditioned arm after an unconditional match of the same arch",
+      rc == 1 and "unreachable" in out, out)
+rc, out = run(cpp=PLAIN_AFTER_CONJUNCTION)
+check("a conditional arm does not consume the arch for what follows",
+      rc == 0, out)
+rc, out = run(cpp=NEGATED_ARM)
+check("a negated arch test is not read as requiring that arch", rc == 0, out)
+rc, out = run(cpp=PARTIAL_DISJUNCTION)
+check("a disjunction with one untaken alternative stays reachable", rc == 0, out)
+
 rc, out = run(cpp=RAW_INSIDE_COMMENT)
 check("an R\"( inside a comment does not open a raw string",
       rc == 1 and "unreachable" in out, out)

--- a/scripts/unsloth/test_pin_merge.py
+++ b/scripts/unsloth/test_pin_merge.py
@@ -143,7 +143,53 @@ t = json.loads(json.dumps(objs)); t[2]["required"] = "maybe"
 rc, _, err = run_objs(objs, o, t)
 check("refuses a two-sided change to the same field", rc == 1, err)
 
-# 11. --help must not crash: argparse %-formats help strings, and the driver
+def run_docs(base, ours, theirs):
+    """Like run(), but the caller supplies the whole document, not just pins."""
+    d = Path(tempfile.mkdtemp(prefix="pm_"))
+    paths = []
+    for name, doc in (("base", base), ("ours", ours), ("theirs", theirs)):
+        p = d / f"{name}.json"
+        p.write_text(json.dumps(doc, indent=2))
+        paths.append(str(p))
+    r = subprocess.run([sys.executable, str(SCRIPT), *paths, "--stdout"],
+                       capture_output=True, text=True)
+    return r.returncode, (json.loads(r.stdout) if r.returncode == 0 else None), r.stderr.strip()
+
+
+# 12. theirs edits a TOP-LEVEL field while ours repins an entry. Rebuilding the
+# document from ours drops theirs' edit and still exits 0, and because a merge
+# driver replaces git's text merge outright, nothing else ever sees the loss.
+doc = {"_doc": ["old doc line"], "prs": list(BASE_PINS)}
+o = json.loads(json.dumps(doc)); o["prs"] = sub(BASE_PINS, 5, "a" * 40)
+t = json.loads(json.dumps(doc)); t["_doc"] = ["old doc line", "prune closed pins"]
+rc, out, err = run_docs(doc, o, t)
+check("keeps theirs' top-level field change alongside ours' repin",
+      rc == 0 and out is not None and out["_doc"] == t["_doc"], err or json.dumps(out))
+check("still takes ours' repin when theirs edited the document",
+      rc == 0 and out is not None and out["prs"] == o["prs"], err)
+check("keeps .prs in its original key position",
+      rc == 0 and out is not None and list(out) == ["_doc", "prs"], json.dumps(list(out or {})))
+
+# 13. theirs ADDS a top-level field ours has never seen: it has to survive.
+t = json.loads(json.dumps(doc)); t["base_tag"] = "b10639"
+rc, out, err = run_docs(doc, o, t)
+check("keeps a top-level field only theirs added",
+      rc == 0 and out is not None and out.get("base_tag") == "b10639", err or json.dumps(out))
+
+# 14. both sides set the same top-level field differently: refuse, never guess.
+o2 = json.loads(json.dumps(doc)); o2["_doc"] = ["ours' rewrite"]
+t2 = json.loads(json.dumps(doc)); t2["_doc"] = ["theirs' rewrite"]
+rc, _, err = run_docs(doc, o2, t2)
+check("refuses a two-sided change to the same top-level field", rc == 1, err)
+check("names the clashing top-level field", "_doc" in err, err)
+
+# 15. a top-level field theirs deleted stays deleted.
+t3 = json.loads(json.dumps(doc)); del t3["_doc"]
+rc, out, err = run_docs(doc, o, t3)
+check("honours a top-level field theirs deleted",
+      rc == 0 and out is not None and "_doc" not in out, err or json.dumps(out))
+
+# 16. --help must not crash: argparse %-formats help strings, and the driver
 # placeholders %O/%A/%B are literal percents that have to be escaped.
 r = subprocess.run([sys.executable, str(SCRIPT), "--help"], capture_output=True, text=True)
 check("--help does not crash on the %O/%A/%B placeholders",

--- a/scripts/unsloth/test_pin_merge.py
+++ b/scripts/unsloth/test_pin_merge.py
@@ -271,6 +271,19 @@ check("refuses a pin set that names one PR twice", rc == 1,
       json.dumps(pins) if pins else err)
 check("names the duplicated PR", "#107" in err, err)
 
+# 25. neither side has a duplicate, but the merge makes one: ours puts a new PR
+# at position 0 and theirs puts the SAME new PR at position 1. Base has it
+# nowhere, so the reorder guard sees nothing, and the driver emitted [C, C].
+two_ab = [{"url": f"{U}/107/commits/{'a' * 40}"}, {"url": f"{U}/108/commits/{'b' * 40}"}]
+c_entry = {"url": f"{U}/999/commits/{'c' * 40}"}
+o = [json.loads(json.dumps(c_entry)), json.loads(json.dumps(two_ab[1]))]
+t = [json.loads(json.dumps(two_ab[0])), json.loads(json.dumps(c_entry))]
+rc, pins, err = run_objs(two_ab, o, t)
+check("refuses a merge that would pin one PR twice", rc == 1,
+      json.dumps(pins) if pins else err)
+check("says the duplicate is in the merged set",
+      "merged pin set" in err and "#999" in err, err)
+
 print()
 print(f"{len(FAILS)} failure(s)" if FAILS else "all pin_merge tests passed")
 sys.exit(1 if FAILS else 0)

--- a/scripts/unsloth/test_pin_merge.py
+++ b/scripts/unsloth/test_pin_merge.py
@@ -234,6 +234,31 @@ check("a same-position swap to a new PR is not a reorder", rc == 0, err)
 rc, pins, err = run(BASE_PINS, sub(BASE_PINS, 0, "1" * 40), sub(BASE_PINS, 3, "2" * 40))
 check("two repins at different positions still merge", rc == 0, err)
 
+# 22. a same-position swap to a different PR while the OTHER side edits that
+# entry's fields. Test 20's swap is safe only because nobody else touched the
+# entry; here both sides did, so the field-wise merge runs and takes the url
+# from one PR and `required` from another. Base A(required=true) with ours
+# swapping in B and theirs making A optional yielded B(required=false) and
+# exit 0, which makes the release skip a PR nobody made optional.
+two = [{"url": BASE_PINS[0], "required": True}, {"url": BASE_PINS[1], "required": True}]
+o = json.loads(json.dumps(two)); o[0]["url"] = f"{U}/999/commits/{'c' * 40}"
+t = json.loads(json.dumps(two)); t[0]["required"] = False
+rc, pins, err = run_objs(two, o, t)
+check("refuses a same-position PR swap the other side also edited", rc == 1,
+      json.dumps(pins) if pins else err)
+check("names both PRs in the refusal", "#999" in err and "#107" in err, err)
+check("never emits the swapped-in PR carrying the other's field",
+      pins is None or pins[0].get("required") is not False, json.dumps(pins))
+
+# 23. both sides swap position 0 to the SAME new PR but disagree on a field.
+# Base still describes the PR that is gone, so every field comparison below is
+# against settings that were never this PR's: refuse rather than pick one.
+o = json.loads(json.dumps(two)); o[0]["url"] = f"{U}/999/commits/{'c' * 40}"
+t = json.loads(json.dumps(two))
+t[0]["url"] = f"{U}/999/commits/{'c' * 40}"; t[0]["required"] = False
+rc, _, err = run_objs(two, o, t)
+check("refuses an agreed swap the sides disagree about", rc == 1, err)
+
 print()
 print(f"{len(FAILS)} failure(s)" if FAILS else "all pin_merge tests passed")
 sys.exit(1 if FAILS else 0)

--- a/scripts/unsloth/test_pin_merge.py
+++ b/scripts/unsloth/test_pin_merge.py
@@ -3,9 +3,8 @@
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
 """Tests for pin_merge.py. Run: python3 scripts/unsloth/test_pin_merge.py
 
-The first case is the real 08-27 collision: master had moved qwen4exp to
-950f135b28 while the GLM-5-Next branch was replacing pin 118 with 125. It was
-resolved by hand at the time; this asserts the script reproduces that answer.
+The first case is the real 08-27 collision: master had moved qwen4exp to 950f135b28 while the GLM-5-Next branch was replacing pin 118 with 125.
+It was resolved by hand at the time; this asserts the script reproduces that answer.
 """
 import json
 import subprocess
@@ -118,8 +117,7 @@ def run_objs(base, ours, theirs):
 
 
 # 8. theirs flips `required` on one entry while ours repins a DIFFERENT one.
-# Comparing only urls makes theirs' flip invisible, and the result is rebuilt
-# from ours, so the flip is silently dropped by a merge that reports success.
+# Comparing only urls makes theirs' flip invisible, and the result is rebuilt from ours, so the flip is silently dropped by a merge that reports success.
 objs = [{"url": u, "required": True} for u in BASE_PINS]
 o = json.loads(json.dumps(objs)); o[5]["url"] = sub(BASE_PINS, 5, "e" * 40)[5]
 t = json.loads(json.dumps(objs)); t[1]["required"] = False
@@ -156,9 +154,8 @@ def run_docs(base, ours, theirs):
     return r.returncode, (json.loads(r.stdout) if r.returncode == 0 else None), r.stderr.strip()
 
 
-# 12. theirs edits a TOP-LEVEL field while ours repins an entry. Rebuilding the
-# document from ours drops theirs' edit and still exits 0, and because a merge
-# driver replaces git's text merge outright, nothing else ever sees the loss.
+# 12. theirs edits a TOP-LEVEL field while ours repins an entry.
+# Rebuilding the document from ours drops theirs' edit and still exits 0, and because a merge driver replaces git's text merge outright, nothing else ever sees the loss.
 doc = {"_doc": ["old doc line"], "prs": list(BASE_PINS)}
 o = json.loads(json.dumps(doc)); o["prs"] = sub(BASE_PINS, 5, "a" * 40)
 t = json.loads(json.dumps(doc)); t["_doc"] = ["old doc line", "prune closed pins"]
@@ -189,17 +186,14 @@ rc, out, err = run_docs(doc, o, t3)
 check("honours a top-level field theirs deleted",
       rc == 0 and out is not None and "_doc" not in out, err or json.dumps(out))
 
-# 16. --help must not crash: argparse %-formats help strings, and the driver
-# placeholders %O/%A/%B are literal percents that have to be escaped.
+# 16. --help must not crash: argparse %-formats help strings, and the driver placeholders %O/%A/%B are literal percents that have to be escaped.
 r = subprocess.run([sys.executable, str(SCRIPT), "--help"], capture_output=True, text=True)
 check("--help does not crash on the %O/%A/%B placeholders",
       r.returncode == 0 and "%O" in r.stdout, (r.stderr or r.stdout)[-200:])
 
-# 17. one side REORDERS the pins while the other changes a field. Merging by
-# position then combines fields belonging to different PRs: base
-# [A(required), B(required)] with ours making A optional and theirs swapping
-# the two produces B(required=false), so the release skips the wrong PR, and
-# the driver exits 0 while doing it. A reorder must be refused instead.
+# 17. one side REORDERS the pins while the other changes a field.
+# Merging by position then combines fields belonging to different PRs: base [A(required), B(required)] with ours making A optional and theirs swapping the two produces B(required=false), so the release skips the wrong PR, and the driver exits 0 while doing it.
+# A reorder must be refused instead.
 two = [{"url": BASE_PINS[0], "required": True}, {"url": BASE_PINS[1], "required": True}]
 o = json.loads(json.dumps(two)); o[0]["required"] = False
 t = [two[1], two[0]]
@@ -210,8 +204,7 @@ check("names the reordered position", "reorder" in err, err)
 check("never emits a pin carrying another PR's field",
       pins is None or pins[0]["required"] is not False, json.dumps(pins))
 
-# 18. a reorder that also repins the moved entry still has to be refused: the
-# url no longer matches, so only the PR number identifies the entry.
+# 18. a reorder that also repins the moved entry still has to be refused: the url no longer matches, so only the PR number identifies the entry.
 t = [dict(two[1]), dict(two[0])]
 t[0]["url"] = sub(BASE_PINS, 1, "9" * 40)[1]
 rc, _, err = run_objs(two, o, t)
@@ -223,8 +216,7 @@ t2 = json.loads(json.dumps(two)); t2[0]["required"] = False
 rc, _, err = run_objs(two, o2, t2)
 check("refuses a reorder on ours", rc == 1, err)
 
-# 20. swapping a pin for a DIFFERENT PR at the same position is not a reorder
-# and must keep merging, which is case 1's real 08-27 resolution.
+# 20. swapping a pin for a DIFFERENT PR at the same position is not a reorder and must keep merging, which is case 1's real 08-27 resolution.
 rc, pins, err = run(BASE_PINS,
                     replace(BASE_PINS, 6, f"{U}/125/commits/{'a' * 40}"),
                     sub(BASE_PINS, 5, "b" * 40))
@@ -234,12 +226,9 @@ check("a same-position swap to a new PR is not a reorder", rc == 0, err)
 rc, pins, err = run(BASE_PINS, sub(BASE_PINS, 0, "1" * 40), sub(BASE_PINS, 3, "2" * 40))
 check("two repins at different positions still merge", rc == 0, err)
 
-# 22. a same-position swap to a different PR while the OTHER side edits that
-# entry's fields. Test 20's swap is safe only because nobody else touched the
-# entry; here both sides did, so the field-wise merge runs and takes the url
-# from one PR and `required` from another. Base A(required=true) with ours
-# swapping in B and theirs making A optional yielded B(required=false) and
-# exit 0, which makes the release skip a PR nobody made optional.
+# 22. a same-position swap to a different PR while the OTHER side edits that entry's fields.
+# Test 20's swap is safe only because nobody else touched the entry; here both sides did, so the field-wise merge runs and takes the url from one PR and `required` from another.
+# Base A(required=true) with ours swapping in B and theirs making A optional yielded B(required=false) and exit 0, which makes the release skip a PR nobody made optional.
 two = [{"url": BASE_PINS[0], "required": True}, {"url": BASE_PINS[1], "required": True}]
 o = json.loads(json.dumps(two)); o[0]["url"] = f"{U}/999/commits/{'c' * 40}"
 t = json.loads(json.dumps(two)); t[0]["required"] = False
@@ -251,17 +240,14 @@ check("never emits the swapped-in PR carrying the other's field",
       pins is None or pins[0].get("required") is not False, json.dumps(pins))
 
 # 23. both sides swap position 0 to the SAME new PR but disagree on a field.
-# Base still describes the PR that is gone, so every field comparison below is
-# against settings that were never this PR's: refuse rather than pick one.
+# Base still describes the PR that is gone, so every field comparison below is against settings that were never this PR's: refuse rather than pick one.
 o = json.loads(json.dumps(two)); o[0]["url"] = f"{U}/999/commits/{'c' * 40}"
 t = json.loads(json.dumps(two))
 t[0]["url"] = f"{U}/999/commits/{'c' * 40}"; t[0]["required"] = False
 rc, _, err = run_objs(two, o, t)
 check("refuses an agreed swap the sides disagree about", rc == 1, err)
 
-# 24. two entries pinning two commits of the SAME PR share one identity, so a
-# swap between them looks like no change and the reorder guard never fires: a
-# field theirs changed on the first entry then lands on the second.
+# 24. two entries pinning two commits of the SAME PR share one identity, so a swap between them looks like no change and the reorder guard never fires: a field theirs changed on the first entry then lands on the second.
 dup = [{"url": f"{U}/107/commits/{'a' * 40}", "required": True},
        {"url": f"{U}/107/commits/{'b' * 40}", "required": True}]
 o = [json.loads(json.dumps(dup[1])), json.loads(json.dumps(dup[0]))]
@@ -271,9 +257,8 @@ check("refuses a pin set that names one PR twice", rc == 1,
       json.dumps(pins) if pins else err)
 check("names the duplicated PR", "#107" in err, err)
 
-# 25. neither side has a duplicate, but the merge makes one: ours puts a new PR
-# at position 0 and theirs puts the SAME new PR at position 1. Base has it
-# nowhere, so the reorder guard sees nothing, and the driver emitted [C, C].
+# 25. neither side has a duplicate, but the merge makes one: ours puts a new PR at position 0 and theirs puts the SAME new PR at position 1.
+# Base has it nowhere, so the reorder guard sees nothing, and the driver emitted [C, C].
 two_ab = [{"url": f"{U}/107/commits/{'a' * 40}"}, {"url": f"{U}/108/commits/{'b' * 40}"}]
 c_entry = {"url": f"{U}/999/commits/{'c' * 40}"}
 o = [json.loads(json.dumps(c_entry)), json.loads(json.dumps(two_ab[1]))]

--- a/scripts/unsloth/test_pin_merge.py
+++ b/scripts/unsloth/test_pin_merge.py
@@ -259,6 +259,18 @@ t[0]["url"] = f"{U}/999/commits/{'c' * 40}"; t[0]["required"] = False
 rc, _, err = run_objs(two, o, t)
 check("refuses an agreed swap the sides disagree about", rc == 1, err)
 
+# 24. two entries pinning two commits of the SAME PR share one identity, so a
+# swap between them looks like no change and the reorder guard never fires: a
+# field theirs changed on the first entry then lands on the second.
+dup = [{"url": f"{U}/107/commits/{'a' * 40}", "required": True},
+       {"url": f"{U}/107/commits/{'b' * 40}", "required": True}]
+o = [json.loads(json.dumps(dup[1])), json.loads(json.dumps(dup[0]))]
+t = json.loads(json.dumps(dup)); t[0]["required"] = False
+rc, pins, err = run_objs(dup, o, t)
+check("refuses a pin set that names one PR twice", rc == 1,
+      json.dumps(pins) if pins else err)
+check("names the duplicated PR", "#107" in err, err)
+
 print()
 print(f"{len(FAILS)} failure(s)" if FAILS else "all pin_merge tests passed")
 sys.exit(1 if FAILS else 0)

--- a/scripts/unsloth/test_pin_merge.py
+++ b/scripts/unsloth/test_pin_merge.py
@@ -104,6 +104,51 @@ r = subprocess.run([sys.executable, str(SCRIPT), str(d / "base.json"), str(d / "
 ok = r.returncode == 0 and all(e.get("required") is False for e in json.loads(r.stdout)["prs"])
 check("object-form entries keep their other fields", ok, r.stdout[:200] + r.stderr)
 
+
+def run_objs(base, ours, theirs):
+    d = Path(tempfile.mkdtemp(prefix="pm_"))
+    paths = []
+    for name, entries in (("base", base), ("ours", ours), ("theirs", theirs)):
+        p = d / f"{name}.json"
+        p.write_text(json.dumps({"prs": entries}, indent=2))
+        paths.append(str(p))
+    r = subprocess.run([sys.executable, str(SCRIPT), *paths, "--stdout"],
+                       capture_output=True, text=True)
+    return r.returncode, (json.loads(r.stdout)["prs"] if r.returncode == 0 else None), r.stderr.strip()
+
+
+# 8. theirs flips `required` on one entry while ours repins a DIFFERENT one.
+# Comparing only urls makes theirs' flip invisible, and the result is rebuilt
+# from ours, so the flip is silently dropped by a merge that reports success.
+objs = [{"url": u, "required": True} for u in BASE_PINS]
+o = json.loads(json.dumps(objs)); o[5]["url"] = sub(BASE_PINS, 5, "e" * 40)[5]
+t = json.loads(json.dumps(objs)); t[1]["required"] = False
+rc, pins, err = run_objs(objs, o, t)
+check("keeps theirs' non-url field change on an entry ours did not touch",
+      rc == 0 and pins is not None and pins[1]["required"] is False, err or json.dumps(pins))
+check("keeps ours' repin alongside theirs' field change",
+      rc == 0 and pins is not None and pins[5]["url"] == o[5]["url"], err)
+
+# 9. both sides touch the SAME entry, but different fields: still mergeable.
+o = json.loads(json.dumps(objs)); o[3]["url"] = sub(BASE_PINS, 3, "f" * 40)[3]
+t = json.loads(json.dumps(objs)); t[3]["required"] = False
+rc, pins, err = run_objs(objs, o, t)
+check("merges a repin and a field change on the same entry",
+      rc == 0 and pins is not None
+      and pins[3]["url"] == o[3]["url"] and pins[3]["required"] is False, err)
+
+# 10. both sides set the same field to different values: still refused.
+o = json.loads(json.dumps(objs)); o[2]["required"] = False
+t = json.loads(json.dumps(objs)); t[2]["required"] = "maybe"
+rc, _, err = run_objs(objs, o, t)
+check("refuses a two-sided change to the same field", rc == 1, err)
+
+# 11. --help must not crash: argparse %-formats help strings, and the driver
+# placeholders %O/%A/%B are literal percents that have to be escaped.
+r = subprocess.run([sys.executable, str(SCRIPT), "--help"], capture_output=True, text=True)
+check("--help does not crash on the %O/%A/%B placeholders",
+      r.returncode == 0 and "%O" in r.stdout, (r.stderr or r.stdout)[-200:])
+
 print()
 print(f"{len(FAILS)} failure(s)" if FAILS else "all pin_merge tests passed")
 sys.exit(1 if FAILS else 0)

--- a/scripts/unsloth/test_pin_merge.py
+++ b/scripts/unsloth/test_pin_merge.py
@@ -195,6 +195,45 @@ r = subprocess.run([sys.executable, str(SCRIPT), "--help"], capture_output=True,
 check("--help does not crash on the %O/%A/%B placeholders",
       r.returncode == 0 and "%O" in r.stdout, (r.stderr or r.stdout)[-200:])
 
+# 17. one side REORDERS the pins while the other changes a field. Merging by
+# position then combines fields belonging to different PRs: base
+# [A(required), B(required)] with ours making A optional and theirs swapping
+# the two produces B(required=false), so the release skips the wrong PR, and
+# the driver exits 0 while doing it. A reorder must be refused instead.
+two = [{"url": BASE_PINS[0], "required": True}, {"url": BASE_PINS[1], "required": True}]
+o = json.loads(json.dumps(two)); o[0]["required"] = False
+t = [two[1], two[0]]
+rc, pins, err = run_objs(two, o, t)
+check("refuses a reorder that would splice fields across PRs", rc == 1,
+      json.dumps(pins) if pins else err)
+check("names the reordered position", "reorder" in err, err)
+check("never emits a pin carrying another PR's field",
+      pins is None or pins[0]["required"] is not False, json.dumps(pins))
+
+# 18. a reorder that also repins the moved entry still has to be refused: the
+# url no longer matches, so only the PR number identifies the entry.
+t = [dict(two[1]), dict(two[0])]
+t[0]["url"] = sub(BASE_PINS, 1, "9" * 40)[1]
+rc, _, err = run_objs(two, o, t)
+check("refuses a reorder combined with a repin", rc == 1, err)
+
+# 19. a reorder on OUR side is refused too, not just on theirs.
+o2 = [two[1], two[0]]
+t2 = json.loads(json.dumps(two)); t2[0]["required"] = False
+rc, _, err = run_objs(two, o2, t2)
+check("refuses a reorder on ours", rc == 1, err)
+
+# 20. swapping a pin for a DIFFERENT PR at the same position is not a reorder
+# and must keep merging, which is case 1's real 08-27 resolution.
+rc, pins, err = run(BASE_PINS,
+                    replace(BASE_PINS, 6, f"{U}/125/commits/{'a' * 40}"),
+                    sub(BASE_PINS, 5, "b" * 40))
+check("a same-position swap to a new PR is not a reorder", rc == 0, err)
+
+# 21. a plain repin is not a reorder either, on either side.
+rc, pins, err = run(BASE_PINS, sub(BASE_PINS, 0, "1" * 40), sub(BASE_PINS, 3, "2" * 40))
+check("two repins at different positions still merge", rc == 0, err)
+
 print()
 print(f"{len(FAILS)} failure(s)" if FAILS else "all pin_merge tests passed")
 sys.exit(1 if FAILS else 0)

--- a/scripts/unsloth/test_pin_merge.py
+++ b/scripts/unsloth/test_pin_merge.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+"""Tests for pin_merge.py. Run: python3 scripts/unsloth/test_pin_merge.py
+
+The first case is the real 08-27 collision: master had moved qwen4exp to
+950f135b28 while the GLM-5-Next branch was replacing pin 118 with 125. It was
+resolved by hand at the time; this asserts the script reproduces that answer.
+"""
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent / "pin_merge.py"
+FAILS = []
+
+U = "https://github.com/unslothai/llama.cpp/pull"
+BASE_PINS = [
+    f"{U}/107/commits/74acc40c37ae2eb36031981feda392b793944f72",
+    f"{U}/108/commits/27278df7000ade4a638d044202dbe82975421df6",
+    f"{U}/70/commits/edfd4c1a3b7a653303a85257ddac2a1f3ce39a2f",
+    f"{U}/91/commits/c86ed269986f2dced6325c5c58bda966a2e2ead1",
+    f"{U}/95/commits/3db8cb5b2e9bf291057b9f19960e8601a162da81",
+    f"{U}/114/commits/c4ddc4805dbc12727897b354237bfd9225212b06",
+    f"{U}/118/commits/3766b41229c20249fd4d83d7ba297499d50e9b80",
+]
+
+
+def check(name, cond, extra=""):
+    print(f"{'PASS' if cond else 'FAIL'}  {name}" + (f"  :: {extra}" if extra and not cond else ""))
+    if not cond:
+        FAILS.append(name)
+
+
+def run(base, ours, theirs):
+    d = Path(tempfile.mkdtemp(prefix="pm_"))
+    paths = []
+    for name, pins in (("base", base), ("ours", ours), ("theirs", theirs)):
+        p = d / f"{name}.json"
+        p.write_text(json.dumps({"prs": pins}, indent=2))
+        paths.append(str(p))
+    r = subprocess.run([sys.executable, str(SCRIPT), *paths, "--stdout"],
+                       capture_output=True, text=True)
+    pins = json.loads(r.stdout)["prs"] if r.returncode == 0 else None
+    return r.returncode, pins, r.stderr.strip()
+
+
+def sub(pins, i, sha):
+    out = list(pins)
+    out[i] = out[i].rsplit("/", 1)[0] + "/" + sha
+    return out
+
+
+def replace(pins, i, url):
+    out = list(pins)
+    out[i] = url
+    return out
+
+
+# 1. the real 08-27 collision
+ours = replace(BASE_PINS, 6, f"{U}/125/commits/f48b99e1fd04628da2a3d4ea5acc335d9ea67f7a")
+theirs = sub(BASE_PINS, 5, "950f135b28789057721a65d76de98fbbcd2f7dd6")
+rc, pins, err = run(BASE_PINS, ours, theirs)
+check("real 08-27 collision resolves", rc == 0, err)
+if pins:
+    check("takes theirs for the pin only theirs moved", pins[5] == theirs[5], pins[5])
+    check("takes ours for the pin only ours moved", pins[6] == ours[6], pins[6])
+    check("leaves untouched pins alone", pins[:5] == BASE_PINS[:5])
+    check("preserves pin order", [p.split("/pull/")[1].split("/")[0] for p in pins]
+          == ["107", "108", "70", "91", "95", "114", "125"])
+
+# 2. both sides repin the same entry differently
+rc, _, err = run(BASE_PINS, sub(BASE_PINS, 5, "a" * 40), sub(BASE_PINS, 5, "b" * 40))
+check("refuses a genuine two-sided repin", rc == 1, err)
+check("says which pin was ambiguous", "pin 5" in err, err)
+
+# 3. a pin added on one side
+rc, _, err = run(BASE_PINS, BASE_PINS + [f"{U}/999/commits/{'c' * 40}"], BASE_PINS)
+check("refuses an added pin", rc == 1, err)
+
+# 4. a pin removed on one side
+rc, _, err = run(BASE_PINS, BASE_PINS[:-1], BASE_PINS)
+check("refuses a removed pin", rc == 1, err)
+
+# 5. both sides make the identical repin
+same = sub(BASE_PINS, 5, "d" * 40)
+rc, pins, err = run(BASE_PINS, same, same)
+check("accepts an identical repin on both sides", rc == 0 and pins == same, err)
+
+# 6. neither side changed anything
+rc, pins, err = run(BASE_PINS, BASE_PINS, BASE_PINS)
+check("no-op merge is a no-op", rc == 0 and pins == BASE_PINS, err)
+
+# 7. object-form entries keep their other fields
+objs = [{"url": u, "required": False} for u in BASE_PINS]
+o = json.loads(json.dumps(objs)); o[5]["url"] = sub(BASE_PINS, 5, "e" * 40)[5]
+d = Path(tempfile.mkdtemp(prefix="pm_"))
+for name, pins_ in (("base", objs), ("ours", o), ("theirs", objs)):
+    (d / f"{name}.json").write_text(json.dumps({"prs": pins_}, indent=2))
+r = subprocess.run([sys.executable, str(SCRIPT), str(d / "base.json"), str(d / "ours.json"),
+                    str(d / "theirs.json"), "--stdout"], capture_output=True, text=True)
+ok = r.returncode == 0 and all(e.get("required") is False for e in json.loads(r.stdout)["prs"])
+check("object-form entries keep their other fields", ok, r.stdout[:200] + r.stderr)
+
+print()
+print(f"{len(FAILS)} failure(s)" if FAILS else "all pin_merge tests passed")
+sys.exit(1 if FAILS else 0)

--- a/scripts/unsloth/test_sync_deletes.py
+++ b/scripts/unsloth/test_sync_deletes.py
@@ -96,6 +96,19 @@ check("keeps upstream composite actions", (d / ".github/actions/ccache-buckets/a
 # 6. source files are never removed by the added-workflow sweep
 check("source file untouched throughout", (d / "src" / "model.cpp").exists())
 
+# 7. an unusable --merge-base. git diff exits nonzero with empty stdout, which
+# reads exactly like "upstream added nothing" if only stdout is looked at, so
+# the run reported success and a sync would have carried every newly added
+# upstream workflow in. The listing failing has to fail the script.
+d, base = scenario(".github/workflows/build-apple.yml",
+                   upstream_adds=".github/workflows/build-wasm.yml")
+rc, out = run(d, "0000000000000000000000000000000000000000")
+check("fails when the added-workflow listing cannot run", rc == 1, out)
+check("says which rev it could not use",
+      "0000000000" in out and "could not list" in out, out)
+check("and leaves the added workflow in place to be dealt with",
+      (d / ".github/workflows/build-wasm.yml").exists(), out)
+
 print()
 print(f"{len(FAILS)} failure(s)" if FAILS else "all sync_deletes tests passed")
 sys.exit(1 if FAILS else 0)

--- a/scripts/unsloth/test_sync_deletes.py
+++ b/scripts/unsloth/test_sync_deletes.py
@@ -109,6 +109,37 @@ check("says which rev it could not use",
 check("and leaves the added workflow in place to be dealt with",
       (d / ".github/workflows/build-wasm.yml").exists(), out)
 
+# 8. upstream RENAMES a workflow rather than adding one. Rename detection calls
+# the new path R, not A, so --diff-filter=A saw nothing and the script exited 0
+# with the renamed upstream workflow left live in the fork.
+def rename_scenario():
+    d = Path(tempfile.mkdtemp(prefix="sd_"))
+    git(d, "init", "-q", "-b", "main")
+    wf = d / ".github" / "workflows"
+    wf.mkdir(parents=True)
+    # Long enough that git scores the move as a rename rather than add+delete.
+    (wf / "old.yml").write_text("".join(f"# line {i}\n" for i in range(40)))
+    (d / "src").mkdir()
+    (d / "src" / "model.cpp").write_text("int x;\n")
+    git(d, "add", "-A"); git(d, "commit", "-qm", "base")
+    base = git(d, "rev-parse", "HEAD").stdout.strip()
+
+    git(d, "checkout", "-qb", "upstream")
+    git(d, "mv", ".github/workflows/old.yml", ".github/workflows/new.yml")
+    git(d, "commit", "-qm", "upstream renames it")
+
+    git(d, "checkout", "-q", "main")
+    git(d, "merge", "--no-ff", "--no-edit", "upstream")
+    return d, base
+
+
+d, base = rename_scenario()
+rc, out = run(d, base)
+check("drops an upstream workflow that arrived by rename", rc == 0, out)
+check("the renamed workflow is gone",
+      not (d / ".github/workflows/new.yml").exists(), out)
+check("source is still untouched", (d / "src" / "model.cpp").exists(), out)
+
 print()
 print(f"{len(FAILS)} failure(s)" if FAILS else "all sync_deletes tests passed")
 sys.exit(1 if FAILS else 0)

--- a/scripts/unsloth/test_sync_deletes.py
+++ b/scripts/unsloth/test_sync_deletes.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+"""Tests for sync_deletes.py. Run: python3 scripts/unsloth/test_sync_deletes.py
+
+Every case builds a real git merge, so the index stages are the ones git
+actually produces rather than a hand-written approximation.
+"""
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent / "sync_deletes.py"
+FAILS = []
+
+
+def check(name, cond, extra=""):
+    print(f"{'PASS' if cond else 'FAIL'}  {name}" + (f"  :: {extra}" if extra and not cond else ""))
+    if not cond:
+        FAILS.append(name)
+
+
+def git(repo, *args):
+    return subprocess.run(["git", "-c", "user.name=t", "-c", "user.email=t@t", *args],
+                          cwd=repo, capture_output=True, text=True)
+
+
+def scenario(path, ours_deletes=True, upstream_modifies=True, upstream_adds=None):
+    """Base has `path`; upstream edits it; we delete it. Returns (repo, merge_base)."""
+    d = Path(tempfile.mkdtemp(prefix="sd_"))
+    git(d, "init", "-q", "-b", "main")
+    f = d / path
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text("name: base\n")
+    (d / "src").mkdir(exist_ok=True)
+    (d / "src" / "model.cpp").write_text("int x;\n")
+    git(d, "add", "-A"); git(d, "commit", "-qm", "base")
+    base = git(d, "rev-parse", "HEAD").stdout.strip()
+
+    git(d, "checkout", "-qb", "upstream")
+    if upstream_modifies:
+        f.write_text("name: upstream edit\n")
+    if upstream_adds:
+        na = d / upstream_adds
+        na.parent.mkdir(parents=True, exist_ok=True)
+        na.write_text("name: new upstream workflow\n")
+    git(d, "add", "-A"); git(d, "commit", "-qm", "upstream")
+
+    git(d, "checkout", "-q", "main")
+    if ours_deletes:
+        git(d, "rm", "-q", str(f.relative_to(d)))
+        git(d, "commit", "-qm", "fork deletes it")
+    git(d, "-c", "merge.conflictStyle=diff3", "merge", "--no-ff", "--no-edit", "upstream")
+    return d, base
+
+
+def run(repo, base=None):
+    args = [sys.executable, str(SCRIPT), "--repo", str(repo)]
+    if base:
+        args += ["--merge-base", base]
+    r = subprocess.run(args, capture_output=True, text=True)
+    return r.returncode, r.stdout + r.stderr
+
+
+# 1. the 68-of-68 historical case
+d, base = scenario(".github/workflows/build-apple.yml")
+rc, out = run(d)
+check("resolves an upstream-workflow modify/delete", rc == 0, out)
+check("the file stays deleted", not (d / ".github/workflows/build-apple.yml").exists())
+check("no unmerged paths remain", git(d, "ls-files", "-u").stdout.strip() == "")
+
+# 2. a workflow we own must never be touched automatically
+d, base = scenario(".github/workflows/unsloth-prebuilt.yml")
+rc, out = run(d)
+check("refuses a fork-owned workflow", rc == 1 and "we own this workflow" in out, out)
+
+# 3. a source file in the same shape must never be touched
+d, base = scenario("src/model.cpp")
+rc, out = run(d)
+check("refuses a source file", rc == 1 and "not an upstream workflow path" in out, out)
+
+# 4. a workflow upstream added, which is not a conflict at all
+d, base = scenario(".github/workflows/build-apple.yml",
+                   upstream_adds=".github/workflows/build-wasm.yml")
+rc, out = run(d, base)
+check("drops a newly added upstream workflow", rc == 0, out)
+check("the added workflow is gone", not (d / ".github/workflows/build-wasm.yml").exists())
+
+# 5. an upstream composite ACTION must survive; only workflows are dropped
+d, base = scenario(".github/workflows/build-apple.yml",
+                   upstream_adds=".github/actions/ccache-buckets/action.yml")
+rc, out = run(d, base)
+check("keeps upstream composite actions", (d / ".github/actions/ccache-buckets/action.yml").exists(), out)
+
+# 6. source files are never removed by the added-workflow sweep
+check("source file untouched throughout", (d / "src" / "model.cpp").exists())
+
+print()
+print(f"{len(FAILS)} failure(s)" if FAILS else "all sync_deletes tests passed")
+sys.exit(1 if FAILS else 0)

--- a/scripts/unsloth/test_sync_deletes.py
+++ b/scripts/unsloth/test_sync_deletes.py
@@ -137,6 +137,14 @@ check("the renamed workflow is gone",
       not (d / ".github/workflows/new.yml").exists(), out)
 check("source is still untouched", (d / "src" / "model.cpp").exists(), out)
 
+# 9. --repo names something that is not a git repository. ls-files fails, its
+# empty stdout read as "no conflicts", and the script reported that it had
+# resolved everything it was asked to.
+notrepo = Path(tempfile.mkdtemp(prefix="sd_notrepo_"))
+rc, out = run(notrepo)
+check("fails when the unmerged listing cannot run", rc == 1, out)
+check("says what could not be listed", "ls-files" in out, out)
+
 print()
 print(f"{len(FAILS)} failure(s)" if FAILS else "all sync_deletes tests passed")
 sys.exit(1 if FAILS else 0)

--- a/scripts/unsloth/test_sync_deletes.py
+++ b/scripts/unsloth/test_sync_deletes.py
@@ -3,8 +3,7 @@
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
 """Tests for sync_deletes.py. Run: python3 scripts/unsloth/test_sync_deletes.py
 
-Every case builds a real git merge, so the index stages are the ones git
-actually produces rather than a hand-written approximation.
+Every case builds a real git merge, so the index stages are the ones git actually produces rather than a hand-written approximation.
 """
 import subprocess
 import sys
@@ -96,10 +95,9 @@ check("keeps upstream composite actions", (d / ".github/actions/ccache-buckets/a
 # 6. source files are never removed by the added-workflow sweep
 check("source file untouched throughout", (d / "src" / "model.cpp").exists())
 
-# 7. an unusable --merge-base. git diff exits nonzero with empty stdout, which
-# reads exactly like "upstream added nothing" if only stdout is looked at, so
-# the run reported success and a sync would have carried every newly added
-# upstream workflow in. The listing failing has to fail the script.
+# 7. an unusable --merge-base.
+# git diff exits nonzero with empty stdout, which reads exactly like "upstream added nothing" if only stdout is looked at, so the run reported success and a sync would have carried every newly added upstream workflow in.
+# The listing failing has to fail the script.
 d, base = scenario(".github/workflows/build-apple.yml",
                    upstream_adds=".github/workflows/build-wasm.yml")
 rc, out = run(d, "0000000000000000000000000000000000000000")
@@ -109,9 +107,8 @@ check("says which rev it could not use",
 check("and leaves the added workflow in place to be dealt with",
       (d / ".github/workflows/build-wasm.yml").exists(), out)
 
-# 8. upstream RENAMES a workflow rather than adding one. Rename detection calls
-# the new path R, not A, so --diff-filter=A saw nothing and the script exited 0
-# with the renamed upstream workflow left live in the fork.
+# 8. upstream RENAMES a workflow rather than adding one.
+# Rename detection calls the new path R, not A, so --diff-filter=A saw nothing and the script exited 0 with the renamed upstream workflow left live in the fork.
 def rename_scenario():
     d = Path(tempfile.mkdtemp(prefix="sd_"))
     git(d, "init", "-q", "-b", "main")


### PR DESCRIPTION
Landing the qwen4exp, Inkling and GLM-5-Next repins on 08-27 took six conflict resolutions by hand, and two were wrong in ways a clean build did not catch. Rather than guess at what would help, I replayed the fork's entire merge history and measured it.

## The measurement

Every two-parent merge commit reachable from any branch was recomputed with `git merge-tree` against its own merge base, then each conflicted file was offered to the resolvers.

| | count |
|---|---|
| merge commits replayed | 116 |
| merged clean | 79 (68 percent) |
| conflicted | 37 |
| of those, `additive_merge.py` resolves | 11 |
| of those, needed a human | 26 |

Broken down by individual file conflict rather than by merge, 149 in total:

| kind | count | share |
|---|---|---|
| modify/delete on an upstream workflow | 68 | 45 percent |
| content conflict in source | 79 | 53 percent |
| add/add in source | 2 | 1 percent |

Nearly half of every conflict this fork has ever had is one decision, repeated.

## The 45 percent

Upstream edits a workflow this fork deletes on purpose, git cannot know which side wins, and a human keeps the deletion. I checked what was actually committed in all 68 historical instances:

| resolution | count |
|---|---|
| kept the fork's deletion | 68 |
| kept the file | 0 |

That is not a heuristic, it is the fork's stated invariant. `scripts/unsloth/upstream-sync.json` requires the diff from the sync point to master to touch only `.github/` and `scripts/unsloth/`, and `verify_upstream_sync.py` already treats these deletions as legitimate.

`sync_deletes.py` applies it. Replaying every sync-shaped merge in history:

| | count |
|---|---|
| sync merges replayed | 5 |
| resolved with a tree byte-identical to the human's | 5 |
| tree differed | 0 |
| conflicts left for a human | 0 |

Replaying also found a gap I would not have thought of. Resolving only the conflicts left `.github/workflows/build-wasm.yml` in the tree, because upstream had ADDED it, which is not a conflict at all: git merges it in silently and the fork acquires a workflow that fires on its own repo. The recorded human resolution had deleted it. With that handled, the replay reproduces the tree exactly.

## No model can break from this

The constraint that governs the design. Across all 5 replayed syncs, `sync_deletes.py` removed 90 paths:

| | count |
|---|---|
| under `.github/workflows/` | 90 |
| outside it | 0 |
| fork-owned `unsloth-*` workflows | 0 |
| source, ggml, conversion, gguf-py or tools files | 0 |

It refuses a source file in the same modify/delete shape, refuses a workflow we own, and keeps upstream composite actions under `.github/actions/`, all covered by tests. Combined with 5 of 5 byte-identical trees, no model-affecting file is reachable by this resolver.

## Per pin, as requested

| pin | merges | clean | auto | needed a human | most refused |
|---|---|---|---|---|---|
| kimi-k3 (70) | 23 | 10 | 3 | 10 | `chat.cpp` x3 |
| Inkling (25731) | 20 | 9 | 3 | 8 | `ggml-rpc.h` x3 |
| MiniMax-M3 (removed) | 12 | 9 | 0 | 3 | upstream workflows |
| IQ1 narrow (61) | 10 | 9 | 0 | 1 | upstream workflows |
| penalties (95) | 9 | 8 | 0 | 1 | upstream workflows |
| GLM-5-Next (27754) | 6 | 4 | 0 | 2 | `tensor_mapping.py` x2 |
| diffusiongemma (24423) | 5 | 2 | 1 | 2 | `llama.h`, `arg.cpp` |
| Qwen3.8 qwen4exp (27742) | 3 | 3 | 0 | 0 | none |

MiniMax-M3, IQ1 and penalties are entirely the upstream-workflow case, so `sync_deletes.py` covers all of them. `ggml-rpc.h` in Inkling is the RPC protocol version triple, refused 5 times across the fork and still the most-refused source file. It is a candidate for a small domain resolver but is not in this PR, because "take their major and minor, keep our patch" is a judgement about protocol compatibility rather than something provable from the tree.

## What a build does not catch

Two of the 08-27 resolutions compiled cleanly and were wrong:

- A resolver unioned two byte-identical additions and left `MODEL_ARCH.GLM5NEXT` defined twice in the tensor map. Python keeps the last duplicate key silently, so the converter reads the wrong mapping and the model converts wrong.
- The same union kept GLM-5-Next in a shared fallthrough condition and also left a dedicated `else if (arch == LLM_ARCH_GLM5NEXT)` arm below it. The shared condition matches first, so the dedicated arm is dead and the model runs without the indexer cache it exists to build.

`merge_checks.py` finds both. It resolves nothing and rewrites nothing; it turns a silent wrong answer into a loud one. It is now wired into the nightly `resolve` step in `unsloth-prebuilt.yml`, on the composed tree, at the last point that tree exists before 39 build jobs run on it.

Scanned across all 116 historical merge trees it reports nothing, which cuts both ways and both are worth saying: these two bugs have never actually shipped, so the value is preventive rather than retroactive, and 116 real trees is decent evidence it does not fire on valid code.

It is deliberately narrow. The unreachable-arm check only fires when the earlier condition is a pure disjunction of `arch == LLM_ARCH_*` terms, because `else if (arch == X && cond)` followed by `else if (arch == X)` is genuinely reachable. There is deliberately no duplicate-C++-definition check: the obvious version flagged `llama_model_base::create_tensor`, which is two different signatures, and a real duplicate is an ODR violation the compiler already rejects.

## pr-set.json

Conflicted twice in one hour on 08-27, because two repins were in flight and both edit adjacent lines of the same list. `pin_merge.py` merges it one pin at a time. Pin order is load-bearing, since `resolve` merges pins sequentially, so it never reorders: it walks the base list positionally.

| case | result |
|---|---|
| the real 08-27 collision | resolves, byte for byte the hand answer |
| both sides repin the same pin differently | refused, names the index |
| a pin added, or removed | refused |
| both sides make the identical repin | resolves |
| mixed `ggml-org` and `unslothai` pins in one set | resolves, order preserved |

A refusal falls back to a normal conflict, which is the status quo. It can cost a hand resolution; it cannot produce a wrong pin set.

## Deciding whether to merge at all

The GLM-5-Next refresh was expensive because our carry was not really diverged from upstream, it was holding a stale copy, and finding that out meant diffing every file the PR touched.

`carry_vintage.py` answers it from blob hashes: if our copy of a file is byte-identical to the version at some commit of the upstream PR, we never edited it. On the real case it reduces 43 touched files to the 15 that genuinely diverge, and those 15 are exactly the shared registry files that qwen4exp and GLM-5-Next both edit. It reports only, because holding a deliberately older vintage is a decision it cannot see.

## Net effect

At file level, 68 of 149 conflicts become automatic and provable. At merge level, the 5 sync merges that needed a human no longer do, taking hand-resolved merges from 26 to 21. The rest stay manual, which is correct: they are genuine content conflicts, and the checks above make getting them wrong loud instead of silent.

## Tests

`test_additive_merge.py` existed and ran nowhere, so changes to a merge resolver were covered by nothing. `unsloth-pr-set-lint.yml` gains a `resolver-tests` job running all four suites, and its triggers now include the resolvers themselves, which they did not before, so the tests fire on exactly the changes that need them.

## Not included

`git rerere` replays a recorded resolution whenever the same conflict shape appears, even when the surrounding code has changed meaning. That is the silent-wrongness class this PR exists to remove.
