### PR TITLE
ggml-cuda: make GGML_CUDA_ENABLE_UNIFIED_MEMORY=0 actually disable it, and say so on HIP

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -85,6 +85,7 @@
 #include <memory>
 #include <mutex>
 #include <cstdarg>
+#include <cctype>
 #include <cstdio>
 #include <cstdlib>
 #include <string>
@@ -94,6 +95,28 @@ static_assert(sizeof(half) == sizeof(ggml_fp16_t), "wrong fp16 size");
 
 #define GGML_LOG_WARN_ONCE(str) \
     { static std::once_flag warn_flag; std::call_once(warn_flag, []() { GGML_LOG_WARN(str); }); }
+
+// Whether an environment variable is set to a value that means "on".
+//
+// Most ggml switches test presence only, and for a name like GGML_CUDA_NO_PINNED
+// that is right: the only sensible use is to set it. GGML_CUDA_ENABLE_UNIFIED_MEMORY
+// is spelled as a positive, so people reasonably write =0 to turn it off, and under a
+// presence test that enabled the very path they were trying to leave. GGML_CUDA_DISABLE_FUSION
+// in this file already parses its value for the same reason.
+//
+// Empty and the usual falsy spellings are off, anything else is on, so =1, =true,
+// =on and =yes all keep working exactly as before.
+static bool ggml_cuda_env_enabled(const char * name) {
+    const char * val = getenv(name);
+    if (val == nullptr || val[0] == '\0') {
+        return false;
+    }
+    std::string v(val);
+    for (char & c : v) {
+        c = (char) std::tolower((unsigned char) c);
+    }
+    return !(v == "0" || v == "false" || v == "no" || v == "off");
+}
 
 [[noreturn]]
 void ggml_cuda_error(const char * stmt, const char * func, const char * file, int line, const char * msg) {
@@ -139,7 +162,26 @@ int ggml_cuda_get_device() {
 static cudaError_t ggml_cuda_device_malloc(void ** ptr, size_t size, int device) {
     ggml_cuda_set_device(device);
     cudaError_t err;
-    if (getenv("GGML_CUDA_ENABLE_UNIFIED_MEMORY") != nullptr) {
+    if (ggml_cuda_env_enabled("GGML_CUDA_ENABLE_UNIFIED_MEMORY")) {
+#if defined(GGML_USE_HIP)
+        // Say so once. Every report of this path going wrong has come from someone
+        // who did not know a front-end had set the variable for them.
+        //
+        // This deliberately does NOT warn about corrupted output. An earlier draft
+        // did, pointing at ggml-org#26148, but that defect is the cpy 2D fast path
+        // using cudaMemcpyDeviceToDevice on managed pages, and it is fixed
+        // separately. Warning about it in a tree that carries the fix would send
+        // users chasing a bug their build does not have.
+        //
+        // What remains true is the cost. On an integrated GPU managed allocation
+        // draws host RAM instead of the device carve-out rather than adding to it,
+        // so it is usually slower and can lower the ceiling: a model that loads
+        // without the variable may be OOM-killed with it.
+        GGML_LOG_WARN_ONCE("GGML_CUDA_ENABLE_UNIFIED_MEMORY is set, allocating device memory as managed. "
+                           "On integrated GPUs this draws host RAM instead of the device carve-out, which is "
+                           "usually slower and can reduce the largest model that will load. Unset the variable "
+                           "to disable it.\n");
+#endif // defined(GGML_USE_HIP)
         err = cudaMallocManaged(ptr, size);
 #if defined(GGML_USE_HIP)
         if (err == hipSuccess) {
@@ -4789,7 +4831,7 @@ static void ggml_backend_cuda_device_get_memory(ggml_backend_dev_t dev, size_t *
     CUDA_CHECK(cudaGetDeviceProperties(&prop, ggml_cuda_get_physical_device(ctx->device)));
 
     // Check if UMA is explicitly enabled via environment variable
-    bool uma_env = getenv("GGML_CUDA_ENABLE_UNIFIED_MEMORY") != nullptr;
+    bool uma_env = ggml_cuda_env_enabled("GGML_CUDA_ENABLE_UNIFIED_MEMORY");
     bool is_uma = prop.integrated > 0 || uma_env;
 
     if (is_uma) {


### PR DESCRIPTION
## Overview

Two small changes to `ggml-cuda.cu`, both aimed at the same problem: users on AMD APUs are running with unified memory on, often without knowing, and cannot turn it off by the obvious means.

## 1. `=0` enabled it

Both read sites test presence:

```c
if (getenv("GGML_CUDA_ENABLE_UNIFIED_MEMORY") != nullptr) {   // line 142
bool uma_env = getenv("GGML_CUDA_ENABLE_UNIFIED_MEMORY") != nullptr;  // line 4792
```

The name is spelled as a positive, so `=0` is the first thing anyone reaches for, and it did the exact opposite of what they asked with no indication. Presence testing is the right call for a name like `GGML_CUDA_NO_PINNED`, where setting it is the only sensible use. It is the wrong call here. `GGML_CUDA_DISABLE_FUSION` in this same file already parses its value for precisely this reason.

Now: empty and the usual falsy spellings are off, anything else is on. `=1`, `=true`, `=on` and `=yes` behave exactly as before, so the only behaviour change is for values that were always meant to mean no.

## 2. Warn once on HIP

Every report I have read of managed allocation misbehaving on an APU came from someone who did not know a front-end had set the variable on their behalf. A single line naming the variable and pointing at [ggml-org#26148](https://github.com/ggml-org/llama.cpp/issues/26148) is most of the diagnosis, and it costs one `GGML_LOG_WARN_ONCE`. HIP only, since that is where the reports are.

## Scope

This is not a fix for the corruption in #26148. It is the thing that has to be true before anyone can test around it: a switch that responds to being switched off, and a build that tells you the switch is on.

## Verification

The helper is compile-checked standalone under `-Wall -Wextra` and exercised against unset, `1`, `0`, empty, `true`, `False`, `OFF`, `on`, `yes`, `no`, `2` and a junk value, which behave as described above.

I cannot build CUDA or HIP where I am, so the prebuilt legs are the first real check on the change in context. Worth a look at whether the warning is too chatty for anyone deliberately running managed memory to fit a large model in a shared pool; I kept it to one line for the process, but I would not argue if a reviewer wants it gated further.