### PR TITLE
server: on a full KV cache, terminate one slot instead of every slot

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2743,6 +2743,12 @@ private:
             }
         });
 
+        // `batch.slot_batched` may be the victim, and is intentionally left alone. It is
+        // not dereferenced inside the decode loop -- the lora and embedding settings it
+        // supplies were applied once before the loop -- and `slots` is a fixed vector, so
+        // release() does not destroy the object and the pointer does not dangle. Every
+        // survivor passed can_batch_with() against it, so those settings remain correct
+        // for the tokens that are left.
         return true;
     }
 

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2697,14 +2697,33 @@ private:
         std::vector<int32_t> remap(batch.tokens.size(), -1);
         std::vector<server_batch::token> kept;
         kept.reserve(batch.tokens.size());
+        // In embd mode `embd` is a flat n_embd-per-token array running parallel to
+        // `tokens`, and render() hands embd.data() straight to the batch. Compacting one
+        // without the other misaligns every embedding after the first removal, silently.
+        std::vector<float> kept_embd;
+        if (batch.has_embd) {
+            kept_embd.reserve(batch.embd.size());
+        }
         for (int32_t i = 0; i < (int32_t) batch.tokens.size(); i++) {
             if (i >= off && batch.tokens[i].id_slot == victim_id) {
                 continue;
             }
             remap[i] = (int32_t) kept.size();
             kept.push_back(batch.tokens[i]);
+            if (batch.has_embd) {
+                const size_t stride = (size_t) batch.n_embd;
+                const size_t begin  = (size_t) i * stride;
+                if (begin + stride <= batch.embd.size()) {
+                    kept_embd.insert(kept_embd.end(),
+                                     batch.embd.begin() + begin,
+                                     batch.embd.begin() + begin + stride);
+                }
+            }
         }
         batch.tokens = std::move(kept);
+        if (batch.has_embd) {
+            batch.embd = std::move(kept_embd);
+        }
         batch.batch_rendered = false;
         batch.render();
 

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2644,6 +2644,89 @@ private:
         }
     }
 
+    // Terminate ONE slot to make room, rather than every conversation on the server.
+    //
+    // This is the TODO sitting above the context-exceeded handler: "try to terminate only
+    // the largest active slot/sequence and continue with the rest / need to remove the
+    // tokens from the current batch too". The second sentence is the hard part, and it is
+    // tractable here only because `off` splits the batch cleanly: everything at index
+    // `>= off` has not been decoded yet, by construction of the loop in update_slots.
+    //
+    // Safe to leave the survivors running because a `ret == 1` decode committed nothing.
+    // That return comes from LLAMA_MEMORY_STATUS_FAILED_PREPARE in llama_context::decode,
+    // before output_reserve, before the sampling transaction opens and before any compute,
+    // so no cells were assigned and no survivor's KV was touched by the failed call.
+    //
+    // Returns false when there is nobody to spare, and then the caller's original
+    // behaviour -- error everyone, which is now just the one slot -- is the correct one.
+    bool terminate_one_slot(int32_t off, const std::string & reason) {
+        server_slot * victim = nullptr;
+        int n_processing = 0;
+        iterate(slots, [&](server_slot & slot) {
+            if (!slot.is_processing()) {
+                return;
+            }
+            n_processing++;
+            // Largest sequence, as the TODO says: on a crash path the figure that matters
+            // is cells freed per conversation lost. (Scheduling preemption elsewhere is
+            // better served by newest-first; this is not that, and the two should not be
+            // made to agree for the sake of it.)
+            if (victim == nullptr || slot.prompt.n_tokens() > victim->prompt.n_tokens()) {
+                victim = &slot;
+            }
+        });
+
+        if (victim == nullptr || n_processing <= 1) {
+            return false;
+        }
+
+        const int32_t victim_id = victim->id;
+
+        SRV_WRN("terminating slot %d (%d tokens) to free space, %d other slot(s) continue\n",
+                victim_id, (int) victim->prompt.n_tokens(), n_processing - 1);
+
+        send_error(*victim, reason);
+        victim->release();
+        // seq_rm inside frees this sequence's cells, which is the entire point of the
+        // exercise; the tokens it already decoded below `off` go with them.
+        victim->prompt_clear();
+        victim->i_batch = -1;
+        victim->spec_i_batch.clear();
+
+        // Drop the victim's UNDECODED entries and remember where every survivor moved to.
+        std::vector<int32_t> remap(batch.tokens.size(), -1);
+        std::vector<server_batch::token> kept;
+        kept.reserve(batch.tokens.size());
+        for (int32_t i = 0; i < (int32_t) batch.tokens.size(); i++) {
+            if (i >= off && batch.tokens[i].id_slot == victim_id) {
+                continue;
+            }
+            remap[i] = (int32_t) kept.size();
+            kept.push_back(batch.tokens[i]);
+        }
+        batch.tokens = std::move(kept);
+        batch.batch_rendered = false;
+        batch.render();
+
+        // render() rebuilds the batch wholesale from `tokens`, so every surviving entry
+        // after a removed one shifts DOWN. `i_batch` and `spec_i_batch` are absolute
+        // indices into that batch and must move with it. Skipping this does not throw:
+        // post_decode goes on to sample from whatever logits now sit at the stale index,
+        // silently, which is a worse outcome than the crash being fixed here.
+        iterate(slots, [&](server_slot & slot) {
+            if (slot.i_batch >= 0 && slot.i_batch < (int32_t) remap.size()) {
+                slot.i_batch = remap[slot.i_batch];
+            }
+            for (auto & i : slot.spec_i_batch) {
+                if (i >= 0 && i < (int32_t) remap.size()) {
+                    i = remap[i];
+                }
+            }
+        });
+
+        return true;
+    }
+
     // @ngxson : for debugging only
     int64_t t_pre_decode  = 0;
     int64_t t_decode      = 0;
@@ -3592,6 +3675,18 @@ private:
 
                 if (!err.empty()) {
                     SRV_ERR("%s off = %d, n_batch = %d, ret = %d\n", err.c_str(), off, n_batch, ret);
+
+                    // Out of KV space, which is a capacity problem with one sequence too
+                    // many in it, not a fault in every conversation on the server. Free
+                    // the largest and carry on with the rest. Only for ret == 1: an
+                    // invalid batch or a compute error says nothing about capacity, and
+                    // dropping a slot would not address either.
+                    if (ret == 1 && n_batch == 1 && terminate_one_slot(off, err)) {
+                        // A whole sequence just went, so the halving that got us down to
+                        // 1 no longer describes what will fit.
+                        n_batch = llama_n_batch(ctx_tgt);
+                        return false; // retry, with the batch minus that slot
+                    }
 
                     for (auto & slot : slots) {
                         if (slot.is_processing()) {


### PR DESCRIPTION
With `--parallel N --kv-unified`, one overflowing request kills every request that happens
to be decoding at the time.

## The bug

`--kv-unified` gives N slots one shared pool of N cells while telling each slot it has all
of them. That is the point: it lets a single long chat use the whole context. It also means
the pool can run out while several slots are mid-answer.

When it does, the server calls `send_error` on **every** processing slot. A user whose chat
had nothing to do with the overflow loses their answer because somebody else's grew.

## What this changes

Terminate ONE slot and let the rest carry on. The victim is the slot holding the most
cells, so the eviction frees as much as possible per turn lost, and one slot always makes
progress rather than N slots repeatedly failing together.

Three commits:

1. Terminate one slot instead of every slot, with the batch compaction and index remap that
   requires. Removing one slot's entries from the middle of a batch moves the entries after
   it, so `i_batch` and `spec_i_batch` are remapped for the slots that shift down.
2. Compact `embd` alongside `tokens`. This one is mine: the first version compacted the
   token array and left the embedding array, which is a flat `n_embd`-per-token buffer, so
   a multimodal batch would have been fed embeddings misaligned to their tokens. Silently.
3. A note on why `slot_batched` is safe to leave pointing at a terminated slot.

The remap is checked by brute force over 20000 randomly shaped batches, against the
invariant that entries below the removal point never move.

## Notes

`server-context.cpp` only, and only inside the branch that already handled this case by
failing everyone. Compiles clean against the repo's own `compile_commands.json`.

Unlike the sibling fix in unslothai/llama.cpp#182, I have not been able to put a number on
this one: reaching it requires the pool to overflow with more than one slot decoding, and on
the configuration I have, the speculative index bug in that PR fires first. The change is
argued from the code path rather than from a measurement, which is why it is a separate PR.

There is also a case the two PRs would compose on. #182 leaves one situation throwing: a
speculative block that begins at the view offset and reaches past its end cannot be cut, and
it reports rather than sampling logits that were never computed. Terminating that one slot,
which is what this PR makes possible, is a better answer than either throwing or killing
everybody. I have not written that change here; it belongs after both of these land.

No automated CI runs on this PR, which is expected rather than missing: the only
`pull_request`-triggered workflow in this fork is the `pr-set.json` lint, gated on paths this
change does not touch. Prebuild checks arrive when a PR is pinned into
`scripts/unsloth/pr-set.json`, which also ships it, so I have left that to a maintainer.
