### PR TITLE
kv-cells: hoist the sequence list out of the for_each_token_in cell loop

### DIFF
--- a/src/llama-kv-cells.h
+++ b/src/llama-kv-cells.h
@@ -314,20 +314,28 @@ public:
     // note: used by n-gram input embeddings to recover the tokens preceding a ubatch
     template<typename F>
     void for_each_token_in(const std::bitset<LLAMA_MAX_SEQ> & seqs, llama_pos p0, llama_pos p1, F && f) const {
+        // hoisted: intersecting a LLAMA_MAX_SEQ-wide bitset per cell is the cost being removed
+        llama_seq_id sel[LLAMA_MAX_SEQ];
+        int n_sel = 0;
+
+        for (llama_seq_id s = 0; s < (llama_seq_id) LLAMA_MAX_SEQ; ++s) {
+            if (seqs.test(s)) {
+                sel[n_sel++] = s;
+            }
+        }
+
+        if (n_sel == 0) {
+            return;
+        }
+
         for (const auto & i : used) {
             if (pos[i] < p0 || pos[i] >= p1) {
                 continue;
             }
 
-            const auto m = seq[i] & seqs;
-
-            // a cell carries a handful of sequences at most, out of LLAMA_MAX_SEQ
-            size_t left = m.count();
-
-            for (llama_seq_id s = 0; left > 0 && s < (llama_seq_id) LLAMA_MAX_SEQ; ++s) {
-                if (m.test(s)) {
-                    f(s, pos[i], ext[i].tok);
-                    --left;
+            for (int k = 0; k < n_sel; ++k) {
+                if (seq[i].test(sel[k])) {
+                    f(sel[k], pos[i], ext[i].tok);
                 }
             }
         }


### PR DESCRIPTION
`for_each_token_in` takes a `seqs` bitset that does not change over the scan, then intersects it against every cell and counts the result.

`62acc89c2` (#28011) fixed the larger half of this by stopping the inner loop once every sequence in the cell has been seen, which removed the fixed `LLAMA_MAX_SEQ` iteration. What remains is the per cell `seq[i] & seqs` and `m.count()`, both of which are computed from an operand that is constant for the whole call.

Listing the set bits of `seqs` once, before the cell loop, removes both. A scan typically asks for a single sequence, so the inner work becomes one `test()` per cell.

## Measurement

`llama-bench -d 65536 -n 32` on Qwen3.8-Flash-Next UD-IQ1_S, arms alternated inside one job, 8 reps each, on top of a master that already contains #28011:

| arm | mean t/s | sd | vs base |
|---|---|---|---|
| base | 59.229 | 0.499 | |
| this patch | 60.815 | 0.819 | **+2.7%** |

7 of 8 reps beat every base rep.

This is a small, incremental change on top of #28011 rather than an independent win, and it should be read that way. `for_each_token_in` currently has exactly one caller, the n-gram predecessor scan, so the effect is confined to models with per layer token embeddings.

## Testing

Built at `9723942ad`, CUDA, B200.

- Byte identical greedy output against base on Qwen3.8-Flash-Next UD-IQ1_S, Qwen3.8-27B Q4_K_M and Qwen3-0.6B Q4_K_M, with a base against base self control run first.
- Byte identical image captioning through `llama-mtmd-cli`.
- `test-llama-archs` for qwen4exp, llama, qwen3next, gemma3n and qwen3moe.
- Callback order is unchanged, and there is no ggml change.
