### PR TITLE
hip: enable GGML_CUDA_USE_CUB via hipCUB (fixes TOP_K abort for >1024 rows)

### DIFF
--- a/ggml/src/ggml-cuda/argsort.cu
+++ b/ggml/src/ggml-cuda/argsort.cu
@@ -1,8 +1,10 @@
 #include "argsort.cuh"
 
 #ifdef GGML_CUDA_USE_CUB
+#    ifndef GGML_USE_HIP // CUB comes from hipCUB via common.cuh on HIP
 #    include <cub/cub.cuh>
-#    if (CCCL_MAJOR_VERSION >= 3 && CCCL_MINOR_VERSION >= 1)
+#    endif
+#    if !defined(GGML_USE_HIP) && (CCCL_MAJOR_VERSION >= 3 && CCCL_MINOR_VERSION >= 1)
 #        define STRIDED_ITERATOR_AVAILABLE
 #        include <cuda/iterator>
 #    endif
@@ -83,12 +85,19 @@ void argsort_f32_i32_cuda_cub(ggml_cuda_pool & pool,
     is_capturing = (capture_status != cudaStreamCaptureStatusNone);
 #endif  // USE_CUDA_GRAPH
 
+#ifdef GGML_USE_HIP
+    // hipCUB does not provide cub::DeviceSegmentedSort - use the radix segmented sort
+    const bool use_segmented_radix = true;
+#else
+    const bool use_segmented_radix = is_capturing;
+#endif
+
     if (order == GGML_SORT_ORDER_ASC) {
         if (nrows == 1) {
             CUDA_CHECK(DeviceRadixSort::SortPairs(nullptr, temp_storage_bytes, temp_keys, temp_keys,  // keys (in-place)
                                                   temp_indices, dst,  // values (indices)
                                                   ncols, 0, sizeof(float) * 8, stream));
-        } else if (is_capturing) {
+        } else if (use_segmented_radix) {
             CUDA_CHECK(DeviceSegmentedRadixSort::SortPairs(
                 nullptr, temp_storage_bytes, temp_keys, temp_keys,  // keys (in-place)
                 temp_indices, dst,                                  // values (indices)
@@ -107,7 +116,7 @@ void argsort_f32_i32_cuda_cub(ggml_cuda_pool & pool,
                                                             temp_keys,          // keys (in-place)
                                                             temp_indices, dst,  // values (indices)
                                                             ncols, 0, sizeof(float) * 8, stream));
-        } else if (is_capturing) {
+        } else if (use_segmented_radix) {
             CUDA_CHECK(DeviceSegmentedRadixSort::SortPairsDescending(
                 nullptr, temp_storage_bytes, temp_keys, temp_keys, temp_indices, dst, ncols * nrows, nrows,
                 offset_iterator, offset_iterator + 1, 0, sizeof(float) * 8, stream));
@@ -127,7 +136,7 @@ void argsort_f32_i32_cuda_cub(ggml_cuda_pool & pool,
                                                   temp_keys,          // keys (in-place)
                                                   temp_indices, dst,  // values (indices)
                                                   ncols, 0, sizeof(float) * 8, stream));
-        } else if (is_capturing) {
+        } else if (use_segmented_radix) {
             CUDA_CHECK(DeviceSegmentedRadixSort::SortPairs(d_temp_storage, temp_storage_bytes, temp_keys, temp_keys,
                                                            temp_indices, dst, ncols * nrows, nrows, offset_iterator,
                                                            offset_iterator + 1, 0, sizeof(float) * 8, stream));
@@ -142,7 +151,7 @@ void argsort_f32_i32_cuda_cub(ggml_cuda_pool & pool,
                                                             temp_keys,          // keys (in-place)
                                                             temp_indices, dst,  // values (indices)
                                                             ncols, 0, sizeof(float) * 8, stream));
-        } else if (is_capturing) {
+        } else if (use_segmented_radix) {
             CUDA_CHECK(DeviceSegmentedRadixSort::SortPairsDescending(
                 d_temp_storage, temp_storage_bytes, temp_keys, temp_keys, temp_indices, dst, ncols * nrows, nrows,
                 offset_iterator, offset_iterator + 1, 0, sizeof(float) * 8, stream));

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -107,9 +107,22 @@
 #define GGML_CUDA_CC_IS_QY2(cc)      (cc >= GGML_CUDA_CC_QY2 && cc < GGML_CUDA_CC_PH1)
 #define GGML_CUDA_CC_IS_PH1(cc)      (cc >= GGML_CUDA_CC_PH1)
 
-#if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA) && CUDART_VERSION >= 11070
+#if (!defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA) && CUDART_VERSION >= 11070) || defined(GGML_USE_HIP)
 #    define GGML_CUDA_USE_CUB
-#endif  // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA) && CUDART_VERSION >= 11070
+#endif  // (!defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA) && CUDART_VERSION >= 11070) || defined(GGML_USE_HIP)
+
+#ifdef GGML_USE_HIP
+// On HIP builds CUB comes from hipCUB: the primitives live in namespace hipcub and
+// there is no <cub/cub.cuh> to include, so alias the namespace and map the few CUDA
+// stream-capture names the GGML_CUDA_USE_CUB code paths use onto the HIP ones.
+#    include <hipcub/hipcub.hpp>
+namespace cub = hipcub;
+using cudaStreamCaptureStatus             = hipStreamCaptureStatus;
+constexpr auto cudaStreamCaptureStatusNone = hipStreamCaptureStatusNone;
+inline cudaError_t cudaStreamIsCapturing(cudaStream_t stream, cudaStreamCaptureStatus * status) {
+    return hipStreamIsCapturing(stream, status);
+}
+#endif // GGML_USE_HIP
 
 // PDL host-side support (cudaLaunchKernelEx) requires CUDART >= 11.8.
 // However, this has been bugged in CTK < 12.3 for MSVC builds, see

--- a/ggml/src/ggml-cuda/cumsum.cu
+++ b/ggml/src/ggml-cuda/cumsum.cu
@@ -5,7 +5,9 @@
 #include "ggml.h"
 
 #ifdef GGML_CUDA_USE_CUB
+#    ifndef GGML_USE_HIP // CUB comes from hipCUB via common.cuh on HIP
 #   include <cub/cub.cuh>
+#    endif
 #endif // GGML_CUDA_USE_CUB
 
 template<typename T, int BLOCK_SIZE>

--- a/ggml/src/ggml-cuda/mean.cu
+++ b/ggml/src/ggml-cuda/mean.cu
@@ -2,7 +2,9 @@
 #include "reduce_rows.cuh"
 
 #ifdef GGML_CUDA_USE_CUB
+#    ifndef GGML_USE_HIP // CUB comes from hipCUB via common.cuh on HIP
 #include <cub/cub.cuh>
+#    endif
 using namespace cub;
 #endif  // GGML_CUDA_USE_CUB
 

--- a/ggml/src/ggml-cuda/sum.cu
+++ b/ggml/src/ggml-cuda/sum.cu
@@ -2,7 +2,9 @@
 #include "sumrows.cuh"
 
 #ifdef GGML_CUDA_USE_CUB
+#    ifndef GGML_USE_HIP // CUB comes from hipCUB via common.cuh on HIP
 #include <cub/cub.cuh>
+#    endif
 using namespace cub;
 #endif  // GGML_CUDA_USE_CUB
 

--- a/ggml/src/ggml-cuda/top-k.cu
+++ b/ggml/src/ggml-cuda/top-k.cu
@@ -2,8 +2,10 @@
 #include "top-k.cuh"
 
 #ifdef GGML_CUDA_USE_CUB
+#    ifndef GGML_USE_HIP // CUB comes from hipCUB via common.cuh on HIP
 #    include <cub/cub.cuh>
-#    if (CCCL_MAJOR_VERSION >= 3 && CCCL_MINOR_VERSION >= 2)
+#    endif
+#    if !defined(GGML_USE_HIP) && (CCCL_MAJOR_VERSION >= 3 && CCCL_MINOR_VERSION >= 2)
 #        define CUB_TOP_K_AVAILABLE
 #        include <cuda/iterator>
 using namespace cub;


### PR DESCRIPTION
## Problem

On HIP builds `GGML_CUDA_USE_CUB` is disabled unconditionally (`common.cuh`), so `ggml_cuda_op_top_k` always takes the no-CUB bitonic argsort fallback. That kernel launches one block of `next_power_of_2(ncols)` threads, which is only valid for `ncols <= 1024` - the CUDA-side `supports_op` for `TOP_K`/`ARGSORT` even advertises `ne[0] <= 1024` when CUB is off, but nothing enforces it at launch time.

GLM-5-Next / GLM-5.3-Flash (PR ggml-org#27754) runs `ggml_top_k` over `n_kv / index_kpool` lightning-indexer pools, so once a conversation grows past ~4k tokens of KV the selection exceeds 1024 rows, the block exceeds the device's 1024-thread limit, and the backend aborts:

```
ggml_cuda_compute_forward: TOP_K failed
ROCm error: invalid configuration argument
```

With the tensor hosted on a `ggml-rpc-server` (the natural way to run the 200 GB Q4 GGUF), this aborts the RPC server and takes the whole llama-server with it.

## Fix

Enable `GGML_CUDA_USE_CUB` on HIP and source CUB from hipCUB, which provides every primitive these paths use:

- `common.cuh`: `#include <hipcub/hipcub.hpp>`, `namespace cub = hipcub` (hipCUB has no `<cub/cub.cuh>`), and a small mapping of `cudaStreamCaptureStatus` / `cudaStreamIsCapturing` onto the `hip*` equivalents used by the capture checks in `argsort.cu` / `mean.cu`.
- The CCCL >= 3.2 `DeviceTopK::MaxPairs` path in `top-k.cu` and the CCCL >= 3.1 strided-iterator path in `argsort.cu` remain off on HIP (hipCUB has no `cuda::execution` / `cuda/iterator`); HIP gets the offsets-array + radix-sort paths instead.
- `argsort.cu`: the multi-row non-capturing branch routes through `DeviceSegmentedRadixSort` on HIP because hipCUB has no `DeviceSegmentedSort` (same call shape already used for the stream-capturing case).
- `cumsum.cu` / `mean.cu` / `sum.cu`: include `<cub/cub.cuh>` only when not on HIP.

CUDA builds are untouched - everything new is inside `#ifdef GGML_USE_HIP`.

## Verification

Ryzen AI Max+ 395 (Radeon 8060S, gfx1151) pair, built with the system `hipcc` (ROCm 7.1), runtime on ROCm 7.14, running GLM-5.3-Flash UD-Q4_K_XL distributed over RPC (`--rpc`, CUDA graphs enabled):

- before: any prompt growing KV past ~4k cells aborts the RPC server with `TOP_K failed` / `invalid configuration argument`
- after: 8.8k-token prompt processed end to end, zero TOP_K errors, CUDA graph capture and replay fine, prompt processing unchanged (~123 t/s)

Fixes the HIP half of the wide-top-k story for `glm5next/upstream`; happy to rebase onto a different branch if that is preferred.
