### PR TITLE
unsloth: pin #149 so GGML_CUDA_ENABLE_UNIFIED_MEMORY=0 actually disables it

### DIFF
--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -26,6 +26,7 @@
     "https://github.com/ggml-org/llama.cpp/pull/27754/commits/5796547f37f5943513dfa130065ec88f9e30e0f5",
     "https://github.com/unslothai/llama.cpp/pull/137/commits/4e1865e34ec5f6ca39403215c89129c13731be70",
     "https://github.com/unslothai/llama.cpp/pull/158/commits/abfc45b9cb21eae4848cb82196e659f42c9a8341",
-    "https://github.com/unslothai/llama.cpp/pull/157/commits/6c6da89266ba7839d825c9997782af4f4d26b81b"
+    "https://github.com/unslothai/llama.cpp/pull/157/commits/6c6da89266ba7839d825c9997782af4f4d26b81b",
+    "https://github.com/unslothai/llama.cpp/pull/149/commits/b65a2dce12c14a489e19a059cb6ee59112f1b733"
   ]
 }


### PR DESCRIPTION
## Overview

Pins #149, one line. Completes the AMD set: #158 and #157 are already pinned and green in the master preflight.

## Why

`ggml` tests `getenv("GGML_CUDA_ENABLE_UNIFIED_MEMORY") != nullptr`, so `=0` **enables** managed allocation. The variable is spelled as a positive, so writing `=0` to turn it off does the opposite.

With #157 pinned this is no longer a correctness bug. It is a cost bug, and still worth fixing:

- roughly 15% throughput, measured here at 47.7 tok/s unset against 40.7 set, on identical output tokens
- it can lower the ceiling rather than raise it, because managed allocation draws host RAM **instead of** the device carve-out rather than adding to it. In unslothai/unsloth#9884 a 28 GiB model loaded in 10 s without the variable and was OOM-killed with it

So a user who sets `=0` to escape that still doesn't.

#149 also carries a HIP `WARN_ONCE`, rewritten for this: it no longer claims corrupted output or links ggml-org#26148, because shipping that alongside #157 would tell users to chase a defect their build does not have.

## Scope

This changes behaviour for **every CUDA and HIP user** who sets `=0`, not only AMD. That is the intended fix, but it is not a no-op.

## Verification

The pinned commit is branched from `11cd98842874`, an upstream ancestor of both master and the base tag, per the rule that a pin cut from fork master drags master's divergence into the merge. Verified locally to co-merge onto `b10705` alongside #157 and #158 for a net +79/-5 across 4 files; #149 and #158 both touch `ggml-cuda.cu` and merge cleanly together.

Comes out once a base tag carries the work upstream.
