### PR TITLE
unsloth: stop the preflight dying on the conflict it exists to report

### DIFF
--- a/.github/workflows/unsloth-pin-preflight.yml
+++ b/.github/workflows/unsloth-pin-preflight.yml
@@ -28,11 +28,18 @@ permissions:
   contents: write
   issues: write
 
-# Every run probes the same pins against the same base, so a second one adds
-# nothing and just competes for runners. On 08-04 a dispatch and the schedule
-# sat queued together for an hour. Newest wins: it sees the newest pr-set.json.
+# Two runs of the same ref probe the same pins against the same base, so the
+# second adds nothing and just competes for runners. On 08-04 a dispatch and the
+# schedule sat queued together for an hour. Newest wins: it sees the newest
+# pr-set.json.
+#
+# Per ref, though, not globally. This file also runs on any push that touches
+# pr-set.json, so with one shared group a push to a second branch cancelled the
+# first branch's run: observed on 09-03, where the run that would have said
+# whether a repin fixed the nightly was cancelled by an unrelated branch, and
+# the PR was left showing the failure from before the fix.
 concurrency:
-  group: unsloth-pin-preflight
+  group: unsloth-pin-preflight-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/unsloth-pin-preflight.yml
+++ b/.github/workflows/unsloth-pin-preflight.yml
@@ -49,6 +49,15 @@ jobs:
         id: p
         run: |
           set -uo pipefail
+          # Everything below reports through `status`/`details`, so a death
+          # anywhere else leaves both empty and the alert blank: a red X on a
+          # scheduled run nobody opens. Report the abort through the same
+          # channel as a finding, so the repin bot sees a failure either way.
+          trap 'rc=$?; if [ "$rc" != 0 ]; then {
+                  echo "status=failure"
+                  echo "details<<ALERT_EOF"
+                  echo "The preflight script exited ${rc} before it finished probing, so the pins were not fully checked. See the run log for the last command it reached."
+                  echo "ALERT_EOF"; } >> "$GITHUB_OUTPUT"; fi' EXIT
           AGE_H="${UNSLOTH_LLAMA_MIN_RELEASE_AGE_HOURS:-6}"
           CUTOFF="$(date -u -d "-${AGE_H} hours" +%s)"
           # Same base tag the nightly resolves: newest aged b#### build.
@@ -145,7 +154,16 @@ jobs:
               continue
             fi
             FILES="$(git diff --name-only --diff-filter=U | sed 's/^/  /')"
-            HUNKS="$(git diff --diff-filter=U -U0 2>/dev/null | grep -E '^\+|^-' | grep -vE '^(\+\+\+|---)' | head -20)"
+            # `|| true` is load-bearing, not tidying. GitHub runs a `run:` block
+            # under `bash -e` whatever this script's own `set` line says, `head`
+            # closes the pipe after 20 lines, and pipefail then makes the whole
+            # assignment fail. So on 09-03 the step died right here, on the first
+            # real conflict, with `grep: write error: Broken pipe` and no alert:
+            # the one path this job exists to report was the one it could not
+            # survive. It only fires when the conflict diff is bigger than the
+            # 64 KiB pipe buffer, since a smaller one is written before `head`
+            # ever closes it, which is why most conflicts got reported fine.
+            HUNKS="$(git diff --diff-filter=U -U0 2>/dev/null | grep -E '^\+|^-' | grep -vE '^(\+\+\+|---)' | head -20 || true)"
             git merge --abort 2>/dev/null
             PROBLEMS="${PROBLEMS}- \`${SRC}#${NUM}\` (\`${SHA:0:10}\`) does not merge onto \`${BASE}\` + the pins before it.\n\n  Conflicting files:\n\n\`\`\`\n${FILES}\n\`\`\`\n\n  <details><summary>conflict hunks</summary>\n\n\`\`\`diff\n${HUNKS}\n\`\`\`\n\n  </details>\n"
             # Stop here, like resolve does. Probing later pins against a tree


### PR DESCRIPTION
The pin preflight runs the nightly's merge seven hours early so a broken pin is a morning annotation instead of 39 wasted build jobs. On 09-03 a pin genuinely stopped merging, which is the one thing this job exists for, and [the run](https://github.com/unslothai/llama.cpp/actions/runs/33750551142/job/100632869775) produced no alert at all:

```
ok unslothai/llama.cpp#107
grep: write error: Broken pipe
##[error]Process completed with exit code 2
```

## Why

The conflict-hunk line ends in `| head -20`. `head` closes the pipe after twenty lines, the upstream `grep` takes SIGPIPE, and pipefail turns that into a failed assignment. GitHub runs a `run:` block under `bash -e` no matter what the script's own `set` line says, so the step dies on that line, before `PROBLEMS` reaches `$GITHUB_OUTPUT`. No alert, no details, and `unsloth-repin-bot.yml` waits on a failed `workflow_run` that never comes.

It only fires when the conflict diff is larger than the 64 KiB pipe buffer, because anything smaller is written before `head` exits. That is why conflicts have been reported correctly until now, and why the one time it mattered most was a big one.

## The fix

- `|| true` on that pipeline. A closed pipe here means we asked for twenty lines and got them.
- An `EXIT` trap reporting any other unexpected death through the same `status` / `details` channel. Everything in the step reports that way, so a death anywhere else leaves both outputs empty, renders a blank alert, and leaves a red X on a scheduled run nobody opens. The trap is the general answer; the `|| true` is the specific one.

## Verified

Against a real conflicting merge whose diff is over the pipe buffer, running the exact lines from the workflow rather than a paraphrase of them:

| | step exit | alert |
|---|---|---|
| before | 141 | none, both outputs empty |
| trap only | 141 | reports that the script aborted |
| both | 0 | twenty hunk lines captured, probing continues |

And with a conflict under 64 KiB, all three pass, which is the case that hid this.
