### PR TITLE
ggml-cuda: use cudaMemcpyDefault in the ggml_cuda_cpy 2D fast path

### DIFF
--- a/ggml/src/ggml-cuda/cpy.cu
+++ b/ggml/src/ggml-cuda/cpy.cu
@@ -474,8 +474,15 @@ void ggml_cuda_cpy(ggml_backend_cuda_context & ctx, const ggml_tensor * src0, gg
             CUDA_CHECK(cudaMemcpyAsync(src1_ddc, src0_ddc, ggml_nbytes(src0), cudaMemcpyDeviceToDevice, main_stream));
         }
     } else if (ggml_cuda_cpy_as_memcpy_2d(src0, src1, mc_width, mc_height, mc_spitch, mc_dpitch)) {
+        // cudaMemcpyDefault, not DeviceToDevice: under
+        // GGML_CUDA_ENABLE_UNIFIED_MEMORY these buffers come from
+        // hipMallocManaged, and managed pages are not guaranteed device
+        // resident. DeviceToDevice asserts that they are, so the runtime skips
+        // residency resolution and a migrated page is read as garbage. Default
+        // lets it infer per pointer, and is a no-op when both really are on the
+        // device.
         CUDA_CHECK(cudaMemcpy2DAsync(src1_ddc, mc_dpitch, src0_ddc, mc_spitch,
-                                     mc_width, mc_height, cudaMemcpyDeviceToDevice, main_stream));
+                                     mc_width, mc_height, cudaMemcpyDefault, main_stream));
     } else if (src0->type == GGML_TYPE_F32 && src1->type == GGML_TYPE_F32) {
         if (can_be_transposed) {
             ggml_cpy_scalar_cuda<float, float, true>

--- a/ggml/src/ggml-cuda/vendors/hip.h
+++ b/ggml/src/ggml-cuda/vendors/hip.h
@@ -87,6 +87,7 @@
 #define cudaMemcpyAsync hipMemcpyAsync
 #define cudaMemcpyPeerAsync hipMemcpyPeerAsync
 #define cudaMemcpy2DAsync hipMemcpy2DAsync
+#define cudaMemcpyDefault hipMemcpyDefault
 #define cudaMemcpyDeviceToDevice hipMemcpyDeviceToDevice
 #define cudaMemcpyDeviceToHost hipMemcpyDeviceToHost
 #define cudaMemcpyHostToDevice hipMemcpyHostToDevice

--- a/ggml/src/ggml-cuda/vendors/musa.h
+++ b/ggml/src/ggml-cuda/vendors/musa.h
@@ -74,6 +74,7 @@
 #define cudaMemcpyAsync musaMemcpyAsync
 #define cudaMemcpyPeerAsync musaMemcpyPeerAsync
 #define cudaMemcpy2DAsync musaMemcpy2DAsync
+#define cudaMemcpyDefault musaMemcpyDefault
 #define cudaMemcpyDeviceToDevice musaMemcpyDeviceToDevice
 #define cudaMemcpyDeviceToHost musaMemcpyDeviceToHost
 #define cudaMemcpyHostToDevice musaMemcpyHostToDevice


### PR DESCRIPTION
## Overview

One word, plus the vendor mapping that makes it compile. Replaces #155, which showed 278 files because its branch was cut from the upstream `b10687` tag while targeting fork master; the change itself was always these three files.

```
ggml/src/ggml-cuda/cpy.cu            +8/-1
ggml/src/ggml-cuda/vendors/hip.h     +1/-0
ggml/src/ggml-cuda/vendors/musa.h    +1/-0
```

## The defect

The 2D fast path added by [ggml-org#25057](https://github.com/ggml-org/llama.cpp/pull/25057) copies with `cudaMemcpyDeviceToDevice`. That argument is not a hint, it is an assertion that both pointers are device resident, and it lets the runtime skip residency resolution.

Under `GGML_CUDA_ENABLE_UNIFIED_MEMORY` the allocator returns `hipMallocManaged` pages. Those migrate to the host once the working set outgrows VRAM, so past a footprint threshold the assertion is false and the copy reads the wrong memory. `cudaMemcpyDefault` resolves residency per pointer, and is a no-op when both pointers really are on the device.

Neither `vendors/hip.h` nor `vendors/musa.h` mapped `cudaMemcpyDefault`. The one copy kind that resolves residency was unreachable from this file on non-CUDA backends, which is plausibly why the defect was easy to write: on HIP the only kinds spelled `cuda*` were the explicit ones, so the fast path used an explicit kind because that is what compiled. The first build of this change failed with `use of undeclared identifier 'cudaMemcpyDefault'`.

## How it was found

A release bisect over prebuilt ROCm tarballs put the corruption on one commit: `0ed235ea`, b9826 clean and b9827 broken, direct parent and child, with 13 consecutive clean builds below and 5 broken above.

A revert-only build then proved causation. On gfx1151, in one job on one host, with a 45.1 GiB model at 73% of RAM: the reverted build produced identical tokens with the variable unset and set, while the stock build reproduced the reported fingerprint `' Paris.,,, or or or is is is is,,,,, from from from'`.

## Why this and not the revert

Deleting the fast path drops same-type strided copies of types outside F32/F16/BF16/I32 onto `GGML_ABORT("unsupported type combination")` at `cpy.cu:609`. That is coverage #25057 added for the GDN recurrent snapshot with `-np 4`. Changing the copy kind keeps it.

## Verification

Run on gfx1151, both cells in one job on one host, same model, same flags:

| cell | binary | UMA unset | UMA=1 | verdict |
| --- | --- | --- | --- | --- |
| D1 | this change | ` Paris. The capital of Germany is Berlin...` 47.7 tok/s | identical 30 tokens, 40.7 tok/s | NO_REGRESSION |
| D2 | stock `b10687-mix-67dfc8b` | same clean text, 48.2 tok/s | ` Paris.,,, or or or is is is is,,,,,` 45.0 tok/s | REGRESSION |

D2 is the load-bearing half: a build that failed to load, or a host too starved to reproduce, would also have made D1 look clean.

Trust checks on all four states: `server_ready` true, no crash, no SIGABRT, loads 6.0 / 43.6 / 18.0 / 35.1 s against a 900 s timeout. Binaries confirmed per file rather than by cell name. D1 and D2 base token vectors are identical, so the change does not perturb the path that was already correct.

## What is not covered

One model, one quant, one configuration, one host. No discrete GPU and no CUDA measurement, and this call site is shared with the path that was never broken. The comparable throughput pair is the two base states, 47.7 against 48.2, which is evidence against a large penalty rather than proof of none: `cudaMemcpyDefault` does a pointer attribute lookup per call, and a same-output benchmark is what would settle it.
