### PR TITLE
unsloth: repin ggml-org#25731 to the commit that merges onto b10705

### DIFF
--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -25,7 +25,7 @@
     "https://github.com/unslothai/llama.cpp/pull/95/commits/3db8cb5b2e9bf291057b9f19960e8601a162da81",
     "https://github.com/ggml-org/llama.cpp/pull/27754/commits/5796547f37f5943513dfa130065ec88f9e30e0f5",
     "https://github.com/unslothai/llama.cpp/pull/137/commits/4e1865e34ec5f6ca39403215c89129c13731be70",
-    "https://github.com/unslothai/llama.cpp/pull/158/commits/bfe2398b64c70cf1e18de0f80101753e905e184d",
-    "https://github.com/unslothai/llama.cpp/pull/157/commits/453cbcbb2a2e3fd32366911ecd787777a52832c1"
+    "https://github.com/unslothai/llama.cpp/pull/158/commits/abfc45b9cb21eae4848cb82196e659f42c9a8341",
+    "https://github.com/unslothai/llama.cpp/pull/157/commits/6c6da89266ba7839d825c9997782af4f4d26b81b"
   ]
 }

--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -19,7 +19,7 @@
   ],
   "prs": [
     "https://github.com/unslothai/llama.cpp/pull/107/commits/74acc40c37ae2eb36031981feda392b793944f72",
-    "https://github.com/ggml-org/llama.cpp/pull/25731/commits/edee0e160ae0a8004dc9205a4197ba6ea3686500",
+    "https://github.com/ggml-org/llama.cpp/pull/25731/commits/44eb88e9aba218b24c0f374f2ec1c4d7d7920877",
     "https://github.com/unslothai/llama.cpp/pull/70/commits/edfd4c1a3b7a653303a85257ddac2a1f3ce39a2f",
     "https://github.com/unslothai/llama.cpp/pull/91/commits/c86ed269986f2dced6325c5c58bda966a2e2ead1",
     "https://github.com/unslothai/llama.cpp/pull/95/commits/3db8cb5b2e9bf291057b9f19960e8601a162da81",


### PR DESCRIPTION
## Overview

Repins [ggml-org#25731](https://github.com/ggml-org/llama.cpp/pull/25731) from `edee0e160a` to `44eb88e9ab`, one line.

## Why

The pin preflight is failing on `master`:

```
- ggml-org/llama.cpp#25731 (edee0e160a) does not merge onto b10705 + the pins before it.
##[error]pins do not merge onto the current base tag
```

`edee0e160a` no longer applies to the current base tag. The upstream conflicts have since been resolved and the PR is `MERGEABLE` again as of 2026-08-31T08:06Z, with head `44eb88e9ab`.

## What this unblocks

The preflight stops at the first conflicting pin, so a single stale entry fails the whole run and no nightly is produced. Two consequences, and the second is the one that matters:

1. No nightly means the AMD fixes pinned by #160, [#157](https://github.com/unslothai/llama.cpp/pull/157) and [#158](https://github.com/unslothai/llama.cpp/pull/158), do not reach users despite that PR having merged. Those fix output corruption currently being reported against our own GGUFs on gfx1151, including [lemonade-sdk/lemonade#3160](https://github.com/lemonade-sdk/lemonade/issues/3160).
2. Because the run aborted at `#25731`, those two pins were **never dry-run merged**. They are unverified rather than known good. #158 in particular was branched from fork master and has to merge onto an upstream tag, which is the mismatch worth watching. This PR is what lets the preflight actually reach and check them.

Supersedes #100, which repinned this same entry to a commit for base tag `b10369` and is now three tags stale.
