### PR TITLE
unsloth: repin #144, dropping the commit upstream squashed as #28123

### DIFF
--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -28,7 +28,7 @@
     "https://github.com/unslothai/llama.cpp/pull/158/commits/abfc45b9cb21eae4848cb82196e659f42c9a8341",
     "https://github.com/unslothai/llama.cpp/pull/157/commits/6c6da89266ba7839d825c9997782af4f4d26b81b",
     "https://github.com/unslothai/llama.cpp/pull/149/commits/b65a2dce12c14a489e19a059cb6ee59112f1b733",
-    "https://github.com/unslothai/llama.cpp/pull/144/commits/586b15ef8ef9488140c64a71424589cec1a6a9a2",
+    "https://github.com/unslothai/llama.cpp/pull/144/commits/5a08a717da20caa6c5c4dfaa85024adf6fc4e7fa",
     "https://github.com/unslothai/llama.cpp/pull/152/commits/258345efa640eb099eb1af3c9ee8f8e6e8e7b0d3",
     "https://github.com/unslothai/llama.cpp/pull/154/commits/31e432e758f8cc4b2c5f27902721500173bf39db"
   ]


### PR DESCRIPTION
Repins [#144](https://github.com/unslothai/llama.cpp/pull/144) from `586b15ef` to `5a08a717`.

## Why

`586b15ef` has `c6e318e3` ("qwen4exp: cover the recurrent conv state for rollback") as an ancestor.
Upstream took the same change from ServeurpersoCom as
[ggml-org#28123](https://github.com/ggml-org/llama.cpp/pull/28123), squashed to `0eadefeb`, merged
2026-09-01. A squash is not an ancestor of the pin, so the merge re-applies code the base already
has, exactly as the `_doc` block in this file warns.

Measured against three candidate bases:

| base | old pin `586b15ef` | new pin `5a08a717` |
|---|---|---|
| b10715 (last built base) | clean | clean |
| b10731 (first tag with `0eadefeb`) | **CONFLICT** | clean |
| current master `0f3a71be` | **CONFLICT** | clean |

The conflict is in `src/models/qwen4exp.cpp`, and the hunk is our loop against the upstream one:
same logic, `slot`/`n_slots` against `t`/`K`/`s_slot`. Upstream is already at b10759, so the next
nightly would have taken a base at or past b10731 and stopped there.

## What changed on the branch

`c6e318e3` dropped; the branch also moves onto its declared base `base/upstream-662a0b012`, which it
was sitting 6 commits behind. 7 commits become 6, no content edits.

## Verification

Built the nightly-shaped artifact (current master + the new pin, merge clean) with CUDA:

- `test-llama-archs`: qwen4exp OK on B200 (NMSE 8.47e-08) and CPU (0.00e+00), roundtrip OK. Same for
  qwen35, qwen3next and llama.
- MTP end to end, `UD-IQ1_S` + the published `mtp-...-Q8_0.gguf` sidecar, 5 reps on one B200:

| arm | tg t/s | drafted | accepted |
|---|---|---|---|
| MTP off | 78.26 | 0 | 0 |
| MTP on | **115.99** | 227 | 140 |

Every MTP rep beats every off rep. The draft counters are identical in all five reps (61.7%
acceptance), and the off arm is asserted to draft nothing, so this is not an arm that silently ran
without a drafter. The off arm's own spread is wide (70.4 to 85.6) so treat the ratio as approximate;
the deterministic counters are the solid part.

`dflash` has no registered arch-test config, so it prints no rows and is not covered here.
