### PR TITLE
server: shift the speculative batch indices on the sub-batch retry

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -3754,8 +3754,27 @@ private:
             }
             if (first < off + n_batch_tokens && last >= off + n_batch_tokens && first >= off) {
                 // Split anyway: only reachable when the retry ladder drove n_batch below
-                // one block. Report it rather than sample from logits that do not exist.
-                throw std::runtime_error(string_format("speculative block [%d, %d] straddles the current sub-batch [%d, %d)", first, last, off, off + n_batch_tokens));
+                // one block, i.e. a cache so full that the view is narrower than the draft.
+                //
+                // Give up the DRAFT rather than the conversation. spec_i_batch[0] is the
+                // index of the token that was actually sampled last round, not a draft
+                // (see the push_back loop in server_slot::add_to_batch), and it is inside
+                // this view, so the slot can still sample its next token the ordinary way.
+                // The drafts behind it are a prediction; losing them costs this one step
+                // its speedup.
+                //
+                // Throwing here instead calls abort_all_slots, which ends EVERY
+                // conversation on the server because one of them was drafting into a full
+                // cache. Measured on the branch's own base: four chats, four errors, all of
+                // them this. It is the same failure shape as the KV-full send_error path
+                // that unslothai/llama.cpp#183 narrows.
+                SRV_WRN("speculative block [%d, %d] does not fit the current sub-batch [%d, %d); "
+                        "dropping the draft for slot %d and sampling one token\n",
+                        first, last, off, off + n_batch_tokens, slot.id);
+                slot.spec_draft.clear();
+                slot.spec_i_batch.clear();
+                slot.i_batch = first;
+                return;
             }
         });
 

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2752,7 +2752,39 @@ private:
         int32_t off_next = 0;
         int32_t n_batch = llama_n_batch(ctx_tgt);
         for (int32_t off = 0; off < batch.size(); off = off_next) {
-            const int32_t n_tokens = std::min(n_batch, batch.size() - off);
+            int32_t n_tokens = std::min(n_batch, batch.size() - off);
+
+            // Do not let the view end in the middle of a slot's speculative block.
+            //
+            // A slot's spec_i_batch entries are contiguous (see the push_back loop where
+            // they are built), and common_sampler_sample_and_accept_n needs the logits
+            // for all of them from ONE decode. A view that cuts through a block leaves
+            // half its logits in a decode that has already happened, which is why
+            // post_decode had no option but to abort the slots. Ending the view just
+            // before the block instead costs one extra decode call and keeps the block
+            // whole. See https://github.com/ggml-org/llama.cpp/issues/24840
+            if (n_tokens < batch.size() - off) {
+                const int32_t view_end = off + n_tokens;
+                int32_t cut = view_end;
+                iterate(slots, [&](server_slot & slot) {
+                    if (slot.spec_i_batch.empty()) {
+                        return;
+                    }
+                    const int32_t first = slot.spec_i_batch.front();
+                    const int32_t last  = slot.spec_i_batch.back();
+                    // straddles the end of the view: stop short of it
+                    if (first > off && first < view_end && last >= view_end) {
+                        cut = std::min(cut, first);
+                    }
+                });
+                n_tokens = cut - off;
+                // A block longer than the whole view cannot be kept whole by cutting.
+                // That needs n_batch below n_draft + 1, which only the retry ladder
+                // reaches; fall back to the original view and let post_decode report it.
+                if (n_tokens <= 0) {
+                    n_tokens = std::min(n_batch, batch.size() - off);
+                }
+            }
             try {
                 scoped_timer t(t_decode, n_decode);
                 // TODO @ngxson : maybe handle n_batch == 1 here instead of inside decode()
@@ -3671,13 +3703,35 @@ private:
             return idx >= off && idx < off + n_batch_tokens;
         };
 
-        // TODO @ngxson : it's tricky to make sub-batch compatible with common_sampler_sample_and_accept_n,
-        // so for now we will throw an error in this case: https://github.com/ggml-org/llama.cpp/issues/24840
-        iterate(slots, [&](server_slot & slot) {
-            for (auto & i : slot.spec_i_batch) {
+        // A slot whose speculative block is not in THIS view is not an error: the batch
+        // was split, and the block belongs to another view, which will sample it when it
+        // is decoded. The loop that builds the views keeps each block whole, so a block
+        // is either entirely inside or entirely outside.
+        //
+        // Aborting every slot here instead is https://github.com/ggml-org/llama.cpp/issues/24840,
+        // reached whenever a KV-full decode halves n_batch, which is exactly when several
+        // long conversations share one cache.
+        auto spec_is_inside_view = [&](const server_slot & slot) {
+            for (const auto & i : slot.spec_i_batch) {
                 if (!is_inside_view(i)) {
-                    throw std::runtime_error(string_format("speculative batch index %d is not inside the current sub-batch [%d, %d)", i, off, off + n_batch_tokens));
+                    return false;
                 }
+            }
+            return true;
+        };
+        iterate(slots, [&](server_slot & slot) {
+            if (slot.spec_i_batch.empty() || spec_is_inside_view(slot)) {
+                return;
+            }
+            const int32_t first = slot.spec_i_batch.front();
+            const int32_t last  = slot.spec_i_batch.back();
+            if (first >= off && last < off + n_batch_tokens) {
+                return;
+            }
+            if (first < off + n_batch_tokens && last >= off + n_batch_tokens && first >= off) {
+                // Split anyway: only reachable when the retry ladder drove n_batch below
+                // one block. Report it rather than sample from logits that do not exist.
+                throw std::runtime_error(string_format("speculative batch index %d is not inside the current sub-batch [%d, %d)", last, off, off + n_batch_tokens));
             }
         });
 
@@ -3785,6 +3839,13 @@ private:
                 return;
             }
 
+            // Its logits are in a different view of this batch, so it is sampled when
+            // that view is decoded, not now. Without this the shift below produces
+            // negative indices and reads whatever is at the front of the wrong view.
+            if (!spec_is_inside_view(slot)) {
+                return;
+            }
+
             // save the original draft size
             const size_t n_draft = slot.spec_draft.size();
 
@@ -3795,7 +3856,17 @@ private:
                 common_sampler_ptr smpl_save(common_sampler_clone(slot.smpl.get()));
 
                 GGML_ASSERT(slot.spec_i_batch.size() == n_draft + 1);
-                auto accepted = common_sampler_sample_and_accept_n(slot.smpl.get(), slot.ctx_tgt, slot.spec_i_batch, slot.spec_draft);
+                // Shifted according to the current sub-batch, exactly as tok_idx is for
+                // the non-speculative path above. These are indices into the batch that
+                // was just decoded, and that batch is the VIEW, not the whole batch.
+                // Passing the absolute indices is the second half of #24840: with off
+                // non-zero they address the wrong logits.
+                std::vector<int32_t> spec_i_view;
+                spec_i_view.reserve(slot.spec_i_batch.size());
+                for (const auto & i : slot.spec_i_batch) {
+                    spec_i_view.push_back(i - off);
+                }
+                auto accepted = common_sampler_sample_and_accept_n(slot.smpl.get(), slot.ctx_tgt, spec_i_view, slot.spec_draft);
                 slot.spec_i_batch.clear();
 
                 GGML_ASSERT(accepted.size() >= 1);

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -3644,6 +3644,22 @@ private:
             // retry with half the batch size to try to find a free slot in the KV cache
             if (!try_clear_idle_slots()) {
                 n_batch /= 2;
+
+                // ... but never below one speculative block. A slot's spec_i_batch
+                // entries all need logits from ONE decode, so a view narrower than a
+                // block cannot serve it however the view is positioned, and post_decode
+                // is left with nothing to do but abort every slot on the server.
+                //
+                // Of 78 occurrences recorded in production logs, 30 were exactly this:
+                // a block starting at the view's own offset and reaching past its end,
+                // with views of 1 and 2 against a 3-index block. Halving past that point
+                // buys no memory worth having -- the difference is a couple of cells --
+                // and costs every conversation in flight.
+                int32_t n_spec_min = 1;
+                iterate(slots, [&](server_slot & slot) {
+                    n_spec_min = std::max(n_spec_min, (int32_t) slot.spec_i_batch.size());
+                });
+                n_batch = std::max(n_batch, n_spec_min);
             }
 
             SRV_WRN("failed to find free space in the KV cache, retrying with smaller batch size, off = %d, n_batch = %d, ret = %d\n", off, n_batch, ret);
@@ -3731,7 +3747,7 @@ private:
             if (first < off + n_batch_tokens && last >= off + n_batch_tokens && first >= off) {
                 // Split anyway: only reachable when the retry ladder drove n_batch below
                 // one block. Report it rather than sample from logits that do not exist.
-                throw std::runtime_error(string_format("speculative batch index %d is not inside the current sub-batch [%d, %d)", last, off, off + n_batch_tokens));
+                throw std::runtime_error(string_format("speculative block [%d, %d] straddles the current sub-batch [%d, %d)", first, last, off, off + n_batch_tokens));
             }
         });
 

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -3643,6 +3643,7 @@ private:
 
             // retry with half the batch size to try to find a free slot in the KV cache
             if (!try_clear_idle_slots()) {
+                const int32_t n_batch_prev = n_batch;
                 n_batch /= 2;
 
                 // ... but never below one speculative block. A slot's spec_i_batch
@@ -3659,7 +3660,14 @@ private:
                 iterate(slots, [&](server_slot & slot) {
                     n_spec_min = std::max(n_spec_min, (int32_t) slot.spec_i_batch.size());
                 });
-                n_batch = std::max(n_batch, n_spec_min);
+                // Pause AT the floor, once, rather than clamping to it forever. The
+                // ladder reaching n_batch == 1 is what terminates this retry: decode()
+                // reports "Context size has been exceeded" only for n_batch == 1, so a
+                // hard clamp above 1 turns a cache that genuinely cannot fit anything
+                // into an infinite retry loop. Halving from the floor continues past it.
+                if (n_batch < n_spec_min && n_batch_prev > n_spec_min) {
+                    n_batch = n_spec_min;
+                }
             }
 
             SRV_WRN("failed to find free space in the KV cache, retrying with smaller batch size, off = %d, n_batch = %d, ret = %d\n", off, n_batch, ret);


### PR DESCRIPTION
`--spec-type draft-mtp` with `--parallel N --kv-unified` throws
`speculative batch index %d is not inside the current sub-batch` and kills the request,
whenever the KV cache is full enough that llama-server has to fall back to a smaller batch.

## The bug

When a decode fails to fit, the server retries the same batch in smaller pieces. On that
path it already does two things for `slot.i_batch`: skips a slot whose index lies outside
the current view, and shifts the index by the view's offset, with the comment "shifted
according to the current sub-batch". It does neither for `slot.spec_i_batch`.

That asymmetry is the whole defect. The speculative indices stay absolute while the view
they are read against becomes relative, so the bounds check fires on indices that were
correct when they were recorded.

The check is also the only thing standing between this and a wrong answer: with it removed
the same indices would sample from another slot's logits.

## What this changes

Three commits, smallest first:

1. Keep a speculative block inside one sub-batch, and shift its indices. A slot's
   `spec_i_batch` entries are contiguous, so a block that would straddle the end of a view
   cuts the view short instead, and the surviving indices are shifted by the offset exactly
   as `i_batch` is.
2. Never halve `n_batch` below one speculative block. The retry ladder halves the batch
   each time; without a floor it can end up smaller than a single block, which no amount of
   cutting can fit.
3. Do not let that floor trap the ladder. A block starting at the view's own offset and
   reaching past its end cannot be cut, so the floor must not stop the ladder from
   descending, or the retry never terminates.

The error message that remains is deliberately different: a block that genuinely cannot be
placed now says `speculative block [%d, %d] straddles the current sub-batch [%d, %d)`, so
the two situations are distinguishable in a log.

## Measurement

Two independent runs, because they answer different questions.

**The branch, against its own base.** Both arms built from this tree, differing only by these
three commits, run as a bare llama-server with no caller in front of it. Four concurrent
chats, `-c 16384 --parallel 4 --kv-unified --spec-type draft-mtp --spec-draft-n-max 2`,
3000-token prompts, driven until the pool overflows:

| arm | `is not inside the current sub-batch` | `straddles the current sub-batch` | chats lost |
|---|---|---|---|
| master | 8 | 0 | 4 of 4 |
| this branch | **0** | 4 | 4 of 4 |

**The same change on the base Unsloth Studio actually ships** (b10715-mix, 92cedc867),
interleaved control and treatment over two rounds with the order reversed, each arm confirmed
from `/proc/PID/maps` of the live server: 18 occurrences of the original error on control,
**0** on treatment.

## What this does and does not fix

It removes the bounds violation this issue is about. It is NOT a complete fix, and the table
above says so: two of the four chats still fail on this branch, with a different error.

The remaining case is a speculative block that begins exactly at the view's own offset and
reaches past its end, `[4, 5]` against `[4, 5)`. It cannot be cut, because cutting the view
before it leaves an empty view, and the retry ladder has already driven `n_batch` below one
block by the time it appears. The code reports it rather than sampling from logits that were
never computed, which is the safe half of the choice.

Sampling only the part of the block inside the view would look like an obvious fix and is
not one: the drafted tokens beyond the view are already in the batch at positions this
sub-batch does not decode, so discarding them mid-flight risks leaving stale cells, and the
failure mode of getting that wrong is a wrong answer rather than an error. I have not
convinced myself of a correct version, so I have not written one.

What the change buys, then, is narrower than "the bug is gone" and still worth having:

  * the failures that remain are a distinct, self-describing message, so the two situations
    can be told apart in a log rather than presenting as one bounds error;
  * on Studio's own base, under its own load, the count went 18 to 0, because the cases it
    handles are the common ones;
  * for a caller that keeps the cache below the line, as Unsloth Studio's preemption now
    does, none of these are reached at all. The value there is that the residual overshoot
    degrades to `Context size has been exceeded`, which a caller can see coming.

The natural next step is to make the unfittable case terminate that one slot through the
ordinary context-exceeded path instead of throwing, which composes with
unslothai/llama.cpp#183. That is a separate change and is not in this PR.

## Notes

`server-context.cpp` only. Builds clean, and the measurements above are from that build. No
effect without `--spec-type`: every new branch is inside a block guarded on a non-empty
`spec_i_batch`.

There is no automated CI on this PR, and that is expected rather than a gap: the only
`pull_request`-triggered workflow in this fork is the `pr-set.json` lint, which is gated on
paths this change does not touch. Prebuild checks arrive when a PR is pinned into
`scripts/unsloth/pr-set.json`, which also ships it into the nightly builds, so I have left
that decision to a maintainer.
