### PR TITLE
unsloth: pin ggml-org#25863 so the ROCm nightlies stop miscomputing on AMD APUs

### DIFF
--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -24,6 +24,7 @@
     "https://github.com/unslothai/llama.cpp/pull/91/commits/c86ed269986f2dced6325c5c58bda966a2e2ead1",
     "https://github.com/unslothai/llama.cpp/pull/95/commits/3db8cb5b2e9bf291057b9f19960e8601a162da81",
     "https://github.com/ggml-org/llama.cpp/pull/27754/commits/f30bed88717059d8a4728864c88f8abad8d329a0",
-    "https://github.com/unslothai/llama.cpp/pull/137/commits/4e1865e34ec5f6ca39403215c89129c13731be70"
+    "https://github.com/unslothai/llama.cpp/pull/137/commits/4e1865e34ec5f6ca39403215c89129c13731be70",
+    "https://github.com/ggml-org/llama.cpp/pull/25863/commits/ce82541acbaf5c532c0727d6ccb6de2b0b0c948d"
   ]
 }


### PR DESCRIPTION
## Overview

Adds [ggml-org#25863](https://github.com/ggml-org/llama.cpp/pull/25863) to the pin set, so the ROCm and Vulkan nightlies stop shipping the AMD APU host-buffer race.

This is the one that actually reaches users. #145 carries the same change onto fork master, but the nightly tree is the upstream tag plus these pins, so a master merge alone ships nothing.

## The defect

`c7d87229` ("ggml-cuda : restore prop.integrated on HIP builds", ggml-org#24233) turned the integrated flag back on for HIP. CUDA keeps it off, with the comment `Temporarily disabled due to issues with corrupted output`. With it on, the scheduler may place a compute input in pinned host memory, where an H2D input write can race a graph that is still running.

Two reporters bisected to that exact commit independently, from different symptoms:

| report | symptom | evidence |
| --- | --- | --- |
| [ggml-org#25992](https://github.com/ggml-org/llama.cpp/issues/25992) | `-np 4 --kv-unified` returns another slot's response verbatim | bisected to `c7d87229`, clean parent, gfx1151 |
| [ggml-org#27506](https://github.com/ggml-org/llama.cpp/issues/27506) | perplexity 7.72 to 3024 on Llama-3.2-3B from b10040 | reproduced on three separate gfx1151 machines, Vulkan clean on each |
| [ggml-org#27579](https://github.com/ggml-org/llama.cpp/issues/27579), [#27556](https://github.com/ggml-org/llama.cpp/issues/27556) | HIP wrong, Vulkan right, same commit, same box | |
| [lemonade-sdk/llamacpp-rocm#123](https://github.com/lemonade-sdk/llamacpp-rocm/issues/123) | "various models start becoming somewhat to fully broken from b1298" | multiple gfx1151 reporters, upstream Vulkan flawless |

The rule those threads converge on is that corruption tracks `n_ubatch < n_batch`, and output is clean whenever the whole prompt lands in a single ubatch. Making `integrated` runtime-switchable on an otherwise unmodified tree gives PPL 850,121 on and 72.80 off, from one binary.

Two things worth carrying into how this gets judged. One reporter ran a greedy completion canary clean for forty minutes against a backend that was numerically broken throughout, so a plausible-looking chat reply is not evidence in either direction here. The same reporter measured Vulkan 24% faster at decode on this chip, so there is no throughput argument for leaving ROCm users on the broken path while upstream deliberates.

## Why this pin and not the other one

[ggml-org#27311](https://github.com/ggml-org/llama.cpp/pull/27311) is the better end state: a ring buffer for input tensors, making host buffers correct rather than unavailable. It is an 18-commit scheduler change and is currently `CONFLICTING`, so it is not pinnable today. When it lands, this pin comes out.

#25863 is the narrow version: refuse to schedule compute out of the host buffer on HIP integrated devices, while pinned memory stays available for staging. Discrete HIP and every CUDA path are untouched, since `integrated` is already false there. It is measured at PPL 63.67 against a Vulkan reference of 64.10, where the base gives 872,006. Open and `MERGEABLE` upstream as of the pinned commit `ce82541`.

## Verification

The pin preflight probes the merge; what I want to see is that plus green gfx1150 and gfx1151 ROCm legs.

I cannot build this here, and I would rather say so than imply otherwise: the Strix Halo runner I have has no compiler and this needs the ROCm toolchain. Once a nightly exists I can drive two checks on that runner: `llama-perplexity` over wikitext-2 at `-b 2048 -ub 512` before and after, expecting the previous nightly to be the broken number and the new one to match a Vulkan reference, and one `-np 4 --kv-unified` run against #25992's nonce-checked harness.

Drop this entry once a base tag carries the work, per the rule in `_doc`.
