### PR TITLE
unsloth: repin #144 to 586b15ef, fixing a brace dropped in the rebase

### DIFF
--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -29,7 +29,7 @@
     "https://github.com/unslothai/llama.cpp/pull/157/commits/6c6da89266ba7839d825c9997782af4f4d26b81b",
     "https://github.com/unslothai/llama.cpp/pull/149/commits/b65a2dce12c14a489e19a059cb6ee59112f1b733",
     "https://github.com/ggml-org/llama.cpp/pull/27941/commits/6b2b85cfbf8a5c612e7d3d4c0ef222e1e58de1c5",
-    "https://github.com/unslothai/llama.cpp/pull/144/commits/6fc8df13a1677759a06ae229155d697c5d725ea7",
+    "https://github.com/unslothai/llama.cpp/pull/144/commits/586b15ef8ef9488140c64a71424589cec1a6a9a2",
     "https://github.com/unslothai/llama.cpp/pull/152/commits/258345efa640eb099eb1af3c9ee8f8e6e8e7b0d3",
     "https://github.com/unslothai/llama.cpp/pull/154/commits/31e432e758f8cc4b2c5f27902721500173bf39db"
   ]


### PR DESCRIPTION
## What broke

Run [33385736675](https://github.com/unslothai/llama.cpp/actions/runs/33385736675) failed to compile on every backend that builds `src/`, which is all of them: CPU, Vulkan, macOS, ROCm and CUDA-legacy.

```
llama-model-loader.cpp:1114:62: error: qualified-id in declaration before '(' token
... repeated at 1176, 1458, 1476, 1515, 1532, 1574, 1579, 1601, 1896, 1900
llama-model-loader.cpp:1908:2: error: expected '}' at end of input
```

`Resolve tag` succeeded, so the 14-pin chain merges. The failure is a syntax error in the merged source.

## Cause

Mine. Rebasing #144 onto `b10709` produced a false conflict: upstream's `lazy_read::add()` and this branch's `borrow_shared_tensor()` landed at the same offset in `llama-model-loader.cpp`. I resolved it keep-both, which was right in intent, but `add()` ended at `return true;` with its closing brace on the far side of the conflict region. Concatenating the two sides left `add()` unterminated, and the shared trailing brace closed `borrow_shared_tensor` instead. Every member function after that parsed as nested, which is exactly what `qualified-id in declaration before '('` means.

## Fix

The brace is restored in the commit that introduced the problem, `a70cf195` in the old lineage, rather than patched on top, so no commit in the branch is left unbuildable.

## Verification

`g++ -fsyntax-only` on the fully merged tree (`b10709` + #27941 + #144), which is the check that would have caught this before the run rather than after:

| file | result |
| --- | --- |
| `src/llama-model-loader.cpp` | OK |
| `src/llama.cpp` | OK |
| `src/llama-model.cpp` | OK |
| `src/models/qwen4exp.cpp` | OK |

Brace counting alone said 0 delta both before and after the fix on the branch tip, so it is not a sufficient check; the parse is.

## Note

A merge that resolves cleanly is not a merge that compiles. The pin preflight only proves the former. Nothing in the pin machinery builds the merged tree, which is why this reached a publish run.