### PR TITLE
unsloth: pin ggml-org#27941 so the qwen4exp fixes reach the nightlies

### DIFF
--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -24,6 +24,7 @@
     "https://github.com/unslothai/llama.cpp/pull/91/commits/c86ed269986f2dced6325c5c58bda966a2e2ead1",
     "https://github.com/unslothai/llama.cpp/pull/95/commits/3db8cb5b2e9bf291057b9f19960e8601a162da81",
     "https://github.com/ggml-org/llama.cpp/pull/27754/commits/f30bed88717059d8a4728864c88f8abad8d329a0",
-    "https://github.com/unslothai/llama.cpp/pull/137/commits/4e1865e34ec5f6ca39403215c89129c13731be70"
+    "https://github.com/unslothai/llama.cpp/pull/137/commits/4e1865e34ec5f6ca39403215c89129c13731be70",
+    "https://github.com/ggml-org/llama.cpp/pull/27941/commits/8161d117fed5c37303081ba95bb63a415fe041ac"
   ]
 }


### PR DESCRIPTION
## Overview

Pins [ggml-org#27941](https://github.com/ggml-org/llama.cpp/pull/27941) into the nightly build set.

We ship Qwen3.8-Flash-Next GGUFs, the qwen4exp path in our nightlies still has the defects this fixes, and the fixes exist in two places, neither of which currently reaches a user. #143 sits on this fork unmerged; #27941 sits upstream unmerged; the nightly tree is the upstream tag plus `scripts/unsloth/pr-set.json`, so it has neither.

## Why the upstream one and not #143

#27941 is a strict superset of unslothai#143:

| file | #143 | #27941 |
| --- | --- | --- |
| `src/llama-kv-cells.h` | +9/-2 | +9/-2 |
| `src/llama-memory-hybrid-idx.cpp` | +228/-39 | +237/-39 |
| `src/llama-memory-hybrid-idx.h` | +2/-2 | +2/-2 |
| `src/models/qwen4exp.cpp` | +48/-10 | +48/-10 |
| `src/llama-kv-cache.cpp` | absent | +16/-0 |

Both are mine. Pinning the upstream one means one copy to maintain, and the entry retires cleanly once a base tag contains the work rather than becoming a conflicting re-application of code the base already has. #143 is closed as superseded.

Pinning both is not an option; they would conflict on every shared line.

## Blast radius

Narrow. `llama_memory_hybrid_idx` is reached from exactly one model, so nothing outside qwen4exp can regress on this pin. The defects are backend independent, which is what accounts for the reporter who hit the same failure on Vulkan, where the ROCm-specific problems tracked in #147 do not apply.

Open and `MERGEABLE` upstream at the pinned commit `8161d11`. Drop the entry once a base tag carries it, per `_doc`.

## Note on ordering

This and #147 both append to the end of `prs`, so whichever merges second needs a one-line rebase. They are independent decisions and I would rather they be judged separately than bundled.