### PR TITLE
ggml-cuda: stop scheduling compute onto the host buffer on HIP integrated GPUs

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -4822,6 +4822,30 @@ static enum ggml_backend_dev_type ggml_backend_cuda_device_get_type(ggml_backend
         : GGML_BACKEND_DEVICE_TYPE_GPU;
 }
 
+static bool ggml_backend_cuda_host_buffer_supported() {
+    return getenv("GGML_CUDA_NO_PINNED") == nullptr;
+}
+
+// Whether the scheduler may place a COMPUTE input on the pinned host buffer type.
+//
+// On HIP the device info sets `integrated = prop.integrated`, while the CUDA
+// branch of the same #if keeps it false "due to issues with corrupted output".
+// That asymmetry is what re-enabled direct host-buffer compute on APUs, and it
+// is the path several gfx1151 corruption reports bisect to. Staging through
+// pinned host memory stays available; only compute directly out of it is
+// refused, which is the narrowest change that closes the reports.
+static bool ggml_backend_cuda_device_supports_cuda_host_buft(int device) {
+#if defined(GGML_USE_HIP)
+    if (ggml_cuda_info().devices[device].integrated) {
+        return false;
+    }
+#else
+    GGML_UNUSED(device);
+#endif
+
+    return ggml_backend_cuda_host_buffer_supported();
+}
+
 static void ggml_backend_cuda_device_get_props(ggml_backend_dev_t dev, ggml_backend_dev_props * props) {
     ggml_backend_cuda_device_context * ctx = (ggml_backend_cuda_device_context *)dev->context;
 
@@ -4831,7 +4855,7 @@ static void ggml_backend_cuda_device_get_props(ggml_backend_dev_t dev, ggml_back
     props->device_id   = ctx->pci_bus_id.empty() ? nullptr : ctx->pci_bus_id.c_str();
     ggml_backend_cuda_device_get_memory(dev, &props->memory_free, &props->memory_total);
 
-    bool host_buffer = getenv("GGML_CUDA_NO_PINNED") == nullptr;
+    bool host_buffer = ggml_backend_cuda_host_buffer_supported();
 #ifdef GGML_CUDA_NO_PEER_COPY
     bool events = false;
 #else
@@ -4860,6 +4884,10 @@ static ggml_backend_buffer_type_t ggml_backend_cuda_device_get_buffer_type(ggml_
 
 static ggml_backend_buffer_type_t ggml_backend_cuda_device_get_host_buffer_type(ggml_backend_dev_t dev) {
     GGML_UNUSED(dev);
+    if (!ggml_backend_cuda_host_buffer_supported()) {
+        return nullptr;
+    }
+
     return ggml_backend_cuda_host_buffer_type();
 }
 
@@ -5320,7 +5348,10 @@ static bool ggml_backend_cuda_device_supports_op(ggml_backend_dev_t dev, const g
 static bool ggml_backend_cuda_device_supports_buft(ggml_backend_dev_t dev, ggml_backend_buffer_type_t buft) {
     ggml_backend_cuda_device_context * dev_ctx = (ggml_backend_cuda_device_context *) dev->context;
     const bool integrated = ggml_cuda_info().devices[dev_ctx->device].integrated;
-    return (ggml_backend_buft_is_cuda(buft) && buft->device == dev) || (integrated && ggml_backend_buft_is_cuda_host(buft));
+    return (ggml_backend_buft_is_cuda(buft) && buft->device == dev) ||
+        (integrated &&
+         ggml_backend_buft_is_cuda_host(buft) &&
+         ggml_backend_cuda_device_supports_cuda_host_buft(dev_ctx->device));
 }
 
 static int64_t get_op_batch_size(const ggml_tensor * op) {


### PR DESCRIPTION
## Overview

Carries [ggml-org#25863](https://github.com/ggml-org/llama.cpp/pull/25863) so our ROCm prebuilts stop scheduling compute onto the pinned host buffer on HIP integrated GPUs.

The asymmetry is one `#if` in `ggml-cuda.cu`:

```c
#if defined(GGML_USE_HIP)
        info.devices[id].integrated = prop.integrated;
#else
        info.devices[id].integrated = false; // Temporarily disabled due to issues with corrupted output (e.g. #15034)
#endif
```

CUDA disables the flag because it produced corrupted output. HIP does not. On an APU that turns on a host-buffer path where the scheduler can place a compute input in pinned host memory, and an H2D input write can then race a graph that is still running.

## Why now

This is the defect behind the largest group of Strix Halo reports, and all of them are on builds we ship:

- [ggml-org#25992](https://github.com/ggml-org/llama.cpp/issues/25992) bisected it to `c7d87229` ("ggml-cuda : restore prop.integrated on HIP builds", ggml-org#24233), with a clean parent, on gfx1151. Symptom: `-np 4 --kv-unified` returns another request's response verbatim.
- [ggml-org#27506](https://github.com/ggml-org/llama.cpp/issues/27506) reached the same commit independently from a different symptom, a perplexity explosion from b10040: 7.72 to 3024 on Llama-3.2-3B. Confirmed on three separate gfx1151 machines, Vulkan clean on each.
- [ggml-org#27579](https://github.com/ggml-org/llama.cpp/issues/27579) and [ggml-org#27556](https://github.com/ggml-org/llama.cpp/issues/27556): HIP wrong, Vulkan correct at the identical commit on the same box.
- [lemonade-sdk/llamacpp-rocm#123](https://github.com/lemonade-sdk/llamacpp-rocm/issues/123): "various models start becoming somewhat to fully broken from b1298", multiple gfx1151 reporters, upstream Vulkan flawless.

The rule those threads established is that corruption tracks `n_ubatch < n_batch` and is clean whenever the whole prompt lands in a single ubatch. Making `integrated` runtime-switchable on an otherwise unmodified tree gives PPL 850,121 with it on and 72.80 with it off, from the same binary.

Two points worth carrying into how we test this. One reporter ran a greedy completion canary clean for forty minutes against a backend that was numerically broken throughout, so tok/s and HTTP 200 are not evidence of correctness here. The same reporter measured Vulkan at 24% faster decode on this chip, so there is no throughput argument for staying on the ROCm build while this is open.

## What the change does

Three call sites, matching #25863:

- `ggml_backend_cuda_host_buffer_supported()` factors out the existing `GGML_CUDA_NO_PINNED` test.
- `ggml_backend_cuda_device_supports_cuda_host_buft()` returns false for HIP integrated devices.
- `ggml_backend_cuda_device_supports_buft()` consults it, so the scheduler stops placing compute inputs on the host buffer type.

Pinned host memory stays available for staging. Only compute directly out of it is refused, which is the narrowest change that closes the reports. Discrete HIP and every CUDA path are untouched, since `integrated` is already false there.

## Alternatives considered

[ggml-org#27311](https://github.com/ggml-org/llama.cpp/pull/27311) is the general fix, a ring buffer for input tensors that makes host buffers correct rather than unavailable. It is the better end state and is what we should follow, but it is a scheduler change with four pending reviews and no approvals. #25863 is small enough to carry now and is measured at PPL 63.67 against a Vulkan reference of 64.10 where the base gives 872,006.

## Verification

Not built or measured here, and I want to be plain about that. The gfx1151 CI runner available to me has no compiler and this needs the ROCm toolchain, so the prebuilt legs in this repo are the first real check. Before merging I would want:

- the gfx1150 and gfx1151 ROCm legs green,
- `llama-perplexity` over wikitext-2 on gfx1151 at `-b 2048 -ub 512`, before and after, expecting the base to be the broken number and the head to match a Vulkan reference,
- one `-np 4 --kv-unified` run against #25992's nonce-checked harness.

I can drive the second and third on the Strix Halo runner once there is a build.
