### PR TITLE
llama: let an MTP draft borrow the target's embeddings and lm head

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -2542,6 +2542,9 @@ common_speculative_init_result::common_speculative_init_result(
         model_path = params.speculative.draft.mparams.path;
         LOG_INF("%s: loading draft model '%s'\n", __func__, model_path.c_str());
 
+        // a draft head can leave out the embeddings and lm head and use the target's
+        mparams.model_shared = model_tgt;
+
         llama_model * model_dft = llama_model_load_from_file(params.model.path.c_str(), mparams);
         if (model_dft == NULL) {
             LOG_ERR("%s: failed to load draft model, '%s'\n", __func__, model_path.c_str());

--- a/conversion/bailingmoe3.py
+++ b/conversion/bailingmoe3.py
@@ -121,9 +121,9 @@ class BailingMoeV3Model(TextModel):
 
         if is_mtp and cls.no_mtp:
             return None
-        if cls.mtp_only and not is_mtp and name not in (
+        if cls.mtp_only and not is_mtp and (cls.mtp_shared_embd or name not in (
             "model.word_embeddings.weight", "model.norm.weight", "lm_head.weight",
-        ):
+        )):
             return None
 
         return super().filter_tensors((name, gen))

--- a/conversion/base.py
+++ b/conversion/base.py
@@ -120,6 +120,8 @@ class ModelBase:
     supports_mtp_export: bool = False
     mtp_only: bool = False
     no_mtp: bool = False
+    # with mtp_only, leave the shared embeddings and lm head to the target model
+    mtp_shared_embd: bool = False
 
     def __init__(self, dir_model: Path, ftype: gguf.LlamaFileType, fname_out: Path, *, is_big_endian: bool = False,
                  use_temp_file: bool = False, eager: bool = False,

--- a/conversion/command_r.py
+++ b/conversion/command_r.py
@@ -131,9 +131,9 @@ class Cohere2MoeModel(TextModel):
             is_mtp = (m := re.match(r"model\.layers\.(\d+)\.", name)) is not None and int(m.group(1)) >= cls._n_main_layers
             if is_mtp and cls.no_mtp:
                 return None
-            if cls.mtp_only and not is_mtp and name not in (
+            if cls.mtp_only and not is_mtp and (cls.mtp_shared_embd or name not in (
                 "model.embed_tokens.weight", "model.norm.weight", "lm_head.weight",
-            ):
+            )):
                 return None
 
         return name, gen

--- a/conversion/dots3.py
+++ b/conversion/dots3.py
@@ -99,9 +99,9 @@ class Dots3NoteModel(DeepseekV2Model):
         # --no-mtp: drop the NextN/MTP block; --mtp: keep only that block plus the shared embeddings/norm/lm_head
         if is_mtp and cls.no_mtp:
             return None
-        if cls.mtp_only and not is_mtp and name not in (
+        if cls.mtp_only and not is_mtp and (cls.mtp_shared_embd or name not in (
             "model.embed_tokens.weight", "model.norm.weight", "lm_head.weight",
-        ):
+        )):
             return None
 
         return name, gen

--- a/conversion/glm.py
+++ b/conversion/glm.py
@@ -138,9 +138,9 @@ class Glm4MoeModel(TextModel):
 
         if is_mtp and cls.no_mtp:
             return None
-        if cls.mtp_only and not is_mtp and name not in (
+        if cls.mtp_only and not is_mtp and (cls.mtp_shared_embd or name not in (
             "model.embed_tokens.weight", "model.norm.weight", "lm_head.weight",
-        ):
+        )):
             return None
 
         return name, gen
@@ -292,9 +292,9 @@ class Glm4MoeLiteModel(DeepseekV2Model):
             is_mtp = match is not None and int(match.group(1)) >= cls._n_main_layers
             if is_mtp and cls.no_mtp:
                 return None
-            if cls.mtp_only and not is_mtp and name not in (
+            if cls.mtp_only and not is_mtp and (cls.mtp_shared_embd or name not in (
                 "model.embed_tokens.weight", "model.norm.weight", "lm_head.weight",
-            ):
+            )):
                 return None
 
         return name, gen
@@ -352,9 +352,9 @@ class GlmMoeDsaModel(DeepseekV2Model):
             return None
         # --mtp: keep ONLY NextN-block tensors plus the shared embeddings/
         # norm/lm_head (so the resulting GGUF carries just the draft head).
-        if cls.mtp_only and not is_mtp and name not in (
+        if cls.mtp_only and not is_mtp and (cls.mtp_shared_embd or name not in (
             "model.embed_tokens.weight", "model.norm.weight", "lm_head.weight",
-        ):
+        )):
             return None
 
         return name, gen

--- a/conversion/qwen.py
+++ b/conversion/qwen.py
@@ -338,7 +338,7 @@ class _QwenMtpMixin:
             elif len(parts) == 3 and parts[1] in remapper:
                 name = f"model.layers.{cls._original_block_count}.{remapper[parts[1]]}.{parts[2]}"
         elif cls.mtp_only:
-            keep = name in (
+            keep = not cls.mtp_shared_embd and name in (
                 "model.embed_tokens.weight", "model.norm.weight", "lm_head.weight",
                 "embed_tokens.weight", "norm.weight",
             )

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -126,6 +126,10 @@ def parse_args() -> argparse.Namespace:
         help="Exclude NextN speculative draft tensors from the converted GGUF. Pair with --mtp or --dspark on a second run to publish target and draft as two files.",
     )
     parser.add_argument(
+        "--mtp-shared-embd", action="store_true",
+        help="With --mtp, leave the token embeddings, output norm and LM head out of the draft and take them from the target model at load time. Much smaller draft, but it needs a llama.cpp new enough to read it.",
+    )
+    parser.add_argument(
         "--dspark", action="store_true",
         help="Export only the DeepSeek-V4 DSpark draft tensors as a separate GGUF.",
     )
@@ -277,6 +281,12 @@ def main() -> None:
                 model_class.no_mtp = True
             if args.mtp:
                 model_class.mtp_only = True
+
+        if args.mtp_shared_embd:
+            if not args.mtp:
+                logger.error("--mtp-shared-embd only applies together with --mtp")
+                sys.exit(1)
+            model_class.mtp_shared_embd = True
 
         model_instance = model_class(dir_model, output_type, fname_out,
                                      is_big_endian=args.bigendian, use_temp_file=args.use_temp_file,

--- a/include/llama.h
+++ b/include/llama.h
@@ -340,6 +340,10 @@ extern "C" {
         // override key-value pairs of the model meta data
         const struct llama_model_kv_override * kv_overrides;
 
+        // already loaded model to take the shared embeddings and lm head from, for a draft
+        // head that ships neither. must outlive the model being loaded
+        const struct llama_model * model_shared;
+
         // Keep the booleans together to avoid misalignment during copy-by-value.
         bool vocab_only;      // only load the vocabulary, no weights
         bool check_tensors;   // validate model tensor data

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -1106,6 +1106,70 @@ bool llama_model_loader::lazy_read::add(const std::string & name, const ggml_ten
     return true;
 }
 
+// declared in llama-model.h, which this file does not include
+const std::vector<std::pair<std::string, ggml_tensor *>> & llama_internal_get_tensor_map(const llama_model * model);
+
+struct ggml_tensor * llama_model_loader::borrow_shared_tensor(const LLM_TN_IMPL & tn, const std::initializer_list<int64_t> & ne) {
+    // only the tensors a draft head is allowed to leave out, checked first so no other
+    // tensor in any model costs a metadata lookup
+    if (tn.tensor != LLM_TENSOR_TOKEN_EMBD && tn.tensor != LLM_TENSOR_OUTPUT && tn.tensor != LLM_TENSOR_OUTPUT_NORM) {
+        return nullptr;
+    }
+
+    // a file that ships the tensor keeps its own copy
+    const std::string name = tn.str();
+    if (get_weight(name.c_str()) != nullptr) {
+        return nullptr;
+    }
+
+    // a draft that left out its embeddings left out the whole set, so the missing token_embd is
+    // what marks one. without this an arch that ties the head to its own token_embd when
+    // output.weight is absent (qwen3.5, qwen3-next) would borrow the target's head instead
+    if (get_weight("token_embd.weight") != nullptr) {
+        return nullptr;
+    }
+
+    if (model_shared == nullptr) {
+        throw std::runtime_error(format("%s: missing tensor '%s'; if this is a draft head that shares "
+                    "the target's embeddings, load it as a draft of its target model, not on its own",
+                    __func__, name.c_str()));
+    }
+
+    ggml_tensor * src = nullptr;
+    for (const auto & [n, t] : llama_internal_get_tensor_map(model_shared)) {
+        if (n == name) {
+            src = t;
+            break;
+        }
+    }
+    if (src == nullptr) {
+        throw std::runtime_error(format("%s: draft needs tensor '%s' from the target, which does not have it",
+                    __func__, name.c_str()));
+    }
+
+    // the draft uses the tensor directly, so the shapes must agree exactly
+    size_t dim = 0;
+    for (const int64_t n : ne) {
+        if (dim >= GGML_MAX_DIMS || src->ne[dim] != n) {
+            throw std::runtime_error(format("%s: draft and target disagree on '%s': target has %s, draft wants %s",
+                        __func__, name.c_str(), llama_format_tensor_shape(src).c_str(), llama_format_tensor_shape(ne).c_str()));
+        }
+        dim++;
+    }
+    for (; dim < GGML_MAX_DIMS; dim++) {
+        if (src->ne[dim] != 1) {
+            throw std::runtime_error(format("%s: draft and target disagree on '%s': target has %s, draft wants %s",
+                        __func__, name.c_str(), llama_format_tensor_shape(src).c_str(), llama_format_tensor_shape(ne).c_str()));
+        }
+    }
+
+    LLAMA_LOG_INFO("%s: tensor %s taken from the target model\n", __func__, name.c_str());
+
+    // not counted in n_created or size_data: the tensor is not in this file and is neither
+    // allocated nor freed here
+    return src;
+}
+
 struct ggml_tensor * llama_model_loader::create_tensor(
         const llama_hparams & hparams, const buft_list_t * buft_list_cpu, const buft_list_t * buft_list_input, const buft_list_t * buft_list_output,
         const buft_list_t * buft_list_layer, const LLM_TN_IMPL & tn, const std::initializer_list<int64_t> & ne, int flags) {
@@ -1324,6 +1388,12 @@ struct ggml_tensor * llama_model_loader::create_tensor(
         ggml_tensor * ret = ggml_dup_tensor(ctx, &t_meta);
         ggml_set_name(ret, tn.str().c_str());
         return ret;
+    }
+
+    // must run before check_tensor_dims: the tensor is absent from this file by design, and for
+    // the lm head it must also win over the arch fallback that ties the head to token_embd
+    if (ggml_tensor * shared = borrow_shared_tensor(tn, ne)) {
+        return shared;
     }
 
     LLAMA_LOG_DEBUG("%s: loading tensor %s\n", __func__, tn.str().c_str());

--- a/src/llama-model-loader.h
+++ b/src/llama-model-loader.h
@@ -117,6 +117,10 @@ struct llama_model_loader {
         std::set<std::string>                  tensors;
     } lazy;
 
+    // target model a draft head borrows the shared tensors from, see borrow_shared_tensor()
+    const struct llama_model * model_shared = nullptr;
+
+
     llama_files files;
     llama_ftype ftype;
     llama_fver  fver;
@@ -237,6 +241,11 @@ struct llama_model_loader {
     struct ggml_tensor * create_tensor(
         const llama_hparams & hparams, const buft_list_t * buft_list_cpu, const buft_list_t * buft_list_input, const buft_list_t * buft_list_output,
         const buft_list_t * buft_list_layer, const LLM_TN_IMPL & tn, const std::initializer_list<int64_t> & ne, int flags);
+
+    // a draft head that shares the target's embeddings does not carry its own token_embd,
+    // output or output_norm; take them from the target model instead. returns null unless the
+    // file is missing token_embd, so a model that ships its own tensors is never affected
+    struct ggml_tensor * borrow_shared_tensor(const LLM_TN_IMPL & tn, const std::initializer_list<int64_t> & ne);
 
     void done_getting_tensors(bool partial = false) const;
 

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -2692,6 +2692,7 @@ llama_model_params llama_model_default_params() {
         /*.progress_callback           =*/ nullptr,
         /*.progress_callback_user_data =*/ nullptr,
         /*.kv_overrides                =*/ nullptr,
+        /*.model_shared                =*/ nullptr,
         /*.vocab_only                  =*/ false,
         /*.check_tensors               =*/ false,
         /*.use_extra_bufts             =*/ true,

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -318,7 +318,8 @@ static std::pair<int, llama_model *> llama_model_load(struct gguf_context * meta
         llama_model_loader ml(metadata, set_tensor_data, set_tensor_data_ud, fname, splits, file, params.load_mode,
             params.check_tensors, params.no_alloc, params.load_mtp, params.kv_overrides, params.tensor_buft_overrides);
 
-        ml.lazy.mode = params.lazy_mode;
+        ml.lazy.mode    = params.lazy_mode;
+        ml.model_shared = params.model_shared;
 
         ml.print_info();
         std::unique_ptr<llama_model> model_ptr(llama_model_create(ml, params));


### PR DESCRIPTION
## What this does

A NextN/MTP draft exported with `--mtp` carries `token_embd`, `output_norm` and `lm_head` so that it can be loaded as a standalone model. For every sidecar published so far those three tensors are most of the file.

Taking ggml-org's own, `ggml-org/Qwen3.8-27B-GGUF` `mtp-Qwen3.8-27B-Q4_0.gguf`, arch `qwen35`, 18 tensors:

| | size | share |
|---|---|---|
| file total | 1.565 GiB | |
| `token_embd` + `output` (both `[5120, 248320]` q4_0) + `output_norm` | **1.332 GiB** | **85.1%** |
| the MTP block itself, `blk.64.*`, 15 tensors | 0.223 GiB | 14.2% |

Their BF16 (5.538 GiB) and Q8_0 (2.947 GiB) sidecars sit at the same ratio.

This adds an opt-in `--mtp-shared-embd` that leaves those tensors out and marks the file with `nextn_shared_target_tensors`. The loader resolves the missing names against the already loaded target model instead.

The graph side needs no change at all. Twelve archs already fall back to `model.tok_embd` / `model.output` for their nextn blocks (`qwen3next.cpp:660,815` and the same in deepseek32, deepseek4, glm4-moe, glm-dsa, nemotron-h-moe, mimo2, cohere2moe, hy-v3, qwen35, qwen35moe, step35). Only the loader half was missing.

## Result

Stripping the three tensors from ggml-org's sidecar with `scripts/mtp_strip_shared.py` and running it against the unmodified `Qwen3.8-27B-Q4_K_M.gguf` target:

| | full sidecar | stripped |
|---|---|---|
| size | 1.565 GiB | **0.233 GiB** (6.7x smaller) |
| acceptance | 64.444% | **64.444%** |
| drafted / accepted | 135 / 87 | **135 / 87** |
| generated text md5 | `2873913f642b14fb6c6ebc46aa64a47e` | **identical** |

`llama-speculative-simple`, greedy, fixed seed, one B200.

## Existing sidecars are not affected

The borrow is gated on the new metadata key, so a file published before this change cannot reach the new code path. There are four independent checks, in this order, and a normal model load exits on the first:

1. the tensor is not `token_embd` / `output` / `output_norm`
2. the file does not set `nextn_shared_target_tensors`
3. the file ships the tensor itself
4. no target model was supplied

Verified against the two published sidecars I could find, on the same binary, before and after:

| pair | acceptance / drafted / accepted / n_predict | generated text |
|---|---|---|
| `unsloth/gemma-4-E2B-it-GGUF` `mtp-gemma-4-E2B-it-Q8_0` | 46.061% / 165 / 76 / 131, unchanged | `c9af508b9a1d596f5bb29bc2eb8592d6`, unchanged |
| `ggml-org/Qwen3.8-27B-GGUF` `mtp-Qwen3.8-27B-Q4_0` | 64.444% / 135 / 87 / 132, unchanged | `2873913f642b14fb6c6ebc46aa64a47e`, unchanged |

Only decode speed moves, and in both directions, which is run to run noise.

The gemma-4 file is the stricter of the two and is worth describing, because it is what shaped the design. It is arch `gemma4-assistant`, a self contained 4 block draft running at hidden 256 against the target's 1536, bridging with `nextn.pre_projection [3072, 256]` and `nextn.post_projection [256, 1536]`. It has its own `token_embd` at `[256, 262144]` and no `output.weight`, because `gemma4-assistant.cpp:37-38` ties the head to its own embeddings unconditionally. A draft may legitimately run at a different width from its target, so "the tensor is missing" is not a safe trigger on its own.

That also decides where the hook sits. It runs before `check_tensor_dims`, which is both before the throw for a required tensor and before the `TENSOR_NOT_REQUIRED` to `TENSOR_DUPLICATED` tie fallback. Without that, an arch whose lm head falls back to `token_embd` would alias the borrowed embedding rather than borrow the target's real `output.weight`, which is silently wrong for any model with untied embeddings.

## Errors

Loading such a file on its own:

```
borrow_shared_tensor: this model is a draft head without its own 'token_embd.weight';
load it as a draft of its target model, not on its own
```

Pointing it at the wrong target:

```
borrow_shared_tensor: draft and target disagree on 'token_embd.weight':
target has   1536, 262144,      1,      1, draft wants   5120, 248320
```

Shapes are compared across all four dimensions, because the draft uses the tensor directly rather than only needing a compatible vocabulary.

## Scope

126 insertions, 13 deletions, 17 files. `git diff --stat` is empty for both `src/models/` and `ggml/`.

Borrowed tensors are deliberately not counted in `n_created`, which `done_getting_tensors` requires to equal the tensor count in the file; they are not in the file and are neither allocated nor freed by the draft.

`--mtp-shared-embd` is opt in and is rejected unless `--mtp` is also given, so files produced by `--mtp` today are unchanged and keep loading on any build. It applies to the shared `_QwenMtpMixin` plus the parallel keep lists in `glm.py`, `dots3.py`, `bailingmoe3.py` and `command_r.py`.

## Tests

- `test-llama-archs -a qwen35`: OK, 8.39e-08 CUDA, 0.00e+00 CPU, roundtrip OK
- `test-llama-archs -a glm4moe`: OK, 8.52e-08 CUDA, 0.00e+00 CPU, roundtrip OK
- both published sidecars, before and after, as above
- the stripped sidecar, as above
- both error paths, as above

## Notes

Based on `base/upstream-6fe749801`, a pushed copy of ggml-org `6fe749801`, because this fork's master does not carry the NextN converter machinery this builds on.

The borrow log line only appears under `-v`, the same as `lazy read enabled`. A user cannot see the mechanism engage at default verbosity.

`scripts/mtp_strip_shared.py`, used to produce the stripped sidecar from a published one, is in the workspace rather than in this diff. It is a test fixture, not part of the change.
