### PR TITLE
unsloth: pin ggml-org#25731 directly and retire the Inkling carry

### DIFF
--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -19,7 +19,7 @@
   ],
   "prs": [
     "https://github.com/unslothai/llama.cpp/pull/107/commits/74acc40c37ae2eb36031981feda392b793944f72",
-    "https://github.com/unslothai/llama.cpp/pull/138/commits/2e9d6fb2149d84ba4eb4d873438062ca724373d0",
+    "https://github.com/ggml-org/llama.cpp/pull/25731/commits/edee0e160ae0a8004dc9205a4197ba6ea3686500",
     "https://github.com/unslothai/llama.cpp/pull/70/commits/edfd4c1a3b7a653303a85257ddac2a1f3ce39a2f",
     "https://github.com/unslothai/llama.cpp/pull/91/commits/c86ed269986f2dced6325c5c58bda966a2e2ead1",
     "https://github.com/unslothai/llama.cpp/pull/95/commits/3db8cb5b2e9bf291057b9f19960e8601a162da81",


### PR DESCRIPTION
Moves the Inkling pin from the `#138` carry to `ggml-org#25731` directly, and retires the last fork carry in the set. After this the pin set has none: every entry is either an upstream PR or a fork PR that carries fork-only work.

`#138` existed because `ggml-org#25731` did not merge onto a base tag containing the qwen4exp squash. danielhanchen/llama.cpp#3 landed that same resolution on `add-inkling` as `edee0e16`, so `25731` is `mergeable` again and the carry has nothing left to add.

## This is a provable no-op

```
tree of ggml-org#25731 head (edee0e16) : 2feb59ed8dcc52c3a500549b75d17ddf3fd4ad2d
tree of the #138 pin      (2e9d6fb2) : 2feb59ed8dcc52c3a500549b75d17ddf3fd4ad2d
```

Identical trees, and `2e9d6fb2` is an ancestor of `edee0e16`.

Replaying the full chain onto `b10665` with the new pin substituted gives the same six merges, the same single `additive_merge.py` resolution on `tools/mtmd/CMakeLists.txt`, and a final merged tree of `eb067b53b35b5dcc8dce7eed6a8554e506015507`, byte-identical to the tree the current pin set produces. Nothing about the build changes.

- `edee0e16` is a commit of `ggml-org#25731` (pin-membership gate)
- mirrored to `refs/pins/edee0e160ae0a8004dc9205a4197ba6ea3686500` before this PR was opened, so the pin stays fetchable even though `25731` is a draft on a personal fork whose head can move

`#138` is closed once this merges. Its branch `inkling-25731-b10665` and the base branch stay in place.
