### PR TITLE
unsloth: repin qwen4exp and glm5next onto b10644

### DIFF
--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -23,7 +23,7 @@
     "https://github.com/unslothai/llama.cpp/pull/70/commits/edfd4c1a3b7a653303a85257ddac2a1f3ce39a2f",
     "https://github.com/unslothai/llama.cpp/pull/91/commits/c86ed269986f2dced6325c5c58bda966a2e2ead1",
     "https://github.com/unslothai/llama.cpp/pull/95/commits/3db8cb5b2e9bf291057b9f19960e8601a162da81",
-    "https://github.com/unslothai/llama.cpp/pull/114/commits/950f135b28789057721a65d76de98fbbcd2f7dd6",
-    "https://github.com/unslothai/llama.cpp/pull/125/commits/f48b99e1fd04628da2a3d4ea5acc335d9ea67f7a"
+    "https://github.com/unslothai/llama.cpp/pull/132/commits/f52a4c39d014701a74e60ac1312221bf6037cc4b",
+    "https://github.com/unslothai/llama.cpp/pull/133/commits/4034bb065e0125bac2276116151a9232addbe5df"
   ]
 }


### PR DESCRIPTION
Moves the qwen4exp pin from #114 to #132, and the glm5next pin from #125 to #133. Both keep their list positions, so the composition order is unchanged: `107 -> 108 -> 70 -> 91 -> 95 -> qwen4exp -> glm5next`.

## Why

The qwen4exp pin `950f135b` is 16 commits behind [ggml-org#27742](https://github.com/ggml-org/llama.cpp/pull/27742). The gap is functional, not cosmetic: the per-block QSA selection bias, the PLE hparams storage, the indexer cache series, the mirrored PLE conv history row, and two kv-cache whole-context restore fixes.

Repinning #114 to its own current head would not have closed it. That head is still 6 commits behind upstream, including the newest change, so the carry itself had to be rebuilt. #132 is upstream's head `ef6876693` with the unaged `--n-cpu-ffn` commit reverted and the `filter_idx` reordering reapplied.

glm5next moves only as a consequence. #125 composes on `92ee7a5ce`, a commit of the old qwen4exp carry, so refreshing qwen4exp alone leaves the same code arriving from two lineages and `additive_merge.py` refuses in 11 files. #133 is the same GLM-5-Next content rebuilt on the new qwen head. The GLM content was already current, 0 commits missing from ggml-org#27754.

## Verification

Against `b10644`, the tag the aging rule selects today:

- all 7 pins merge in list order with only `additive_merge.py` resolutions. The single resolution is the known `tools/mtmd/CMakeLists.txt` add/add between kimik3 and inkling
- `merge_checks.py --root .` clean, 23 python and 187 c++ files, exit 0
- merged tree builds 573/573, exit 0, zero warnings, with `-DGGML_RPC=ON -DLLAMA_BUILD_EXAMPLES=ON -DLLAMA_BUILD_TOOLS=ON -DLLAMA_BUILD_SERVER=ON -DLLAMA_BUILD_TESTS=ON`
- `test-llama-archs -s 1` exits 0 with `qwen4exp` OK (0.00e+00) and `glm5next` OK (0.00e+00), zero FAIL rows
- both pinned shas are commits of their PRs and are each PR's current head
- both mirrored to `refs/pins/<sha>` before this PR was opened

One thing worth recording. Composing glm5next on the new qwen carry left a duplicate `filter_idx` declaration in the same scope in `llama-model.cpp`, which does not compile. `merge_checks.py` passed on that tree, because it has no duplicate C++ definition check by design. Nothing else would have caught it either: no `pull_request` workflow compiles a carry, and every nightly build leg sets `LLAMA_BUILD_TESTS=OFF`. Without a local build the first compile of the mix would have been the 03:00 nightly with the full build matrix already running. Worth considering whether the preflight compile gate in #110 should land.

Not done: `test-backend-ops` and a real weights run, no CUDA device available on the machine used.

#114 and #125 stay open and their branches stay in place. A merged carry PR stops refreshing its commit list, which breaks the pin membership check.
