### PR TITLE
ggml-cuda: avoid direct ROCm_Host compute on HIP integrated GPUs (port of ggml-org#25863)

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -4822,6 +4822,22 @@ static enum ggml_backend_dev_type ggml_backend_cuda_device_get_type(ggml_backend
         : GGML_BACKEND_DEVICE_TYPE_GPU;
 }
 
+static bool ggml_backend_cuda_host_buffer_supported() {
+    return getenv("GGML_CUDA_NO_PINNED") == nullptr;
+}
+
+static bool ggml_backend_cuda_device_supports_cuda_host_buft(int device) {
+#if defined(GGML_USE_HIP)
+    if (ggml_cuda_info().devices[device].integrated) {
+        return false;
+    }
+#else
+    GGML_UNUSED(device);
+#endif
+
+    return ggml_backend_cuda_host_buffer_supported();
+}
+
 static void ggml_backend_cuda_device_get_props(ggml_backend_dev_t dev, ggml_backend_dev_props * props) {
     ggml_backend_cuda_device_context * ctx = (ggml_backend_cuda_device_context *)dev->context;
 
@@ -4831,7 +4847,7 @@ static void ggml_backend_cuda_device_get_props(ggml_backend_dev_t dev, ggml_back
     props->device_id   = ctx->pci_bus_id.empty() ? nullptr : ctx->pci_bus_id.c_str();
     ggml_backend_cuda_device_get_memory(dev, &props->memory_free, &props->memory_total);
 
-    bool host_buffer = getenv("GGML_CUDA_NO_PINNED") == nullptr;
+    bool host_buffer = ggml_backend_cuda_host_buffer_supported();
 #ifdef GGML_CUDA_NO_PEER_COPY
     bool events = false;
 #else
@@ -4860,6 +4876,10 @@ static ggml_backend_buffer_type_t ggml_backend_cuda_device_get_buffer_type(ggml_
 
 static ggml_backend_buffer_type_t ggml_backend_cuda_device_get_host_buffer_type(ggml_backend_dev_t dev) {
     GGML_UNUSED(dev);
+    if (!ggml_backend_cuda_host_buffer_supported()) {
+        return nullptr;
+    }
+
     return ggml_backend_cuda_host_buffer_type();
 }
 
@@ -5320,7 +5340,10 @@ static bool ggml_backend_cuda_device_supports_op(ggml_backend_dev_t dev, const g
 static bool ggml_backend_cuda_device_supports_buft(ggml_backend_dev_t dev, ggml_backend_buffer_type_t buft) {
     ggml_backend_cuda_device_context * dev_ctx = (ggml_backend_cuda_device_context *) dev->context;
     const bool integrated = ggml_cuda_info().devices[dev_ctx->device].integrated;
-    return (ggml_backend_buft_is_cuda(buft) && buft->device == dev) || (integrated && ggml_backend_buft_is_cuda_host(buft));
+    return (ggml_backend_buft_is_cuda(buft) && buft->device == dev) ||
+        (integrated &&
+         ggml_backend_buft_is_cuda_host(buft) &&
+         ggml_backend_cuda_device_supports_cuda_host_buft(dev_ctx->device));
 }
 
 static int64_t get_op_batch_size(const ggml_tensor * op) {


### PR DESCRIPTION
## Overview

Carries [ggml-org#25863](https://github.com/ggml-org/llama.cpp/pull/25863) at `ce82541a` into the fork, unmodified except for dropping that PR's file mode change (it flips `ggml-cuda.cu` to `100755`; kept at `100644` here).

25 insertions, 2 deletions, one file. Companion to #147, which pins the same upstream commit into the nightlies. This one puts the code in the fork so it is reviewable here and survives as a branch of record.

## The defect

`c7d87229` ([ggml-org#24233](https://github.com/ggml-org/llama.cpp/pull/24233)) restored `prop.integrated` on HIP builds. CUDA keeps it off, with the comment `Temporarily disabled due to issues with corrupted output`. With it on, the scheduler may place a compute input in pinned host memory, where an H2D input write can race a graph that is still running.

Two reporters bisected to that exact commit independently, from different symptoms:

| report | symptom |
| --- | --- |
| [ggml-org#25992](https://github.com/ggml-org/llama.cpp/issues/25992) | `-np 4 --kv-unified` returns another slot's response verbatim, gfx1151 |
| [ggml-org#27506](https://github.com/ggml-org/llama.cpp/issues/27506) | perplexity 7.72 to 3024 on Llama-3.2-3B, reproduced on three gfx1151 machines, Vulkan clean on each |
| [lemonade-sdk/lemonade#3160](https://github.com/lemonade-sdk/lemonade/issues/3160) | our own Qwen3.8-27B UD-Q4_K_XL degrading under 8 concurrent requests until it emits `////////`, recovering on reload; same harness scores 78-82% against cloud endpoints and ~17% here |

Corruption tracks `n_ubatch < n_batch`, and output is clean whenever the whole prompt lands in a single ubatch. Making `integrated` runtime-switchable on an otherwise unmodified tree gives PPL 850,121 on and 72.80 off, from one binary.

This is the bug that reaches users who did nothing unusual: no environment variable, no special flags. It is separate from the unified-memory corruption in #157, and neither fix addresses the other.

## Scope, checked rather than assumed

- `info.devices[id].integrated` is set from `prop.integrated` **only** under `GGML_USE_HIP`; CUDA and MUSA get a hard `false` (`ggml-cuda.cu:305-309`). The `supports_buft` change is therefore dead code off HIP.
- Discrete AMD is unaffected, since `prop.integrated` is false there.
- One hunk is genuinely broader and should not be described as integrated-only: `get_host_buffer_type` now returns `nullptr` when `GGML_CUDA_NO_PINNED` is set, on every backend. That is a consistency fix, since `props->host_buffer` already reported `false` while the buffer type was still handed out, so a user asking for no pinned memory could still get it. The only caller in the tree, `ggml-backend-meta.cpp:379`, handles `nullptr` explicitly.

## Why this and not #27311

[ggml-org#27311](https://github.com/ggml-org/llama.cpp/pull/27311) is the better end state: a ring buffer for input tensors, making host buffers correct rather than unavailable. It is an 18-commit scheduler change and currently `CONFLICTING`, so it is not pinnable today. When it lands, both this and the #147 pin come out.

#25863 is the narrow version: refuse to schedule compute out of the host buffer on HIP integrated devices, while pinned memory stays available for staging. Measured at PPL 63.67 against a Vulkan reference of 64.10, where the base gives 872,006.

## Verification

Not yet measured on our runner. I would rather say so than imply otherwise: the gfx1151 machine available here has no compiler, so the check has to run against a nightly that carries the pin. Once one exists, `llama-perplexity` over wikitext-2 at `-b 2048 -ub 512` before and after, expecting the previous nightly to be the broken number and the new one to match a Vulkan reference, plus one `-np 4 --kv-unified` run against #25992's nonce-checked harness.

Throughput is unmeasured. This changes buffer placement on a chip where both pools are the same DRAM, so a benchmark is warranted before assuming it is free, and a benchmark has to check output validity or it will reward the broken build.
