### PR TITLE
unsloth: pin #166, and repin 27941 which is two rounds stale

### DIFF
--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -28,9 +28,10 @@
     "https://github.com/unslothai/llama.cpp/pull/158/commits/abfc45b9cb21eae4848cb82196e659f42c9a8341",
     "https://github.com/unslothai/llama.cpp/pull/157/commits/6c6da89266ba7839d825c9997782af4f4d26b81b",
     "https://github.com/unslothai/llama.cpp/pull/149/commits/b65a2dce12c14a489e19a059cb6ee59112f1b733",
-    "https://github.com/ggml-org/llama.cpp/pull/27941/commits/6b2b85cfbf8a5c612e7d3d4c0ef222e1e58de1c5",
+    "https://github.com/ggml-org/llama.cpp/pull/27941/commits/21c13c48b265e9a76854666b45dba99cdc4e1efa",
     "https://github.com/unslothai/llama.cpp/pull/144/commits/586b15ef8ef9488140c64a71424589cec1a6a9a2",
     "https://github.com/unslothai/llama.cpp/pull/152/commits/258345efa640eb099eb1af3c9ee8f8e6e8e7b0d3",
-    "https://github.com/unslothai/llama.cpp/pull/154/commits/31e432e758f8cc4b2c5f27902721500173bf39db"
+    "https://github.com/unslothai/llama.cpp/pull/154/commits/31e432e758f8cc4b2c5f27902721500173bf39db",
+    "https://github.com/unslothai/llama.cpp/pull/166/commits/2a7b0dbe11597afaa6f1e10ae330a00a58ecd309"
   ]
 }


### PR DESCRIPTION
Two pin changes.

## Pin #166

[#166](https://github.com/unslothai/llama.cpp/pull/166) teaches sidecar discovery to look in a
dedicated `MTP/` folder, which is how both `unsloth/Qwen3.8-27B-GGUF` and
`unsloth/Qwen3.8-Flash-Next-GGUF` publish their draft heads.

Without it, `--spec-type draft-mtp` finds nothing on either repo. On Flash-Next that is a silent
miss. On the 27B it is not silent: with no sidecar found the target is used as its own draft, and
the server refuses to start with `model doesn't contain MTP layers`.

Verified on the shipped `b10715-mix-86bd2d3` prebuilt before the change and on a build of the branch
after it. Details and the full test matrix are in #166.

## Repin 27941

The pin was still `6b2b85cf`. That branch has moved twice since, to `52bc9ff1` and then to
`21c13c48`, so the nightly has been building a commit that predates both of these:

* the `--kv-unified` NaN collapse fix, where a sequence holding fewer than `compress_ratio` cells
  owned no block, its whole bias row was `-inf`, and the softmax produced NaN that then reached
  every other sequence
* the indexer cache `ext.x`/`ext.y` restore fix

Repinned to the current head, `21c13c48`.
