### PR TITLE
macOS: pin the RPC RDMA transport off instead of auto-detecting it

### DIFF
--- a/.github/workflows/unsloth-prebuilt-macos.yml
+++ b/.github/workflows/unsloth-prebuilt-macos.yml
@@ -100,8 +100,44 @@ jobs:
             -DLLAMA_FATAL_WARNINGS=ON \
             -DLLAMA_BUILD_BORINGSSL=ON \
             -DLLAMA_BUILD_EXAMPLES=OFF -DLLAMA_BUILD_TESTS=OFF -DLLAMA_BUILD_TOOLS=ON \
-            -DLLAMA_BUILD_SERVER=ON -DGGML_RPC=ON
+            -DLLAMA_BUILD_SERVER=ON -DGGML_RPC=ON -DGGML_RPC_RDMA=OFF
           cmake --build build --config Release -j "$(sysctl -n hw.logicalcpu)"
+
+      # ggml-rpc AUTO-DETECTS RDMA: on Apple it find_library(rdma)s and, when the
+      # runner has one, defaults GGML_RPC_RDMA to ON and links /usr/lib/librdma.dylib
+      # into libggml-rpc. That library ships with the runner image, not with macOS,
+      # so the bundle loaded on the builder and died everywhere else:
+      #
+      #   dyld: Library not loaded: /usr/lib/librdma.dylib
+      #     Referenced from: .../libggml-rpc.0.dylib
+      #
+      # (b10639-mix-f6f92fe, the first release carrying upstream b114b4739.) A
+      # redistributable must not have its configuration decided by whatever happened
+      # to be installed where it was built, so the value is pinned rather than
+      # detected. Pinned OFF specifically because RDMA-over-Thunderbolt is not
+      # something the prebuilt's consumers can use.
+      - name: Assert the RDMA transport stayed off
+        working-directory: src
+        run: |
+          set -euo pipefail
+          grep -q '^GGML_RPC_RDMA:BOOL=OFF$' build/CMakeCache.txt || {
+            echo "::error::GGML_RPC_RDMA is not OFF in the CMake cache; a macOS"\
+                 "prebuilt that links librdma cannot load on a consumer Mac"
+            grep -i 'rdma' build/CMakeCache.txt || true
+            exit 1
+          }
+          # The cache says what was asked for; otool says what was linked. The
+          # launch gate below cannot see this, because it runs on the one host
+          # where the library does exist.
+          # No xargs -r: that is a GNU extension and these are BSD userland runners.
+          # An empty find just makes otool complain to a discarded stderr and grep
+          # match nothing, which is the answer we want anyway.
+          if find build/bin -type f \( -name '*.dylib' -o -perm -u+x \) -print0 \
+             | xargs -0 otool -L 2>/dev/null | grep -i 'librdma'; then
+            echo "::error::a shipped Mach-O still links librdma"
+            exit 1
+          fi
+          echo "rdma gate passed: GGML_RPC_RDMA=OFF and nothing links librdma"
 
       - name: Load gate (minos <= ${{ matrix.deploy_target }}, arch, launch)
         run: bash tooling/scripts/unsloth/assert_macho_minos.sh src/build/bin "${{ matrix.expect_arch }}" "${{ matrix.deploy_target }}"


### PR DESCRIPTION
## The break

Every macOS lane in `unslothai/unsloth` CI, and every macOS user who installed after `b10639-mix-f6f92fe` went out:

```
dyld[41694]: Library not loaded: /usr/lib/librdma.dylib
  Referenced from: .../llama.cpp/build/bin/libggml-rpc.0.dylib
  Reason: tried: '/usr/lib/librdma.dylib' (no such file), ... (not in dyld cache)
llama-server failed to launch on macOS 15.7.7 (dyld load / symbol error)
```

## Cause

`ggml/src/ggml-rpc/CMakeLists.txt` auto-detects the transport:

```cmake
if (APPLE)
    set(RDMA_LIB_NAME rdma)
find_library(RDMA_LIB ${RDMA_LIB_NAME})
if (RDMA_LIB)
    option(GGML_RPC_RDMA "ggml: enable RDMA transport for RPC" ON)
```

This workflow passes `-DGGML_RPC=ON` and leaves RDMA to that detection. The runner resolved `librdma`, so the option defaulted ON and `/usr/lib/librdma.dylib` was linked into `libggml-rpc`. That library comes with the runner image, not with macOS.

`b10639-mix-f6f92fe` (2026-08-27) is the first release carrying upstream `b114b4739` (2026-08-25, "rpc: support apple RDMA as an RPC transport"). `b10472-mix-4b653db` predates it and is unaffected.

## Why the load gate missed it

`assert_macho_minos.sh` does launch the binaries - `llama-cli --version` forces dyld to resolve the full link graph. But it runs on the build host, which is the one machine where `librdma` exists. A build-host-only dependency is invisible to any check that runs on the build host.

## The change

- `-DGGML_RPC_RDMA=OFF` on the cmake line. A redistributable must not have its configuration decided by whatever happened to be installed where it was built. OFF specifically, because RDMA-over-Thunderbolt is not something a downloaded prebuilt's consumers can use; RPC itself stays ON.
- A gate that checks **both** what was asked for (`CMakeCache.txt`) and what was actually linked (`otool -L`), because those can disagree - a stale cache or a future transitive link would satisfy one and not the other.

Only the macOS legs are touched. Linux/Windows RPC builds are unaffected.

## Verification

I have no macOS host, so the dyld behaviour is argued from the CI log above rather than reproduced. What I did verify locally, by extracting the step and driving it against fixtures:

| cache | linked | result |
|---|---|---|
| `GGML_RPC_RDMA:BOOL=ON` | - | exit 1 |
| `GGML_RPC_RDMA:BOOL=OFF` | clean | exit 0 |
| `GGML_RPC_RDMA:BOOL=OFF` | binary links `librdma` | exit 1 |

Also `bash -n` clean, and the workflow YAML parses with the new step landing between Build and the load gate. `xargs -r` is deliberately not used - it is a GNU extension and these are BSD userland runners.

## Still needed after this

This fixes the build. **`b10639-mix-f6f92fe` still needs rebuilding and republishing** - until then, installs continue to pick up the broken bundle. The same release also broke whisper.cpp pairing, which now reports it wants `b10472-mix-4b653db`.

Related: unslothai/unsloth#9843 makes the installer refuse a bundle like this rather than logging "prebuilt installed and validated" and failing at first launch.

## Not addressed

The general class - a release artifact silently picking up a dependency that only exists on the builder - is only closed for RDMA here. An allowlist of permitted absolute install names, diffed per release, would close it properly; I did not attempt that without a macOS host to derive the baseline from.