### PR TITLE
llama: batched readahead for lazily read gather tables

### DIFF
--- a/src/llama-mmap.cpp
+++ b/src/llama-mmap.cpp
@@ -439,6 +439,56 @@ void llama_file::write_u32(uint32_t val) const { pimpl->write_u32(val); }
 // llama_mmap
 
 #if defined(_POSIX_MAPPED_FILES) || defined(_WIN32)
+static size_t llama_mmap_page_size() {
+#if defined(_WIN32)
+    SYSTEM_INFO si;
+    GetSystemInfo(&si);
+    return (size_t) si.dwPageSize;
+#else
+    return (size_t) sysconf(_SC_PAGESIZE);
+#endif
+}
+
+// the pages the given rows fall on, merged into runs. rows are smaller than a page and
+// repeat within a batch, so this turns a hint per row into a hint per page.
+static llama_mmap::ranges llama_mmap_row_pages(
+        size_t base_off, size_t stride, size_t row_size, size_t map_size,
+        const int32_t * rows, size_t n_rows, size_t page_size) {
+    std::vector<size_t> pages;
+    pages.reserve(n_rows);
+
+    for (size_t i = 0; i < n_rows; ++i) {
+        if (rows[i] < 0) {
+            continue;
+        }
+        const size_t first = base_off + (size_t) rows[i] * stride;
+        const size_t last  = first + row_size;
+        // an unexpected index must not turn into a hint outside the mapping
+        if (row_size == 0 || last > map_size || last < first) {
+            continue;
+        }
+        for (size_t p = first / page_size; p <= (last - 1) / page_size; ++p) {
+            pages.push_back(p);
+        }
+    }
+
+    std::sort(pages.begin(), pages.end());
+    pages.erase(std::unique(pages.begin(), pages.end()), pages.end());
+
+    llama_mmap::ranges res;
+    for (size_t i = 0; i < pages.size(); ) {
+        size_t j = i + 1;
+        while (j < pages.size() && pages[j] == pages[j - 1] + 1) {
+            ++j;
+        }
+        const size_t off = pages[i] * page_size;
+        res.emplace_back(off, off + std::min((pages[j - 1] - pages[i] + 1) * page_size, map_size - off));
+        i = j;
+    }
+
+    return res;
+}
+
 // merge `ranges` and return their complement within [0, limit)
 static llama_mmap::ranges ranges_complement(llama_mmap::ranges ranges, size_t limit) {
     llama_mmap::ranges res;
@@ -670,6 +720,60 @@ size_t llama_mmap::size() const { return pimpl->size; }
 void * llama_mmap::addr() const { return pimpl->addr; }
 
 void llama_mmap::unmap_fragment(size_t first, size_t last) { pimpl->unmap_fragment(first, last); }
+
+bool llama_mmap::contains(const void * ptr, size_t len) const {
+    const char * addr = (const char *) pimpl->addr;
+    const char * p    = (const char *) ptr;
+    return addr != nullptr && p >= addr && p + len <= addr + pimpl->size;
+}
+
+void llama_mmap::prefetch_rows(const void * base, size_t stride, size_t row_size,
+                               const int32_t * rows, size_t n_rows) const {
+#if defined(_POSIX_MAPPED_FILES) || defined(_WIN32)
+    const size_t base_off = (const char *) base - (const char *) pimpl->addr;
+    const auto ranges = llama_mmap_row_pages(base_off, stride, row_size, pimpl->size,
+                                             rows, n_rows, llama_mmap_page_size());
+#endif
+
+#if defined(_POSIX_MAPPED_FILES)
+    for (const auto & range : ranges) {
+        // unchecked: a failed hint only costs the fault it would have avoided
+        posix_madvise((char *) pimpl->addr + range.first, range.second - range.first,
+                      POSIX_MADV_WILLNEED);
+    }
+#elif defined(_WIN32)
+    #if _WIN32_WINNT >= 0x602
+    // PrefetchVirtualMemory takes all ranges in one call, which is the batching we want
+    BOOL (WINAPI *pPrefetchVirtualMemory) (HANDLE, ULONG_PTR, PWIN32_MEMORY_RANGE_ENTRY, ULONG);
+    HMODULE hKernel32 = GetModuleHandleW(L"kernel32.dll");
+
+    pPrefetchVirtualMemory = (decltype(pPrefetchVirtualMemory))(void *) GetProcAddress(hKernel32, "PrefetchVirtualMemory");
+    if (!pPrefetchVirtualMemory) {
+        return;
+    }
+
+    std::vector<WIN32_MEMORY_RANGE_ENTRY> entries;
+    entries.reserve(ranges.size());
+    for (const auto & range : ranges) {
+        WIN32_MEMORY_RANGE_ENTRY e;
+        e.VirtualAddress = (char *) pimpl->addr + range.first;
+        e.NumberOfBytes  = (SIZE_T) (range.second - range.first);
+        entries.push_back(e);
+    }
+
+    if (!entries.empty()) {
+        // unchecked, same as the POSIX branch
+        pPrefetchVirtualMemory(GetCurrentProcess(), (ULONG_PTR) entries.size(), entries.data(), 0);
+    }
+    #endif
+#else
+    GGML_UNUSED(base);
+    GGML_UNUSED(stride);
+    GGML_UNUSED(row_size);
+    GGML_UNUSED(rows);
+    GGML_UNUSED(n_rows);
+#endif
+}
 
 #if defined(_POSIX_MEMLOCK_RANGE) || defined(_WIN32)
 const bool llama_mmap::SUPPORTED  = true;

--- a/src/llama-mmap.h
+++ b/src/llama-mmap.h
@@ -55,6 +55,15 @@ struct llama_mmap {
 
     void unmap_fragment(size_t first, size_t last);
 
+    // true if [ptr, ptr + len) is inside this mapping
+    bool contains(const void * ptr, size_t len) const;
+
+    // start reading the given rows of a tensor in this mapping, in one batch.
+    // lazy ranges are MADV_RANDOM, which turns kernel readahead off, so without this a
+    // sparse gather costs one synchronous fault per row. hints only, never changes results.
+    void prefetch_rows(const void * base, size_t stride, size_t row_size,
+                       const int32_t * rows, size_t n_rows) const;
+
     static const bool SUPPORTED;
 
 private:

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -2180,6 +2180,19 @@ const ggml_tensor * llama_model::get_tensor(const char * name) const {
     return it->second;
 }
 
+void llama_model::prefetch_rows(const ggml_tensor * t, const int32_t * rows, size_t n_rows) const {
+    if (t == nullptr || t->data == nullptr || n_rows == 0) {
+        return;
+    }
+
+    for (const auto & mapping : pimpl->mappings) {
+        if (mapping->contains(t->data, ggml_nbytes(t))) {
+            mapping->prefetch_rows(t->data, t->nb[1], ggml_row_size(t->type, t->ne[0]), rows, n_rows);
+            return;
+        }
+    }
+}
+
 float llama_model::get_rope_freq_base (const llama_cparams & cparams, int il) const {
     return hparams.is_swa(il) ? hparams.rope_freq_base_train_swa : cparams.rope_freq_base;
 }

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -744,6 +744,9 @@ struct llama_model {
 
     const struct ggml_tensor * get_tensor(const char * name) const;
 
+    // queue readahead for rows a gather is about to read. no-op unless the tensor is mmap'd
+    void prefetch_rows(const struct ggml_tensor * t, const int32_t * rows, size_t n_rows) const;
+
     float get_rope_freq_base (const llama_cparams & cparams, int il) const;
     float get_rope_freq_scale(const llama_cparams & cparams, int il) const;
 

--- a/src/models/gemma4.cpp
+++ b/src/models/gemma4.cpp
@@ -408,10 +408,27 @@ llama_model_gemma4::graph::graph(const llama_model & model, const llm_graph_para
     ggml_build_forward_expand(gf, cur);
 }
 
+// same as llm_graph_input_embd, but also hints the per-layer table rows this batch reads.
+// the table can stay on disk (TENSOR_READ_LAZY), where a gather is one fault per token
+class llm_graph_input_embd_per_layer : public llm_graph_input_embd {
+public:
+    llm_graph_input_embd_per_layer(int64_t n_embd, const llama_model & model) :
+        llm_graph_input_embd(n_embd), model(model) {}
+
+    void set_input(const llama_ubatch * ubatch) override {
+        if (ubatch->token) {
+            model.prefetch_rows(model.per_layer_tok_embd, ubatch->token, ubatch->n_tokens);
+        }
+        llm_graph_input_embd::set_input(ubatch);
+    }
+
+    const llama_model & model;
+};
+
 // equivalent to get_per_layer_inputs() in python code
 // output shape: [n_embd_per_layer, n_layer, n_tokens]
 ggml_tensor * llama_model_gemma4::graph::build_inp_per_layer() {
-    auto inp = std::make_unique<llm_graph_input_embd>(n_embd);
+    auto inp = std::make_unique<llm_graph_input_embd_per_layer>(n_embd, model);
 
     ggml_tensor * inp_per_layer;
     float tok_embd_scale = sqrtf((float) n_embd_per_layer);

--- a/src/models/qwen4exp.cpp
+++ b/src/models/qwen4exp.cpp
@@ -1039,6 +1039,10 @@ void llm_graph_input_ple::set_input(const llama_ubatch * ubatch) {
         }
     }
 
+    // the table stays host side and is read by 16 gathers per token, no two on the same page.
+    // queued here they are in flight before the graph runs
+    pmodel.prefetch_rows(pmodel.per_layer_tok_embd, idx.data(), idx.size());
+
     ggml_backend_tensor_set(rows, idx.data(), 0, idx.size()*ggml_element_size(rows));
 }
 


### PR DESCRIPTION
Batched readahead for gather tables read through `TENSOR_READ_LAZY`.

Based on ggml-org/llama.cpp master `ca3d5a3e1`. `unslothai/llama.cpp:master` does not carry `TENSOR_READ_LAZY` or `qwen4exp` yet, so this PR targets `base/upstream-ca3d5a3e1` (that upstream commit pushed as a branch) to keep the diff to the six files this change touches.

## The problem

[#27794](https://github.com/ggml-org/llama.cpp/pull/27794) added `TENSOR_READ_LAZY`, which skips the eager pull-in for a large per-layer embedding table and marks its byte range `MADV_RANDOM`. That saves real memory, but `MADV_RANDOM` also switches off the kernel's own readahead, and nothing was put in its place. A sparse gather over the table then takes one synchronous fault per row.

Measured on the 26.8 GiB `iq4_nl` PLE table with a real 320,000 gather trace, no model and no GPU involved, median of three runs on an evicted page cache:

| policy | ns/gather | major faults |
|---|---|---|
| no advice (kernel readahead on) | 34,767 | 5,044 |
| `MADV_RANDOM` only, what ships today | 130,112 | 205,849 |
| `MADV_RANDOM` plus this change | 5,634 | 16 |

`MADV_RANDOM` on its own is 3.7x slower than leaving the mapping alone. This is the same effect #27794's own gemma-4 table shows, where the `MADV_RANDOM` variant scored worse than skipping the prefetch alone.

## The change

`llama_mmap::prefetch_rows()` takes the row indices a batch is about to gather, merges them to whole pages, and issues the reads as one batch: `MADV_WILLNEED` on POSIX, `PrefetchVirtualMemory` on Windows, no-op elsewhere. `llama_model::prefetch_rows()` finds the mapping holding the tensor and returns if there is none, so it is inert for anything not read out of a mapping. Both `TENSOR_READ_LAZY` users call it from `set_input`, which is far enough ahead of the gather for the reads to be in flight.

151 insertions, 1 deletion, six files. No `ggml` changes at all, so no new op and no backend work.

No new user-facing flag. The behaviour belongs to `TENSOR_READ_LAZY`, which already has `--tensor-read-lazy`; a second knob for the half that makes the first one usable would be the wrong shape.

## Results

Cold page cache, three repetitions, `llama-batched-bench -npp 512 -ntg 128 -npl 1`, one B200. Four arms per repetition so that `lazy off` appears on both builds: those two agree within noise throughout, which is what makes the rest of the table attributable to this change alone.

**qwen4exp, UD-IQ1_S, 26.8 GiB table**

| build | lazy | prompt t/s | generation t/s | peak RSS |
|---|---|---|---|---|
| base | off | 1810 / 1867 / 1853 | 93.9 / 94.1 / 93.2 | 71.3 GB |
| this PR | off | 1847 / 1835 / 1840 | 93.8 / 93.7 / 93.6 | 71.3 GB |
| base | on | 198 / 201 / 224 | 68.2 / 68.0 / 63.0 | 42.9 GB |
| this PR | on | 1397 / 1364 / 1337 | 93.0 / 92.8 / 92.3 | 42.9 GB |

**gemma-4-E4B-it Q4_K_M, 1.94 GB table**, the model #27794 was measured on

| build | lazy | prompt t/s | generation t/s | peak RSS |
|---|---|---|---|---|
| base | off | 2420 / 2480 / 2598 | 207.5 / 207.6 / 208.5 | 5.4 GB |
| this PR | off | 2495 / 2433 / 2453 | 207.7 / 207.8 / 208.2 | 5.4 GB |
| base | on | 894 / 955 / 853 | 182.8 / 182.9 / 172.4 | 3.5 GB |
| this PR | on | 2522 / 2547 / 2564 | 180.3 / 191.1 / 193.2 | 3.5 GB |

Prompt throughput returns to eager parity on both models while keeping the whole memory saving lazy reading buys: 28.4 GB on qwen4exp, 1.9 GB on gemma-4.

## Correctness

Readahead cannot change arithmetic, and that is verified rather than assumed. Greedy generation from the base build and from this branch, same prompt, same file, `--tensor-read-lazy on`, is byte-identical on both models.

## What this does not claim

- Generation throughput is fully recovered on qwen4exp (92-93 against 93-94 eager). On gemma-4 the three runs are 180.3, 191.1 and 193.2 against a 172-183 baseline: the spreads overlap, so the honest reading is "not worse", not a recovery. Prompt throughput is the real result there.
- Everything here is the cold-cache regime. Warm, the table is resident and every arm converges. This is a claim about first touch and about machines that cannot hold the table, which is the case the feature exists for, not a steady-state serving speedup.
- One machine, one NVMe, Linux. The Windows path is written but has not been compiled or run.
- Not applying `MADV_RANDOM` at all would also recover much of the loss, and is a smaller change. The gather benchmark says this is still 7.4x better than that (4,666 against 34,767 ns/gather), but that arm has not been measured at model level.


## Warm cache: no measurable difference either way

Once the rows a workload touches are resident, the hints buy nothing, and the question is whether they cost anything. Five repetitions, same run repeated with no eviction, `--tensor-read-lazy on` on both builds:

| build | prompt t/s | generation t/s |
|---|---|---|
| base | 1769 / 1734 / 1717 / 1679 / 1761 | 92.99 / 93.55 / 93.77 / 92.11 / 92.72 |
| this PR | 1656 / 1672 / 1698 / 1720 / 1713 | 91.11 / 92.15 / 92.49 / 92.78 / 93.14 |

Means are 1732 against 1692 for prompt and 93.0 against 92.3 for generation, so roughly 2% and 1% in favour of the base build, but the ranges overlap and the ordering flips between repetitions. Five runs cannot resolve a difference this small. The honest statement is that warm behaviour is unchanged, with a possible small overhead from the extra `madvise` calls that would need a much longer run to measure.

Worth recording how that number moved: the first two repetitions alone showed a clean 5% loss with no overlap, and three more turned it into noise.

## Where the memory actually goes

The peak RSS column above is the whole process, so it is worth separating. Page cache residency after a cold run, measured per file with `mincore`:

| | lazy off | lazy on |
|---|---|---|
| the PLE table alone (26.82 GiB) | 26.82 GiB, 100% | 0.06 GiB, 0.23% |
| the rest of the model | 40.75 GiB, 100% | 40.75 GiB, 100% |

Lazy reading removes essentially all of the table, and that is the whole 28.4 GB of RSS saving. What stays resident is the quantized weights, which are read through the mapping while being copied to the device and are left in page cache afterwards. That is a separate problem from this PR, and `--load-mode` is the lever for it.

The 0.23% figure is low because this benchmark decodes 640 tokens and touches few rows. A gather trace over 60,000 tokens of wikitext needs about 0.39 GB of page cache to serve half its gathers and 1.91 GB to serve 90%, so a long-running server settles at a few GB resident for the table rather than at zero.
