### PR TITLE
unsloth: pin the two AMD fixes so the ROCm nightlies carry them

### DIFF
--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -24,6 +24,8 @@
     "https://github.com/unslothai/llama.cpp/pull/91/commits/c86ed269986f2dced6325c5c58bda966a2e2ead1",
     "https://github.com/unslothai/llama.cpp/pull/95/commits/3db8cb5b2e9bf291057b9f19960e8601a162da81",
     "https://github.com/ggml-org/llama.cpp/pull/27754/commits/5796547f37f5943513dfa130065ec88f9e30e0f5",
-    "https://github.com/unslothai/llama.cpp/pull/137/commits/4e1865e34ec5f6ca39403215c89129c13731be70"
+    "https://github.com/unslothai/llama.cpp/pull/137/commits/4e1865e34ec5f6ca39403215c89129c13731be70",
+    "https://github.com/unslothai/llama.cpp/pull/158/commits/bfe2398b64c70cf1e18de0f80101753e905e184d",
+    "https://github.com/unslothai/llama.cpp/pull/157/commits/453cbcbb2a2e3fd32366911ecd787777a52832c1"
   ]
 }


### PR DESCRIPTION
## Overview

Pins the two AMD fixes so the ROCm and Vulkan nightlies actually carry them. Two lines in `scripts/unsloth/pr-set.json`.

| pin | fixes | who is affected |
| --- | --- | --- |
| #158 | HIP integrated host-buffer race (`c7d87229`) | **every ROCm APU user**, no flag needed |
| #157 | unified-memory corruption (`0ed235ea` / ggml-org#25057) | users with `GGML_CUDA_ENABLE_UNIFIED_MEMORY` set |

The nightly tree is the upstream tag plus these pins, so merging either PR into fork master ships nothing on its own. That is the point of this change, and it is the trap that made #145 useless.

## This supersedes #147

#147 pins [ggml-org#25863](https://github.com/ggml-org/llama.cpp/pull/25863); #158 is that same change carried in this fork. Pinning both would apply the same hunks twice and fail the resolve step, so only one can be listed. This uses ours, which keeps the code reviewable here. **#147 should be closed if this merges**, or this entry dropped if you would rather track upstream directly. Either works, but not both.

## Why these two

**#158.** `c7d87229` (ggml-org#24233) restored `prop.integrated` on HIP builds, where CUDA keeps it off with the comment `Temporarily disabled due to issues with corrupted output`. The scheduler may then place a compute input in pinned host memory and an H2D write races a running graph. Two reporters bisected to that commit independently, and [lemonade-sdk/lemonade#3160](https://github.com/lemonade-sdk/lemonade/issues/3160) is the same failure on our own Qwen3.8-27B UD-Q4_K_XL: coherent at first, then word salad under 8 concurrent requests, then `////////` even for sequential requests, recovering on reload. Same harness scores 78-82% against cloud endpoints and ~17% here. Measured at PPL 63.67 against a Vulkan reference of 64.10, where the base gives 872,006.

**#157.** A release bisect over prebuilt ROCm tarballs put the corruption on `0ed235ea`, b9826 clean and b9827 broken, direct parent and child. Verified on gfx1151 with both cells in one job on one host: the fixed build emitted identical tokens with the variable unset and set, while the stock build reproduced `' Paris.,,, or or or is is is is,,,,,'`.

## Verification

The preflight probes the merges; what I want to see is that plus green gfx1150 and gfx1151 ROCm legs.

Neither fix is measured for throughput, and I would rather say so than let the correctness results stand in for a benchmark. #158 changes buffer placement on a chip where both pools are the same DRAM. #157 makes the runtime resolve residency per pointer on a hot path; the comparable pair measured 47.7 against 48.2 tok/s, which is evidence against a large penalty rather than proof of none. Any benchmark here has to check output validity, because the corrupted build is not slower: in our own run the broken state generated at 45.0 tok/s.

Both entries come out once a base tag carries the upstream merge, per the rule in `_doc`.
