### PR TITLE
repin GLM-5-Next to the current head of ggml-org#27754

### DIFF
--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -23,7 +23,7 @@
     "https://github.com/unslothai/llama.cpp/pull/70/commits/edfd4c1a3b7a653303a85257ddac2a1f3ce39a2f",
     "https://github.com/unslothai/llama.cpp/pull/91/commits/c86ed269986f2dced6325c5c58bda966a2e2ead1",
     "https://github.com/unslothai/llama.cpp/pull/95/commits/3db8cb5b2e9bf291057b9f19960e8601a162da81",
-    "https://github.com/ggml-org/llama.cpp/pull/27754/commits/f30bed88717059d8a4728864c88f8abad8d329a0",
+    "https://github.com/ggml-org/llama.cpp/pull/27754/commits/5796547f37f5943513dfa130065ec88f9e30e0f5",
     "https://github.com/unslothai/llama.cpp/pull/137/commits/4e1865e34ec5f6ca39403215c89129c13731be70"
   ]
 }


### PR DESCRIPTION
The GLM-5-Next pin was 50 commits behind the head of ggml-org/llama.cpp#27754, and sat before `d07e71ede Add MTP support`. The nightly has therefore been shipping GLM-5-Next without the NextN draft head, without the master merge, and without the pooled-key shift fix.

```
- .../pull/27754/commits/f30bed88717059d8a4728864c88f8abad8d329a0
+ .../pull/27754/commits/5796547f37f5943513dfa130065ec88f9e30e0f5
```

### Verification

Replayed the resolve step against `b10705` (the tag the aging rule selects right now): checked out the base, merged the pins in listed order with `--no-ff -c merge.conflictStyle=diff3`, and ran `additive_merge.py` on any conflict.

```
OK  unslothai#107
OK  unslothai#70
OK  unslothai#91
OK  unslothai#95
OK  ggml-org#27754   <- clean, no additive resolution needed
OK  unslothai#137
```

Both resolve gates pass on the new commit: it fetches directly from `ggml-org`, and it is present in the `pulls/27754/commits` listing.

On the merged tree, MTP measured 1.29x on GLM-5.3-Flash UD-IQ1_S (61.5 -> 79.3 t/s, `--spec-draft-n-max 3`, draft acceptance 0.634). 1-chunk wikitext perplexity is unchanged at 3.3749 +/- 0.40867.

### Separate issue, not addressed here

`ggml-org#25731` (TML Inkling) no longer merges at `b10705`. Upstream #27960 touched `ggml/src/ggml-rpc/ggml-rpc.cpp`, which the Inkling branch also edits, so `additive_merge.py` refuses it:

```
refused  ggml/src/ggml-rpc/ggml-rpc.cpp: merge base is not empty, so at least one side edited existing text
```

It still merges on `b10698`, the base of the last shipped nightly, which is why runs are currently green. The next run on a base at or past `b10705` will fail on that pin regardless of this change. It needs the Inkling branch merged forward.