### PR TITLE
qwen4exp: keep the QSA indexer cache in lockstep with the attention cache

### DIFF
--- a/src/llama-memory-hybrid-idx.cpp
+++ b/src/llama-memory-hybrid-idx.cpp
@@ -52,10 +52,17 @@ llama_memory_hybrid_idx::llama_memory_hybrid_idx(
 
         LLAMA_LOG_INFO("%s: creating indexer KV cache, size = %u cells\n", __func__, kv_size);
 
+        // the indexer cache is a side buffer addressed cell-for-cell by the attention
+        // cache: it must track the attention cache's cells exactly or QSA top-k reads
+        // the wrong cells. sharing the attention cache's cell metadata (v_cells_impl)
+        // via `other` makes the two agree by construction -- the indexer keeps its own
+        // K/V tensors but sees the same positions/sequences/used-set as attention, so
+        // used_max_p1 and hence n_kv can never drift apart. seq ops on the indexer
+        // become no-ops (the shared cells are managed by the attention cache).
         return new llama_kv_cache(
             model, hparams_idx, type_k, type_v, v_trans, offload, unified,
             kv_size, n_seq_max, n_pad, n_swa, swa_type,
-            nullptr, filter_idx, nullptr, nullptr, "idx_");
+            get_mem_attn(), filter_idx, nullptr, nullptr, "idx_");
     }()) {}
 
 llama_memory_context_ptr llama_memory_hybrid_idx::init_batch(llama_batch_allocr & balloc, uint32_t n_ubatch, bool embd_all) {


### PR DESCRIPTION
## Problem

`llama-server` built from the qwen4exp branch (PR #27742) `SIGABRT`s when a request's context exceeds the QSA sparse-attention budget and decodes long, or when two concurrent unified-KV slots have different KV lengths:

```
src/models/qwen4exp.cpp:284:
GGML_ASSERT(mctx_idx->get_n_kv() == inp->mctx->get_attn()->get_n_kv() &&
            "the indexer cache must track the attention cache cell for cell") failed
```

Reproduced on DGX Spark / GB10 (SM121), Q4_K_XL, `-c 262144 -ngl 48 -kvu --cache-ram -1 --parallel 2`.

## Root cause

The QSA **indexer cache** (`llama_memory_hybrid_idx::mem_idx`) was a separate `llama_kv_cache` with its **own cell metadata** (`v_cells_impl`: positions, sequence ownership, used-set). Although `init_batch` hands it the attention cache's slot infos, the two caches' cell state drifts apart under server slot management (`seq_rm` on slot release): the indexer drops cells the attention cache keeps. Because `get_n_kv()` is driven by `used_max_p1` (highest used cell index), the two caches' `n_kv` diverge and the graph builder aborts.

## Fix

Construct the indexer cache with the attention cache as `mem_other`, so it shares the attention cache's cell metadata (`v_cells_impl`) via the existing `other` mechanism. The two then agree cell-for-cell **by construction** and can never drift. The indexer keeps its own K/V tensors (the `share` callback is null), and the `attn_rot`/`n_embd_head` values it inherits from the attention cache are harmless because the indexer path never uses them (`cpy_k` stores raw keys).

## Verification (DGX Spark, Q4_K_XL, 2 slots)

- No `n_kv` divergence across all decode steps; the assert no longer fires.
- Deep-context 25k–175k tps sweep rows all complete; 32k-token prompt generation stays coherent (answers correctly).
- Two concurrent requests with different KV lengths complete without abort.
- Short and long-context throughput unchanged (coding ~33–34 t/s per stream, TTFT ~0.6s).

This fix targets the qwen4exp branch in PR #27742 (the code is not on master yet). Refs #27780.
