### PR TITLE
kv-cache: scan only the predecessor window in get_prev_tokens

### DIFF
--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -1866,28 +1866,35 @@ void llama_kv_cache::get_prev_tokens(const llama_ubatch & ubatch, uint32_t n, st
     std::array<std::pair<llama_pos, llama_token>, LLAMA_MAX_SEQ> below;
     below.fill({ -1, LLAMA_TOKEN_NULL });
 
+    const auto collect = [&](llama_seq_id seq_id, llama_pos pos, llama_token tok) {
+        if (pos >= w0) {
+            hist[key(seq_id, pos)] = tok;
+        } else if (pos > below[seq_id].first) {
+            below[seq_id] = { pos, tok };
+        }
+    };
+
+    // cells below w0 only answer a lookup that misses the window, which needs an M-RoPE gap
+    const llama_pos p_scan0 = std::max<llama_pos>(0, w0);
+
     for (uint32_t s = 0; s < n_stream; ++s) {
         // p_max inclusive: an embd token looks up cells at its own (shared) position
-        v_cells[s].for_each_token_in(seqs, 0, p_max + 1,
-            [&](llama_seq_id seq_id, llama_pos pos, llama_token tok) {
-                if (pos >= w0) {
-                    hist[key(seq_id, pos)] = tok;
-                } else if (pos > below[seq_id].first) {
-                    below[seq_id] = { pos, tok };
-                }
-            });
+        v_cells[s].for_each_token_in(seqs, p_scan0, p_max + 1, collect);
     }
 
-    // the token at pos p, or the nearest earlier one when p falls in an M-RoPE gap
-    const auto lookup = [&](llama_seq_id seq_id, llama_pos p) -> llama_token {
+    // false means nothing in [w0, p]; the caller must then fall back to below[]
+    const auto lookup = [&](llama_seq_id seq_id, llama_pos p, llama_token & out) -> bool {
         for (llama_pos q = p; q >= w0; --q) {
             const auto it = hist.find(key(seq_id, q));
             if (it != hist.end()) {
-                return it->second;
+                out = it->second;
+                return true;
             }
         }
-        return below[seq_id].second;
+        return false;
     };
+
+    std::vector<std::pair<uint32_t, llama_seq_id>> missed;
 
     // an embd (multimodal) ubatch can repeat one position for a whole image, so positions
     // do not encode the token order; resolve its predecessors by ubatch order instead
@@ -1925,8 +1932,24 @@ void llama_kv_cache::get_prev_tokens(const llama_ubatch & ubatch, uint32_t n, st
                 continue;
             }
 
-            res[i*n + j] = lookup(seq_id, p);
+            if (!lookup(seq_id, p, res[i*n + j])) {
+                missed.push_back({ i*n + j, seq_id });
+            }
         }
+    }
+
+    if (missed.empty()) {
+        return;
+    }
+
+    if (p_scan0 > 0) {
+        for (uint32_t s = 0; s < n_stream; ++s) {
+            v_cells[s].for_each_token_in(seqs, 0, p_scan0, collect);
+        }
+    }
+
+    for (const auto & [idx, seq_id] : missed) {
+        res[idx] = below[seq_id].second;
     }
 }
 


### PR DESCRIPTION
`get_prev_tokens` rebuilds the n-gram predecessor history for the PLE input by walking **every** cell of the cache, at every decode step. Only positions in `[w0, p_max]` are ever read back out of the map it builds. The cells below `w0` exist for one reason: to fill `below[]`, which is the fallback for a lookup that lands in an M-RoPE position gap.

For text that fallback is never used, because text positions are unique and every lookup resolves inside the window. So at 64k context the scan visits 65536 cells to return two tokens.

This scans the window first and falls back to the full scan only when a lookup actually misses.

## The M-RoPE path is why this is not a one line change

An earlier version simply narrowed the range and dropped `below[]`. It was byte identical on text, which made the fallback look like dead weight. It is not: a multimodal ubatch repeats one position across a whole image, so a lookup can legitimately land in a gap, and that version produced a different, still plausible caption.

`lookup` therefore reports a miss instead of silently returning `below[]`, the missed `(index, seq_id)` pairs are collected, and the `[0, w0)` scan runs only if that list is non empty, through the same `collect` lambda.

## Measurement

Note that `62acc89c2` (#28011) landed first and already stops the inner sequence loop once every sequence in a cell has been seen. That removed most of this cost. Any number measured before it, including the ones I had from earlier work, no longer describes this patch.

Re-measured against current master, `llama-bench -d 65536 -n 32`, arms alternated inside one job, 8 reps each:

| arm | mean t/s | sd | vs base |
|---|---|---|---|
| base | 59.229 | 0.499 | |
| this patch | 60.708 | 1.723 | **+2.5%** |

7 of 8 reps beat every base rep. This is a couple of percent at 64k context, not the large win it was before #28011, and it is worth stating plainly.

The two changes attack different loops, this one the number of cells visited and #28011 the work per cell, but they land on the same total because what remains after #28011 is small.

## Testing

Built at `9723942ad`, CUDA, B200.

- Byte identical greedy output against base on Qwen3.8-Flash-Next UD-IQ1_S, Qwen3.8-27B Q4_K_M and Qwen3-0.6B Q4_K_M, with a base against base self control run first.
- Byte identical image captioning through `llama-mtmd-cli`, which is the gate the earlier version failed.
- `test-llama-archs` for qwen4exp, llama, qwen3next, gemma3n and qwen3moe.
- No ggml change.
