### PR TITLE
unsloth: pin ggml-org#27941, #152 and #154

### DIFF
--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -23,7 +23,7 @@
     "https://github.com/unslothai/llama.cpp/pull/70/commits/edfd4c1a3b7a653303a85257ddac2a1f3ce39a2f",
     "https://github.com/unslothai/llama.cpp/pull/91/commits/c86ed269986f2dced6325c5c58bda966a2e2ead1",
     "https://github.com/unslothai/llama.cpp/pull/95/commits/3db8cb5b2e9bf291057b9f19960e8601a162da81",
-    "https://github.com/ggml-org/llama.cpp/pull/27754/commits/5796547f37f5943513dfa130065ec88f9e30e0f5",
+    "https://github.com/ggml-org/llama.cpp/pull/27754/commits/949f7efb097eb20ef36fecdb1afaebff9a4ae7ed",
     "https://github.com/unslothai/llama.cpp/pull/137/commits/4e1865e34ec5f6ca39403215c89129c13731be70",
     "https://github.com/unslothai/llama.cpp/pull/158/commits/abfc45b9cb21eae4848cb82196e659f42c9a8341",
     "https://github.com/unslothai/llama.cpp/pull/157/commits/6c6da89266ba7839d825c9997782af4f4d26b81b",

--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -28,7 +28,7 @@
     "https://github.com/unslothai/llama.cpp/pull/158/commits/abfc45b9cb21eae4848cb82196e659f42c9a8341",
     "https://github.com/unslothai/llama.cpp/pull/157/commits/6c6da89266ba7839d825c9997782af4f4d26b81b",
     "https://github.com/unslothai/llama.cpp/pull/149/commits/b65a2dce12c14a489e19a059cb6ee59112f1b733",
-    "https://github.com/ggml-org/llama.cpp/pull/27941/commits/02eb201def6cecb12c25b7b4613d44e546acabda",
+    "https://github.com/ggml-org/llama.cpp/pull/27941/commits/6b2b85cfbf8a5c612e7d3d4c0ef222e1e58de1c5",
     "https://github.com/unslothai/llama.cpp/pull/152/commits/258345efa640eb099eb1af3c9ee8f8e6e8e7b0d3",
     "https://github.com/unslothai/llama.cpp/pull/154/commits/31e432e758f8cc4b2c5f27902721500173bf39db"
   ]

--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -29,6 +29,7 @@
     "https://github.com/unslothai/llama.cpp/pull/157/commits/6c6da89266ba7839d825c9997782af4f4d26b81b",
     "https://github.com/unslothai/llama.cpp/pull/149/commits/b65a2dce12c14a489e19a059cb6ee59112f1b733",
     "https://github.com/ggml-org/llama.cpp/pull/27941/commits/6b2b85cfbf8a5c612e7d3d4c0ef222e1e58de1c5",
+    "https://github.com/unslothai/llama.cpp/pull/144/commits/6fc8df13a1677759a06ae229155d697c5d725ea7",
     "https://github.com/unslothai/llama.cpp/pull/152/commits/258345efa640eb099eb1af3c9ee8f8e6e8e7b0d3",
     "https://github.com/unslothai/llama.cpp/pull/154/commits/31e432e758f8cc4b2c5f27902721500173bf39db"
   ]

--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -27,6 +27,9 @@
     "https://github.com/unslothai/llama.cpp/pull/137/commits/4e1865e34ec5f6ca39403215c89129c13731be70",
     "https://github.com/unslothai/llama.cpp/pull/158/commits/abfc45b9cb21eae4848cb82196e659f42c9a8341",
     "https://github.com/unslothai/llama.cpp/pull/157/commits/6c6da89266ba7839d825c9997782af4f4d26b81b",
-    "https://github.com/unslothai/llama.cpp/pull/149/commits/b65a2dce12c14a489e19a059cb6ee59112f1b733"
+    "https://github.com/unslothai/llama.cpp/pull/149/commits/b65a2dce12c14a489e19a059cb6ee59112f1b733",
+    "https://github.com/ggml-org/llama.cpp/pull/27941/commits/02eb201def6cecb12c25b7b4613d44e546acabda",
+    "https://github.com/unslothai/llama.cpp/pull/152/commits/258345efa640eb099eb1af3c9ee8f8e6e8e7b0d3",
+    "https://github.com/unslothai/llama.cpp/pull/154/commits/31e432e758f8cc4b2c5f27902721500173bf39db"
   ]
 }


### PR DESCRIPTION
## Overview

Adds three pins: ggml-org#27941, #152 and #154.

| pin | commit | note |
| --- | --- | --- |
| ggml-org#27941 | `02eb201d` | no longer a draft, `MERGEABLE` upstream. Replaces the stale `8161d117` that closed PR #148 carried |
| #152 | `258345ef` | merges onto `b10708` on its own |
| #154 | `31e432e7` | merges onto `b10708` on its own |

**#137 needs no change.** It is already pinned at `4e1865e3`, which is still its head.

## Why #27941 matters here

It fixes four `qwen4exp` correctness defects, and it is the only account of the one Flash-Next reporter the unified-memory work could not explain: **edsonmedina, who says "I only use Vulkan"**, where Studio never sets the allocator variable. Two of the defects need no AMD involvement at all:

- sequence copies lost their indexer keys, so a copied sequence kept the destination stream's stale keys. Silently wrong output, reachable through the OpenAI `n` parameter.
- blocks were keyed on position alone, correct only for a single sequence, so under `--kv-unified` a block could be pooled from another sequence's cells.

So Flash-Next gibberish has two independent causes stacked on one model, which is why the workarounds in that thread contradict each other. The AMD pins fix one of them; this fixes the other.

## #142 and #144 are deliberately NOT pinned

Both conflict against `b10708` on `src/llama.cpp` and `src/llama-model-loader.cpp`, and it is a real semantic conflict rather than a textual one. Upstream folded `lazy_mode` and `model_shared` into a `lazy` struct:

```
b10708:  ml.lazy.mode    = params.lazy_mode;
#142:    ml.tensor_read_lazy = params.tensor_read_lazy;  ml.model_shared = params.model_shared;
#144:    ml.lazy_mode        = params.lazy_mode;         ml.model_shared = params.model_shared;
```

Both branches predate that refactor. Pinning them as they stand would fail the resolve and take every pin after them down with it, since the preflight stops at the first conflict. They need rebasing onto current upstream first, which is a code change in MTP paths and wants its own review rather than being smuggled through a pin update.

## Verification

Each new pin was merged onto `b10708` individually before being listed:

```
#152    ok   9 files changed, 306 insertions(+), 25 deletions(-)
#154    ok   7 files changed, 249 insertions(+), 20 deletions(-)
#27941  ok   6 files changed, 505 insertions(+), 138 deletions(-)
```

The full chain is left to the preflight, which resolves some overlaps with `additive_merge.py` and is the authority; a plain `git merge` replay is not equivalent.
