### PR TITLE
unsloth: retire the qwen4exp carry chain now that upstream carries it

### DIFF
--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -19,11 +19,10 @@
   ],
   "prs": [
     "https://github.com/unslothai/llama.cpp/pull/107/commits/74acc40c37ae2eb36031981feda392b793944f72",
-    "https://github.com/unslothai/llama.cpp/pull/108/commits/2c5b0007bca737c15c77217e864c072953a3fe2d",
+    "https://github.com/unslothai/llama.cpp/pull/138/commits/2e9d6fb2149d84ba4eb4d873438062ca724373d0",
     "https://github.com/unslothai/llama.cpp/pull/70/commits/edfd4c1a3b7a653303a85257ddac2a1f3ce39a2f",
     "https://github.com/unslothai/llama.cpp/pull/91/commits/c86ed269986f2dced6325c5c58bda966a2e2ead1",
     "https://github.com/unslothai/llama.cpp/pull/95/commits/3db8cb5b2e9bf291057b9f19960e8601a162da81",
-    "https://github.com/unslothai/llama.cpp/pull/132/commits/f52a4c39d014701a74e60ac1312221bf6037cc4b",
-    "https://github.com/unslothai/llama.cpp/pull/133/commits/4034bb065e0125bac2276116151a9232addbe5df"
+    "https://github.com/ggml-org/llama.cpp/pull/27754/commits/f30bed88717059d8a4728864c88f8abad8d329a0"
   ]
 }


### PR DESCRIPTION
Retires the qwen4exp carry chain. `ggml-org#27742` (Qwen3.8-Flash-Next) was squash-merged upstream on 2026-08-27 as `6c84c7d5` and is in every base tag from `b10660` on, so the architecture now arrives from the base and nothing needs to carry it.

Final list, order unchanged:

```
107 -> 138 (was 108) -> 70 -> 91 -> 95 -> ggml-org#27754 (was 133)
```

## Why the nightly broke

Run 33141605830 failed in `Resolve tag`, before a single build job started:

```
CONFLICT (content): Merge conflict in src/llama-model.cpp
refused  src/llama-model.cpp: merge base is not empty, so at least one side edited existing text
unslothai/llama.cpp#108 (2c5b0007) does not merge cleanly onto b10663 + the PRs listed before it
```

It failed at `#108`, not at the qwen carry, and that is the part worth recording. Upstream's qwen4exp declares `filter_idx` and `needs_mem_idx` immediately above `if (arch == LLM_ARCH_FALCON_H1) {`, and Inkling edits that same `if` line to add `LLM_ARCH_INKLING`. `additive_merge.py` refuses, correctly: the merge base is not empty, so a side edited shared text.

`#132` had been hiding that. Its carry-only commit `f52a4c39` moved the `filter_idx` declaration off the Inkling anchor. Dropping the carry gives up the accommodation, so Inkling has to face upstream's arrangement, which is what `#138` does.

## The three changes

**`#108` to `#138`.** `#138` is `ggml-org#25731`'s head merged onto `b10665` with that one conflict resolved as the union: upstream's two declarations kept, and the condition widened to `FALCON_H1 || INKLING`. `needs_mem_idx` is true only for `LLM_ARCH_QWEN4EXP`, so Inkling still lands on the plain `llama_memory_hybrid` branch and `filter_idx` stays null there. `#108`'s three carry-only fixes are all in the upstream branch now, so `#138` is a plain merge with nothing extra.

**`#132` deleted.** Upstream took `27742` as a squash, so the pin was never going to become a no-op. This is verbatim the case `pr-set.json`'s own `_doc` describes.

**`#133` to a direct `ggml-org#27754` pin.** `#133` was composed on top of `#132`'s head, so it carried the entire qwen4exp diff and conflicted in 16 paths against a base that already has the squash, 9 of them pure duplication. Deleting `#132` alone would have changed nothing, because the tree is byte-identical either way. `27754`'s own head is a direct descendant of the base and needs no carry at all, which is the exit condition both carry PRs wrote for themselves.

Two commits were pushed to `27754` to make that work:

- `b5517b15` adds the missing `glm5next` fixture to `tests/test-llama-archs.cpp`. The PR added an architecture whose loader requires `attention.key_length_mla`, `attention.indexer_kpool`, the hyper-connection trio and a per-layer `head_count_kv` array, but never added a fixture, so `test-generate-models` failed on 15 CI jobs with `key not found in model: glm5next.attention.key_length_mla`.
- `f30bed88` moves `llama_kv_cache_context::get_n_stream()` and `get_kv()` in `src/llama-kv-cache.cpp` from just after `get_n_kv()` to just after `type_v()`. Inkling adds `get_n_kv_pos_contiguous()` at the same anchor, and although both sides are pure additions, `additive_merge.py` refuses them because the two added blocks share a bare `}` line and its shared-line rule reads that as one change made twice. Separating the anchors makes git merge both without help, which is better than loosening a resolver rule that exists to stop real duplication.

## Verification

Replayed against `b10665`, the newest tag at time of writing:

- all 6 pins merge in list order, with exactly one `additive_merge.py` resolution: the known `tools/mtmd/CMakeLists.txt` add/add between `models/kimik3.cpp` and `models/inkling.cpp`
- ancestry proof on the merged tree: upstream `6c84c7d5` is an ancestor, and `f52a4c39` (old qwen pin), `4034bb06` (old GLM pin) and `2c5b0007` (old Inkling pin) are all absent, so no carry lineage survives
- `merge_checks.py --root .` clean, 23 python and 187 c++ files, exit 0
- merged tree builds 123/123, exit 0, zero warnings, with `-DGGML_RPC=ON -DLLAMA_BUILD_EXAMPLES=ON -DLLAMA_BUILD_TOOLS=ON -DLLAMA_BUILD_SERVER=ON -DLLAMA_BUILD_TESTS=ON`
- `test-llama-archs -s 1` exits 0, zero FAIL rows, with `qwen4exp` OK (0.00e+00), `glm5next` OK (0.00e+00), `deepseek4` OK (0.00e+00), `kimi-k3` OK (0.00e+00), `inkling` SKIP per its own skip entry
- both new pinned shas are commits of the PRs they name, and both are mirrored to `refs/pins/<sha>`

Not done: `test-backend-ops` and a real weights run.

## Aging

`27754`'s head sits two upstream commits past `b10663`, namely `b10664` (`e70802a0`) and `b10665` (`ca3d5a3e`), and `#138` is built on `b10665`. Both are released tags and will be well inside the aging window by the time the schedule fires, so I did not add revert commits the way `#132` did for `--n-cpu-ffn`. A revert-based carry also goes actively wrong the moment the base advances past what it reverts, which is the failure mode this change is trying to get out of.

## Follow-ups, not in this PR

- `#107` is closed-unmerged, upstream declined it, and it is still pinned as required, so the resolve log warns every run and the nightly ships declined code. Worth pruning deliberately.
- `#110`, the preflight compile gate, would have caught the `glm5next` fixture gap before 03:00 rather than in the nightly. Nothing on `pull_request` compiles a carry today and every nightly leg sets `LLAMA_BUILD_TESTS=OFF`.
- `ggml-org#25731` is still `CONFLICTING` upstream. The same resolution `#138` carries is open against it as danielhanchen/llama.cpp#3; once that merges, `#138` can be dropped for a direct `25731` pin.
