### PR TITLE
download: find MTP heads published in a dedicated MTP/ folder

### DIFF
--- a/common/download.cpp
+++ b/common/download.cpp
@@ -17,6 +17,7 @@
 #include <unordered_set>
 #include <string>
 #include <thread>
+#include <tuple>
 #include <vector>
 
 #include "http.h"
@@ -563,23 +564,37 @@ static hf_cache::hf_files get_split_files(const hf_cache::hf_files & files,
     return result;
 }
 
+static std::string to_upper(const std::string & s) {
+    std::string r = s;
+    for (char & c : r) {
+        c = (char) std::toupper((unsigned char) c);
+    }
+    return r;
+}
+
 // pick the best sibling GGUF whose filename contains `keyword` (e.g. "mmproj" / "mtp"),
 // preferring deeper shared directory prefix with the model, then exact `tag` match,
 // then closest quantization to the tag when given, or to the model otherwise
+//
+// `sidecar_dir` additionally admits candidates in a dedicated top-level folder of that name, which
+// shares no directory prefix with the model and is otherwise unreachable: unsloth publishes MTP
+// heads as MTP/mtp-<model>-<quant>.gguf, and without this the folder is silently never matched
+// `prefer_bits` wins over proximity when no candidate matches `tag` exactly, so a repo offering
+// several heads has one designated default rather than whichever is arithmetically nearest
 static hf_cache::hf_file find_best_sibling(const hf_cache::hf_files & files,
                                            const std::string        & model,
                                            const std::string        & keyword,
-                                           const std::string        & tag = "") {
+                                           const std::string        & tag = "",
+                                           const std::string        & sidecar_dir = "",
+                                           int                        prefer_bits = 0) {
+    using rank_t = std::tuple<size_t, bool, bool, int, bool>;
+
     hf_cache::hf_file best;
-    size_t best_depth = 0;
-    int best_diff = 0;
-    bool best_exact = false;
+    rank_t best_rank;
     bool found = false;
 
-    std::string tag_upper = tag;
-    for (char & c : tag_upper) {
-        c = (char) std::toupper((unsigned char) c);
-    }
+    const std::string tag_upper     = to_upper(tag);
+    const std::string sidecar_upper = to_upper(sidecar_dir);
 
     int model_bits = 0;
     if (!tag_upper.empty()) {
@@ -602,27 +617,32 @@ static hf_cache::hf_file find_best_sibling(const hf_cache::hf_files & files,
 
         auto [_, dir] = std::mismatch(model_parts.begin(), model_dir,
                                       sib_parts.begin(), sib_dir);
-        if (dir != sib_dir) {
+
+        size_t depth = 0;
+        if (dir == sib_dir) {
+            depth = dir - sib_parts.begin();
+        } else if (sidecar_upper.empty() || sib_parts.size() != 2 ||
+                   to_upper(sib_parts[0]) != sidecar_upper) {
             continue;
         }
+        // a dedicated folder ranks as depth 0, so a true same-directory sibling still wins
 
-        size_t depth = dir - sib_parts.begin();
         auto bits = extract_quant_bits(f.path);
         auto diff = std::abs(bits - model_bits);
 
-        std::string path_upper = f.path;
-        for (char & c : path_upper) {
-            c = (char) std::toupper((unsigned char) c);
-        }
-        bool exact = !tag_upper.empty() && path_upper.find("-" + tag_upper + ".") != std::string::npos;
+        const std::string path_upper = to_upper(f.path);
 
-        if (!found || depth > best_depth ||
-            (depth == best_depth && exact && !best_exact) ||
-            (depth == best_depth && exact == best_exact && diff < best_diff)) {
+        bool exact     = !tag_upper.empty() && path_upper.find("-" + tag_upper + ".") != std::string::npos;
+        bool preferred = prefer_bits != 0 && bits == prefer_bits;
+        // a head carrying its own token_embd/output loads against any build, where one that borrows
+        // them from the target needs a build that supports the borrow
+        bool self_contained = path_upper.find("SHARED") == std::string::npos;
+
+        rank_t rank{depth, exact, preferred, -diff, self_contained};
+
+        if (!found || rank > best_rank) {
             best = f;
-            best_depth = depth;
-            best_diff = diff;
-            best_exact = exact;
+            best_rank = rank;
             found = true;
         }
     }
@@ -634,10 +654,12 @@ static hf_cache::hf_file find_best_mmproj(const hf_cache::hf_files & files,
     return find_best_sibling(files, model, "mmproj");
 }
 
+// 8 bits is Q8_0: measured the fastest MTP head as well as the most accurate, because a draft step
+// is dominated by the LM head and that head is cheaper to execute at 8 bits than at bf16
 static hf_cache::hf_file find_best_mtp(const hf_cache::hf_files & files,
                                        const std::string        & model,
                                        const std::string        & tag = "") {
-    return find_best_sibling(files, model, "mtp-", tag);
+    return find_best_sibling(files, model, "mtp-", tag, "MTP", 8);
 }
 
 static hf_cache::hf_file find_best_eagle3(const hf_cache::hf_files & files,

--- a/common/download.cpp
+++ b/common/download.cpp
@@ -581,13 +581,16 @@ static std::string to_upper(const std::string & s) {
 // heads as MTP/mtp-<model>-<quant>.gguf, and without this the folder is silently never matched
 // `prefer_bits` wins over proximity when no candidate matches `tag` exactly, so a repo offering
 // several heads has one designated default rather than whichever is arithmetically nearest
+//
+// both only ever apply to candidates admitted by `sidecar_dir`, so a repository that resolved
+// before this existed resolves to the same file afterwards
 static hf_cache::hf_file find_best_sibling(const hf_cache::hf_files & files,
                                            const std::string        & model,
                                            const std::string        & keyword,
                                            const std::string        & tag = "",
                                            const std::string        & sidecar_dir = "",
                                            int                        prefer_bits = 0) {
-    using rank_t = std::tuple<size_t, bool, bool, int, bool>;
+    using rank_t = std::tuple<bool, size_t, bool, bool, int, bool>;
 
     hf_cache::hf_file best;
     rank_t best_rank;
@@ -618,27 +621,30 @@ static hf_cache::hf_file find_best_sibling(const hf_cache::hf_files & files,
         auto [_, dir] = std::mismatch(model_parts.begin(), model_dir,
                                       sib_parts.begin(), sib_dir);
 
-        size_t depth = 0;
-        if (dir == sib_dir) {
+        size_t depth  = 0;
+        bool   prefix = dir == sib_dir;
+        if (prefix) {
             depth = dir - sib_parts.begin();
         } else if (sidecar_upper.empty() || sib_parts.size() != 2 ||
                    to_upper(sib_parts[0]) != sidecar_upper) {
             continue;
         }
-        // a dedicated folder ranks as depth 0, so a true same-directory sibling still wins
 
         auto bits = extract_quant_bits(f.path);
         auto diff = std::abs(bits - model_bits);
 
         const std::string path_upper = to_upper(f.path);
 
-        bool exact     = !tag_upper.empty() && path_upper.find("-" + tag_upper + ".") != std::string::npos;
-        bool preferred = prefer_bits != 0 && bits == prefer_bits;
+        bool exact = !tag_upper.empty() && path_upper.find("-" + tag_upper + ".") != std::string::npos;
+
+        // a sibling sharing the model's directory prefix always outranks the dedicated folder, and
+        // the two rules below never fire for one, so every layout that resolved before is unchanged
+        bool preferred = !prefix && prefer_bits != 0 && bits == prefer_bits;
         // a head carrying its own token_embd/output loads against any build, where one that borrows
         // them from the target needs a build that supports the borrow
-        bool self_contained = path_upper.find("SHARED") == std::string::npos;
+        bool self_contained = !prefix && path_upper.find("SHARED") == std::string::npos;
 
-        rank_t rank{depth, exact, preferred, -diff, self_contained};
+        rank_t rank{prefix, depth, exact, preferred, -diff, self_contained};
 
         if (!found || rank > best_rank) {
             best = f;

--- a/tests/test-model-resolution.cpp
+++ b/tests/test-model-resolution.cpp
@@ -180,6 +180,41 @@ static const std::vector<std::string> spark = {
     "dspark-model-MXFP4.gguf",
 };
 
+// heads in a dedicated folder beside a root model, in the style of unsloth/Qwen3.8-27B-GGUF
+static const std::vector<std::string> mtp_dir_flat = {
+    "model-Q4_K_M.gguf",
+    "model-Q8_0.gguf",
+    "MTP/mtp-model-Q4_0.gguf",
+};
+
+// the same folder beside quant subdirectories, in the style of unsloth/Qwen3.8-Flash-Next-GGUF,
+// carrying every head we publish: three quants, each self-contained and borrowing
+static const std::vector<std::string> mtp_dir_subdir = {
+    "mmproj-BF16.gguf",
+    "UD-IQ1_S/model-UD-IQ1_S-00001-of-00002.gguf",
+    "UD-IQ1_S/model-UD-IQ1_S-00002-of-00002.gguf",
+    "Q8_0/model-Q8_0.gguf",
+    "MTP/mtp-model-BF16.gguf",
+    "MTP/mtp-model-Q4_K_M.gguf",
+    "MTP/mtp-model-Q8_0.gguf",
+    "MTP/mtp-model-shared-BF16.gguf",
+    "MTP/mtp-model-shared-Q4_K_M.gguf",
+    "MTP/mtp-model-shared-Q8_0.gguf",
+};
+
+// a dedicated folder must not take precedence over a head sharing the model's own directory
+static const std::vector<std::string> mtp_dir_and_sibling = {
+    "model-Q8_0.gguf",
+    "mtp-model-BF16.gguf",
+    "MTP/mtp-model-Q8_0.gguf",
+};
+
+// a top-level name that merely starts with MTP is not the dedicated folder
+static const std::vector<std::string> mtp_dir_near_miss = {
+    "model-Q8_0.gguf",
+    "MTPX/mtp-model-Q8_0.gguf",
+};
+
 // dspark outranks dflash in the type auto-selection
 static const std::vector<std::string> dspark_dflash = {
     "model-Q8_0.gguf",
@@ -283,6 +318,37 @@ static const plan_case plan_cases[] = {
     {"spark tag sidecar", spark, "test/repo:BF16", "", true, false,
      "", {},
      "", "", "", "", "dspark-model-BF16.gguf"},
+
+    // a head in the dedicated folder is reachable from a model at the repo root,
+    // where the directory prefix rule alone finds nothing
+    {"mtp dir flat", mtp_dir_flat, "test/repo:Q8_0", "", true, false,
+     "model-Q8_0.gguf", {"model-Q8_0.gguf"},
+     "", "MTP/mtp-model-Q4_0.gguf", "", "", ""},
+
+    // and from a model in a quant subdirectory, which shares no prefix with it either.
+    // no head matches UD-IQ1_S, so the preferred quant wins over the nearest one, and the
+    // self-contained head wins over the one that borrows from the target
+    {"mtp dir subdir", mtp_dir_subdir, "test/repo:UD-IQ1_S", "", true, false,
+     "UD-IQ1_S/model-UD-IQ1_S-00001-of-00002.gguf",
+     {"UD-IQ1_S/model-UD-IQ1_S-00001-of-00002.gguf",
+      "UD-IQ1_S/model-UD-IQ1_S-00002-of-00002.gguf"},
+     "mmproj-BF16.gguf", "MTP/mtp-model-Q8_0.gguf", "", "", ""},
+
+    // an exact tag still beats the preferred quant
+    {"mtp dir exact tag", mtp_dir_subdir, "test/repo:Q8_0", "", true, false,
+     "Q8_0/model-Q8_0.gguf", {"Q8_0/model-Q8_0.gguf"},
+     "mmproj-BF16.gguf", "MTP/mtp-model-Q8_0.gguf", "", "", ""},
+
+    // a head sharing the model's own directory outranks the dedicated folder, even though the
+    // folder holds the exact tag and the sibling does not
+    {"mtp dir loses to sibling", mtp_dir_and_sibling, "test/repo:Q8_0", "", true, false,
+     "model-Q8_0.gguf", {"model-Q8_0.gguf"},
+     "", "mtp-model-BF16.gguf", "", "", ""},
+
+    // only the exact folder name is special, MTPX/ is not
+    {"mtp dir near miss", mtp_dir_near_miss, "test/repo:Q8_0", "", true, false,
+     "model-Q8_0.gguf", {"model-Q8_0.gguf"},
+     "", "", "", "", ""},
 };
 
 static void check_plan(const plan_case & c) {


### PR DESCRIPTION
## Problem

`find_best_sibling` in `common/download.cpp` only accepts a sidecar whose directory components are a
prefix of the model's, so a top-level `MTP/` folder is unreachable. It matches neither a model at the
repository root nor one in a quant subfolder.

Both of our GGUF repos publish their draft heads that way, and on the 27B the miss is not silent.
With no sidecar found, `params.speculative.draft.mparams.path` stays empty and the target is used as
its own draft, so the server refuses to start:

```
common_speculative_init_result: creating MTP draft context against the target model '.../Qwen3.8-27B-UD-IQ1_S.gguf'
llama_init_from_model: context type MTP requested but model doesn't contain MTP layers
common_speculative_init_result: failed to create MTP context
srv    load_model: failed to create MTP context
```

Measured on the shipped `b10715-mix-86bd2d3` prebuilt:

| repo | layout | `--spec-type draft-mtp`, no `-md` |
| --- | --- | --- |
| `unsloth/Qwen3.8-27B-GGUF` | model at root, sidecar in `MTP/` | nothing found, server fails to start |
| `unsloth/Qwen3.8-Flash-Next-GGUF` | model in `UD-IQ1_S/`, sidecar in `MTP/` | fetches the 3 model shards and root `mmproj-BF16.gguf`, no MTP file |

The second row is also the control that shows sibling discovery itself is fine: `mmproj-BF16.gguf`
sits at the repo root while the model is in `UD-IQ1_S/`, and it is discovered. The `MTP/` directory
is specifically what defeats the match.

Note `--mtp` is registered only for `LLAMA_EXAMPLE_DOWNLOAD`, so on `llama-server` the switch that
enables discovery is `--spec-type draft-mtp`.

## Change

`common/download.cpp` and `tests/test-model-resolution.cpp`. `git diff --stat -- ggml/` is empty.

`find_best_sibling` gains an optional `sidecar_dir` that additionally admits a candidate sitting in a
single top-level folder of that name, case insensitive. It ranks as depth 0, so a genuine
same-directory sibling still wins. An empty `sidecar_dir` is exactly the previous behaviour, which is
what leaves `find_best_mmproj`, `find_best_dflash`, `find_best_eagle3` and `find_best_dspark`
untouched. Only `find_best_mtp` passes one, `"MTP"`.

Having more than one head in that folder forces two selection details:

* `prefer_bits` picks a designated default when nothing matches the requested tag exactly, instead of
  whichever head is arithmetically nearest. For MTP that is Q8_0. Without it a `UD-IQ1_S` user would
  be handed the Q4_K_M head on bit proximity, and a `BF16` user the bf16 head, which is the worst of
  the three: it is 1.88x larger than Q8_0 and slower, because a draft step is dominated by the LM
  head and that head is cheaper to execute at 8 bits. An exact tag match still wins.
* a head carrying its own `token_embd`/`output` is preferred over one that borrows them from the
  target, so the choice does not depend on repository listing order. The self contained file loads
  against any build.

Both new rules are gated on the candidate having come from the dedicated folder, and a
directory-prefix match ranks ahead of a dedicated-folder one. So any layout that resolved before this
existed resolves to the same file by construction, and a head sharing the model's own directory keeps
winning even when only the folder holds the exact tag.

That gating is the second commit rather than the first, and `test-model-resolution` is what forced
it. The first version applied both rules to every `mtp-` candidate, which broke `hole default
anchor`: an untagged Q4_K_M primary expects `mtp-model-Q4_0` on quantization distance, and the
preferred quant overrode it to `mtp-model-Q8_0`.

The ranking keys are now a tuple instead of a chained condition. Order and semantics of the existing
keys are unchanged: greater depth, then exact tag match, then smallest quantization distance.

## Verification

Built CPU only from this branch. Selection was read by mapping the blobs the downloader actually
fetched back to repo paths through the HF tree API, so each assertion is about the chosen path rather
than about a download having happened.

`test-model-resolution` covers the new path with no network, on 19 cases, each replayed on the
harness's listing reorderings:

| case | asserts |
| --- | --- |
| `mtp dir flat` | the folder is found from a model at the repo root |
| `mtp dir subdir` | and from a model in a quant subdirectory, choosing the preferred quant and the self contained head |
| `mtp dir exact tag` | an exact tag still beats the preferred quant |
| `mtp dir loses to sibling` | a same-directory head outranks the folder even when only the folder holds the exact tag |
| `mtp dir near miss` | `MTPX/` is not treated as the dedicated folder |

The 14 pre-existing cases are unchanged and still pass.

Live checks against the two real repos, with selection read by mapping the blobs the downloader
actually fetched back to repo paths through the HF tree API, so each assertion is about the chosen
path rather than about a download having happened:

| arm | expected | result |
| --- | --- | --- |
| Flash-Next `:UD-IQ1_S` | Q8_0 head, not Q4_K_M and not a `shared-` one | pass |
| Flash-Next `:BF16` | exact tag wins, bf16 head | pass |
| Flash-Next `:Q8_0` | exact tag wins, Q8_0 head | pass |
| positive control, all three arms | root `mmproj-BF16.gguf` still discovered | pass |
| negative control, shipped `b10715` binary | still finds no MTP file | pass |
| 27B `:UD-IQ1_S` end to end | server starts | pass, it fails to start today |
| `Llama-3.2-1B-Instruct-GGUF:Q8_0`, no `--spec-type` | starts normally | pass |

The 27B arm is the sharpest one: today it fails outright, so a clean start is only reachable if the
sidecar was found. A repo with no MTP folder still errors under `--spec-type draft-mtp`, which is
unchanged pre-existing behaviour, not something this introduces.

`gguf_filename_is_model` already excludes basenames containing `mtp-`, so publishing several
`mtp-*.gguf` files cannot affect primary model selection. Confirmed by `-hf ...:Q8_0` still resolving
the model to `Q8_0/Qwen3.8-Flash-Next-Q8_0-*.gguf`.

## Scope

Fork only for now. `find_best_sibling` is byte identical in ggml-org master and fork master, so this
is an upstream limitation being patched locally rather than a fork divergence being repaired. Worth
proposing upstream separately once it has run in a few nightlies.
