### PR TITLE
unsloth: add #137 to the pin set

### DIFF
--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -23,6 +23,7 @@
     "https://github.com/unslothai/llama.cpp/pull/70/commits/edfd4c1a3b7a653303a85257ddac2a1f3ce39a2f",
     "https://github.com/unslothai/llama.cpp/pull/91/commits/c86ed269986f2dced6325c5c58bda966a2e2ead1",
     "https://github.com/unslothai/llama.cpp/pull/95/commits/3db8cb5b2e9bf291057b9f19960e8601a162da81",
-    "https://github.com/ggml-org/llama.cpp/pull/27754/commits/f30bed88717059d8a4728864c88f8abad8d329a0"
+    "https://github.com/ggml-org/llama.cpp/pull/27754/commits/f30bed88717059d8a4728864c88f8abad8d329a0",
+    "https://github.com/unslothai/llama.cpp/pull/137/commits/4e1865e34ec5f6ca39403215c89129c13731be70"
   ]
 }


### PR DESCRIPTION
Adds `#137` (batched readahead for lazily read gather tables) to the nightly pin set, appended last so the existing composition order is untouched:

```
107 -> 25731 -> 70 -> 91 -> 95 -> 27754 -> 137
```

One commit, `4e1865e3`, based on `base/upstream-ca3d5a3e1` which is tag `b10665`, so the pin carries only its own work. Six files, and every one of them purely additive except a single line in `src/models/gemma4.cpp`: `src/llama-mmap.cpp` +104, `src/llama-mmap.h` +9, `src/llama-model.cpp` +13, `src/llama-model.h` +3, `src/models/gemma4.cpp` +18-1, `src/models/qwen4exp.cpp` +4.

## additive_merge.py

It is not exercised by this pin, which is the useful thing to report. `#137` merges onto `b10665` plus the six pins ahead of it with **no conflict at all**, so the resolver is never invoked for it. The only additive resolution in the whole chain is still the long-standing one from `#70`, unchanged by this addition:

```
file: tools/mtmd/CMakeLists.txt
  OURS   : '            models/inkling.cpp\n'
  THEIRS : '            models/kimik3.cpp\n'
  RESULT : '            models/kimik3.cpp\n            models/inkling.cpp\n'
```

That is a textbook pure add/add: the merge base is empty at that anchor and neither side's line appears on the other, so the union is the resolution and the resolver takes it. Worth noting that `#137` touches `src/llama-model.cpp` and `src/models/qwen4exp.cpp`, both of which other pins in the set also touch, and it still merges without help.

## Verification

Full replay against `b10665` with all seven pins in list order:

- all 7 merge, exactly one `additive_merge.py` resolution, the `#70` one quoted above
- `merge_checks.py --root .` clean, 23 python and 187 c++ files, exit 0
- merged tree builds 123/123, exit 0, zero warnings, with `-DGGML_RPC=ON -DLLAMA_BUILD_EXAMPLES=ON -DLLAMA_BUILD_TOOLS=ON -DLLAMA_BUILD_SERVER=ON -DLLAMA_BUILD_TESTS=ON`
- `test-llama-archs -s 1` exits 0, 308 rows, zero FAIL, with `qwen4exp` OK (0.00e+00) and `glm5next` OK (0.00e+00)
- `4e1865e3` is a commit of `#137` and is mirrored to `refs/pins/4e1865e34ec5f6ca39403215c89129c13731be70`

## Gap worth knowing

`test-llama-archs` does not cover `gemma4` at all. `arch_supported()` returns false for `LLM_ARCH_GEMMA4`, `LLM_ARCH_GEMMA4_ASSISTANT` and `LLM_ARCH_DIFFUSION_GEMMA` behind a pre-existing `FIXME @ngxson`, and the graph loop skips them again for ISWA fixture params. So the `+18-1` in `src/models/gemma4.cpp` compiles here but is not exercised by any test in this verification. That FIXME predates this PR and is not something this change introduces, but it means the gemma4 half of `#137` rides in on compile coverage only.
