### PR TITLE
server: --pipeline-groups, run the slots over several contexts of one model

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2539,6 +2539,17 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
                 params.n_parallel = value;
             }
         ).set_env("LLAMA_ARG_N_PARALLEL").set_examples({LLAMA_EXAMPLE_SERVER}));
+        add_opt(common_arg(
+            {"--pipeline-groups"}, "N",
+            string_format("run the server slots over N independent contexts of one model, so one "
+                          "group decodes while another is between steps (default: %d)", params.n_pipeline_groups),
+            [](common_params & params, int value) {
+                if (value < 1) {
+                    throw std::invalid_argument("error: --pipeline-groups must be >= 1\n");
+                }
+                params.n_pipeline_groups = value;
+            }
+        ).set_env("LLAMA_ARG_PIPELINE_GROUPS").set_examples({LLAMA_EXAMPLE_SERVER}));
     } else {
         add_opt(common_arg(
             {"-np", "--parallel"}, "N",

--- a/common/common.h
+++ b/common/common.h
@@ -465,6 +465,8 @@ struct common_params {
     int32_t n_gpu_layers       = -1;    // number of layers to store in VRAM, -1 is auto, <= -2 is all
     int32_t main_gpu           = 0;     // the GPU that is used for scratch and small tensors
     float   tensor_split[128]  = {0};   // how split tensors should be distributed across GPUs
+    int32_t n_pipeline_groups  = 1;     // llama-server: run the slots over N independent contexts
+
     bool    fit_params         = true;  // whether to fit unset model/context parameters to free device memory
     bool    fit_params_print   = false; // print the estimated required memory to run the model
     int32_t fit_params_min_ctx = 4096;  // minimum context size to set when trying to reduce memory use

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -212,7 +212,7 @@ struct ggml_backend_rpc_device_context {
     uint32_t    device;
     std::string name;
     std::string description;
-    uint64_t    last_graph_uid;
+    // note: the uid of the last graph stored on the server is tracked per connection, see socket_t
 };
 
 struct ggml_backend_rpc_buffer_type_context {
@@ -300,7 +300,8 @@ static bool parse_endpoint(const std::string & endpoint, std::string & host, int
 
 // RPC request : | rpc_cmd (1 byte) | request_size (8 bytes) | request_data (request_size bytes) |
 // No response
-static bool send_rpc_cmd(socket_ptr sock, enum rpc_cmd cmd, const void * input, size_t input_size) {
+// writes one whole message; the caller must hold sock->conn.mtx_send
+static bool send_rpc_cmd_locked(socket_ptr sock, enum rpc_cmd cmd, const void * input, size_t input_size) {
     uint8_t cmd_byte = cmd;
     if (!sock->send_data(&cmd_byte, sizeof(cmd_byte))) {
         return false;
@@ -314,12 +315,61 @@ static bool send_rpc_cmd(socket_ptr sock, enum rpc_cmd cmd, const void * input, 
     return sock->flush();
 }
 
+static bool send_rpc_cmd(socket_ptr sock, enum rpc_cmd cmd, const void * input, size_t input_size) {
+    std::lock_guard<std::mutex> lock(sock->conn.mtx_send);
+    return send_rpc_cmd_locked(sock, cmd, input, input_size);
+}
+
+// Reserves this thread's place in the response order of a connection. The server answers the
+// commands of one connection strictly in the order it received them, so the n-th response
+// belongs to the n-th response-bearing request that was written to the socket. The ticket is
+// taken while mtx_send is still held by the sender, and always released, so a failed send
+// cannot leave the later waiters stuck.
+struct rpc_response_ticket {
+    rpc_conn_state & conn;
+    uint64_t         seq;
+
+    // must be constructed with conn.mtx_send held
+    explicit rpc_response_ticket(rpc_conn_state & conn) : conn(conn) {
+        std::lock_guard<std::mutex> lock(conn.mtx_seq);
+        seq = conn.seq_next++;
+    }
+
+    void wait() {
+        std::unique_lock<std::mutex> lock(conn.mtx_seq);
+        conn.cv_seq.wait(lock, [this] { return conn.seq_serving == seq; });
+    }
+
+    ~rpc_response_ticket() {
+        std::lock_guard<std::mutex> lock(conn.mtx_seq);
+        conn.seq_serving = seq + 1;
+        conn.cv_seq.notify_all();
+    }
+};
+
 // RPC request : | rpc_cmd (1 byte) | request_size (8 bytes) | request_data (request_size bytes) |
 // RPC response: | response_size (8 bytes) | response_data (response_size bytes) |
 static bool send_rpc_cmd(socket_ptr sock, enum rpc_cmd cmd, const void * input, size_t input_size, void * output, size_t output_size) {
-    if (!send_rpc_cmd(sock, cmd, input, input_size)) {
+    std::unique_ptr<rpc_response_ticket> ticket;
+    bool failed = false;
+    {
+        std::lock_guard<std::mutex> lock(sock->conn.mtx_send);
+        ticket.reset(new rpc_response_ticket(sock->conn));
+        if (!send_rpc_cmd_locked(sock, cmd, input, input_size)) {
+            // still take our turn, so the ticket is released in order and no later waiter is
+            // woken with a response that is not theirs
+            failed = true;
+        }
+    }
+
+    if (failed) {
+        ticket->wait();
         return false;
     }
+
+    // the response is read outside mtx_send, so the other threads can keep submitting
+    ticket->wait();
+
     uint64_t out_size;
     if (!sock->recv_data(&out_size, sizeof(out_size))) {
         return false;
@@ -731,21 +781,31 @@ static enum ggml_status ggml_backend_rpc_graph_compute(ggml_backend_t backend, g
     ggml_backend_rpc_device_context * rpc_dev_ctx = (ggml_backend_rpc_device_context *)rpc_dev->context;
 
     GGML_ASSERT(cgraph->n_nodes > 0);
-    bool reuse = cgraph->uid != 0 && rpc_dev_ctx->last_graph_uid == cgraph->uid;
-    if (reuse) {
+    GGML_UNUSED(rpc_dev_ctx);
+
+    auto sock = get_socket(rpc_ctx->endpoint);
+
+    // The graph stored by RPC_CMD_GRAPH_COMPUTE lives on the server per connection and device,
+    // and one connection is shared by every backend of this endpoint - including the backends of
+    // other llama_contexts. So the uid of the last graph sent has to be tracked per connection,
+    // and the check has to happen under the same lock as the send, or a RECOMPUTE could re-run
+    // the graph another context stored in between.
+    std::unique_lock<std::mutex> lock(sock->conn.mtx_send);
+
+    auto & last_uid = sock->conn.last_graph_uid[rpc_ctx->device];
+    if (cgraph->uid != 0 && last_uid == cgraph->uid) {
         rpc_msg_graph_recompute_req request;
         request.device = rpc_ctx->device;
-        auto sock = get_socket(rpc_ctx->endpoint);
-        bool status = send_rpc_cmd(sock, RPC_CMD_GRAPH_RECOMPUTE, &request, sizeof(request));
+        bool status = send_rpc_cmd_locked(sock, RPC_CMD_GRAPH_RECOMPUTE, &request, sizeof(request));
         RPC_STATUS_ASSERT(status);
-    } else {
-        rpc_dev_ctx->last_graph_uid = cgraph->uid;
-        std::vector<uint8_t> input;
-        serialize_graph(rpc_ctx->device, cgraph, input);
-        auto sock = get_socket(rpc_ctx->endpoint);
-        bool status = send_rpc_cmd(sock, RPC_CMD_GRAPH_COMPUTE, input.data(), input.size());
-        RPC_STATUS_ASSERT(status);
+        return GGML_STATUS_SUCCESS;
     }
+
+    last_uid = cgraph->uid;
+    std::vector<uint8_t> input;
+    serialize_graph(rpc_ctx->device, cgraph, input);
+    bool status = send_rpc_cmd_locked(sock, RPC_CMD_GRAPH_COMPUTE, input.data(), input.size());
+    RPC_STATUS_ASSERT(status);
     return GGML_STATUS_SUCCESS;
 }
 
@@ -2044,7 +2104,6 @@ ggml_backend_reg_t ggml_backend_rpc_add_server(const char * endpoint) {
             /* .device      = */    ind,
             /* .name        = */    dev_name,
             /* .description = */    dev_desc,
-            /* .last_graph_uid = */ 0,
         };
 
         ggml_backend_dev_t dev = new ggml_backend_device {

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -212,7 +212,6 @@ struct ggml_backend_rpc_device_context {
     uint32_t    device;
     std::string name;
     std::string description;
-    // note: the uid of the last graph stored on the server is tracked per connection, see socket_t
 };
 
 struct ggml_backend_rpc_buffer_type_context {
@@ -300,7 +299,7 @@ static bool parse_endpoint(const std::string & endpoint, std::string & host, int
 
 // RPC request : | rpc_cmd (1 byte) | request_size (8 bytes) | request_data (request_size bytes) |
 // No response
-// writes one whole message; the caller must hold sock->conn.mtx_send
+// the caller must hold sock->conn.mtx_send
 static bool send_rpc_cmd_locked(socket_ptr sock, enum rpc_cmd cmd, const void * input, size_t input_size) {
     uint8_t cmd_byte = cmd;
     if (!sock->send_data(&cmd_byte, sizeof(cmd_byte))) {
@@ -320,11 +319,7 @@ static bool send_rpc_cmd(socket_ptr sock, enum rpc_cmd cmd, const void * input, 
     return send_rpc_cmd_locked(sock, cmd, input, input_size);
 }
 
-// Reserves this thread's place in the response order of a connection. The server answers the
-// commands of one connection strictly in the order it received them, so the n-th response
-// belongs to the n-th response-bearing request that was written to the socket. The ticket is
-// taken while mtx_send is still held by the sender, and always released, so a failed send
-// cannot leave the later waiters stuck.
+// the server answers one connection strictly in request order
 struct rpc_response_ticket {
     rpc_conn_state & conn;
     uint64_t         seq;
@@ -356,8 +351,7 @@ static bool send_rpc_cmd(socket_ptr sock, enum rpc_cmd cmd, const void * input, 
         std::lock_guard<std::mutex> lock(sock->conn.mtx_send);
         ticket.reset(new rpc_response_ticket(sock->conn));
         if (!send_rpc_cmd_locked(sock, cmd, input, input_size)) {
-            // still take our turn, so the ticket is released in order and no later waiter is
-            // woken with a response that is not theirs
+            // still take our turn, or a later waiter is woken with a response that is not theirs
             failed = true;
         }
     }
@@ -367,7 +361,6 @@ static bool send_rpc_cmd(socket_ptr sock, enum rpc_cmd cmd, const void * input, 
         return false;
     }
 
-    // the response is read outside mtx_send, so the other threads can keep submitting
     ticket->wait();
 
     uint64_t out_size;
@@ -785,11 +778,8 @@ static enum ggml_status ggml_backend_rpc_graph_compute(ggml_backend_t backend, g
 
     auto sock = get_socket(rpc_ctx->endpoint);
 
-    // The graph stored by RPC_CMD_GRAPH_COMPUTE lives on the server per connection and device,
-    // and one connection is shared by every backend of this endpoint - including the backends of
-    // other llama_contexts. So the uid of the last graph sent has to be tracked per connection,
-    // and the check has to happen under the same lock as the send, or a RECOMPUTE could re-run
-    // the graph another context stored in between.
+    // the stored graph is per connection and device, and other llama_contexts share the connection:
+    // the uid check must stay under mtx_send, or RECOMPUTE re-runs a graph stored in between
     std::unique_lock<std::mutex> lock(sock->conn.mtx_send);
 
     auto & last_uid = sock->conn.last_graph_uid[rpc_ctx->device];

--- a/ggml/src/ggml-rpc/transport.h
+++ b/ggml/src/ggml-rpc/transport.h
@@ -1,8 +1,11 @@
 #pragma once
 
+#include <condition_variable>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <mutex>
+#include <unordered_map>
 
 struct socket_t;
 typedef std::shared_ptr<socket_t> socket_ptr;
@@ -10,8 +13,29 @@ typedef std::shared_ptr<socket_t> socket_ptr;
 static constexpr size_t MAX_CHUNK_SIZE = 1024ull * 1024ull * 1024ull; // 1 GiB
 static constexpr size_t RPC_CONN_CAPS_SIZE = 24;
 
+// State shared by every client thread that uses one connection. A connection is looked up by
+// endpoint and is therefore shared by all backends of that endpoint, including the backends of
+// different llama_contexts, so all of it has to be serialised:
+//   - mtx_send makes a whole RPC message atomic on the wire
+//   - seq_* hands the responses out in request order (the server answers strictly in order),
+//     without holding mtx_send while waiting, so another thread can keep submitting work
+//   - last_graph_uid mirrors the server's per-connection stored graph for a device, so that
+//     RPC_CMD_GRAPH_RECOMPUTE can never re-run a graph submitted by another context
+struct rpc_conn_state {
+    std::mutex              mtx_send;
+    std::mutex              mtx_seq;
+    std::condition_variable cv_seq;
+    uint64_t                seq_next    = 0;
+    uint64_t                seq_serving = 0;
+
+    std::unordered_map<uint32_t, uint64_t> last_graph_uid;
+};
+
 struct socket_t {
     ~socket_t();
+
+    // guarded by conn.mtx_send / conn.mtx_seq, see rpc_conn_state
+    rpc_conn_state conn;
 
     bool send_data(const void * data, size_t size);
     bool recv_data(void * data, size_t size);

--- a/ggml/src/ggml-rpc/transport.h
+++ b/ggml/src/ggml-rpc/transport.h
@@ -13,14 +13,9 @@ typedef std::shared_ptr<socket_t> socket_ptr;
 static constexpr size_t MAX_CHUNK_SIZE = 1024ull * 1024ull * 1024ull; // 1 GiB
 static constexpr size_t RPC_CONN_CAPS_SIZE = 24;
 
-// State shared by every client thread that uses one connection. A connection is looked up by
-// endpoint and is therefore shared by all backends of that endpoint, including the backends of
-// different llama_contexts, so all of it has to be serialised:
-//   - mtx_send makes a whole RPC message atomic on the wire
-//   - seq_* hands the responses out in request order (the server answers strictly in order),
-//     without holding mtx_send while waiting, so another thread can keep submitting work
-//   - last_graph_uid mirrors the server's per-connection stored graph for a device, so that
-//     RPC_CMD_GRAPH_RECOMPUTE can never re-run a graph submitted by another context
+// a connection is looked up by endpoint, so every backend of that endpoint shares it, including
+// those of other llama_contexts: mtx_send makes a whole message atomic on the wire, seq_* hands
+// the responses out in request order without holding mtx_send, last_graph_uid mirrors the server
 struct rpc_conn_state {
     std::mutex              mtx_send;
     std::mutex              mtx_seq;
@@ -34,7 +29,6 @@ struct rpc_conn_state {
 struct socket_t {
     ~socket_t();
 
-    // guarded by conn.mtx_send / conn.mtx_seq, see rpc_conn_state
     rpc_conn_state conn;
 
     bool send_data(const void * data, size_t size);

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -2074,6 +2074,40 @@ Note that the following endpoints are exempt from being considered as incoming t
 - `GET /models`
 - `GET /metrics`
 
+## Pipeline groups
+
+`--pipeline-groups N` (default `1`) runs the server's slots over `N` independent `llama_context`
+objects created from the same model. Each group has its own batch, its own sampling and its own
+decode thread; the model weights, the task queue, the results queue and the HTTP layer are shared.
+
+This is meant for a layer split across two machines, e.g.
+
+```sh
+llama-server -m model.gguf -c 32768 --parallel 16 \
+    --rpc peer:50052 --device CUDA0,RPC0 -sm layer -ngl 99 \
+    --pipeline-groups 2
+```
+
+With one context, a layer split is a two-stage pipeline that is fed one batch at a time, so each
+stage is idle while the other one computes. With two groups there are two batches in flight, so
+while group A is being computed on the second stage, group B is being computed on the first one.
+
+Details:
+
+- The slots are partitioned contiguously: with `--parallel P` and `--pipeline-groups N`, group `g`
+  owns slots `[g*P/N, (g+1)*P/N)`. `--parallel` must be a positive multiple of `--pipeline-groups`.
+- Each context is created with `n_seq_max = P/N` and `n_ctx = C/N`, so the per-slot context and the
+  total KV memory over all groups are the same as with a single context. `-c` must be given
+  explicitly and must be a multiple of `N`.
+- Slot selection for an incoming request still runs over *all* slots, so prompt cache similarity and
+  the slot save / restore endpoints work exactly as before: a returning conversation lands on the
+  slot that still holds its prefix, whichever group that slot belongs to.
+- Task processing briefly pauses the decode loops, so `/slots`, `/metrics` and cancellations are
+  answered after the in-flight decode of each group finishes rather than during it.
+- `N > 1` is refused at startup together with speculative decoding (`--model-draft`, MTP),
+  multimodal (`--mmproj`) and `--sleep-idle-seconds`.
+- With `N = 1` nothing changes: one context, one batch and one update loop on the main thread.
+
 ## More examples
 
 ### Interactive mode

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -2084,9 +2084,24 @@ This is meant for a layer split across two machines, e.g.
 
 ```sh
 llama-server -m model.gguf -c 32768 --parallel 16 \
-    --rpc peer:50052 --device CUDA0,RPC0 -sm layer -ngl 99 \
+    --rpc peer:50052 --device RPC0,CUDA0 -sm layer -ngl 99 \
     --pipeline-groups 2
 ```
+
+Note the device order: **list the remote device first and the local one last**. With `-sm layer`
+the devices are filled in the order they are given, so the last one holds the output layer. Put
+the local GPU last and the logits are produced locally, which removes a `n_vocab * n_rows * 4`
+byte transfer from every decode step (31.8 MB per step at 32 rows on a 248320-token vocabulary)
+and lets the sampler read them out of local memory. On a pair of DGX Sparks with
+Qwen3.8-27B-UD-Q4_K_XL at 32 concurrent clients this is worth more than the pipeline groups
+themselves, and the two compound:
+
+| device order | groups | tok/s | TPOT ms | GPU busy, local / remote |
+|---|---|---|---|---|
+| `CUDA0,RPC0` | 1 | 94.9 | 310 | 44 / 43 pc |
+| `CUDA0,RPC0` | 2 | 75.5 | 395 | 43 / 44 pc |
+| `RPC0,CUDA0` | 1 | 99.7 | 295 | 41 / 43 pc |
+| `RPC0,CUDA0` | 2 | **130.4** | 223 | 76 / 79 pc |
 
 With one context, a layer split is a two-stage pipeline that is fed one batch at a time, so each
 stage is idle while the other one computes. With two groups there are two batches in flight, so
@@ -2107,6 +2122,20 @@ Details:
 - `N > 1` is refused at startup together with speculative decoding (`--model-draft`, MTP),
   multimodal (`--mmproj`) and `--sleep-idle-seconds`.
 - With `N = 1` nothing changes: one context, one batch and one update loop on the main thread.
+- Each group samples its own rows over a small worker pool, because a serial pass over the slots
+  costs tens of milliseconds per step between the decode and the next submit and, at `N > 1`,
+  competes for memory bandwidth with the other group's GPU work. The total number of sampling
+  threads is the same however many groups there are; `LLAMA_SERVER_SAMPLE_THREADS=1` turns the
+  pool off. The sampled tokens do not depend on how the pass is scheduled.
+- Use `--cache-ram 0` with a layer split. The RAM prompt cache moves a whole slot state on every
+  slot handover, and on a split most of that state lives on the remote node, so it goes over the
+  wire; at 32 concurrent clients on the pair it costs about a quarter of the throughput with one
+  group and much more with two, because the handover runs on the single task thread and the other
+  group starves while it does.
+- `LLAMA_SERVER_PIPE_PROF=1` prints, every five seconds and per group, how long an iteration
+  spends waiting for the engine, in `pre_decode`, in `llama_decode`, in `llama_synchronize`, and
+  in `post_decode`, and splits `post_decode` per token into sampling, detokenization, stop-string
+  handling and the result queue. That is how the numbers above were found.
 
 ## More examples
 

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -2119,8 +2119,13 @@ Details:
   slot that still holds its prefix, whichever group that slot belongs to.
 - Task processing briefly pauses the decode loops, so `/slots`, `/metrics` and cancellations are
   answered after the in-flight decode of each group finishes rather than during it.
-- `N > 1` is refused at startup together with speculative decoding (`--model-draft`, MTP),
-  multimodal (`--mmproj`) and `--sleep-idle-seconds`.
+- Speculative decoding works per group: every group owns a draft or MTP context bound to its own
+  target context and a `common_speculative` of its own, so `--spec-type draft-mtp` and
+  `--model-draft` combine with `N > 1` (with `--model-draft` the draft model is loaded once per
+  group). Slot save / restore, checkpoints and the prompt cache carry the draft state exactly as
+  with one group.
+- `N > 1` is refused at startup together with multimodal (`--mmproj`), `--control-vector` and
+  `--sleep-idle-seconds`.
 - With `N = 1` nothing changes: one context, one batch and one update loop on the main thread.
 - Each group samples its own rows over a small worker pool, because a serial pass over the slots
   costs tens of milliseconds per step between the decode and the next submit and, at `N > 1`,

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -2111,16 +2111,22 @@ Details:
 
 - The slots are partitioned contiguously: with `--parallel P` and `--pipeline-groups N`, group `g`
   owns slots `[g*P/N, (g+1)*P/N)`. `--parallel` must be a positive multiple of `--pipeline-groups`.
-- Each context is created with `n_seq_max = P/N`. What happens to `n_ctx` depends on the KV mode,
-  because `llama_context` derives the per-request context differently in each:
-  - **Split KV** (the default): `n_ctx = C/N`. Since the per-request context is `n_ctx / n_seq_max`,
-    dividing both leaves it at `C/P`, and the total KV memory over all groups is the same as with a
-    single context. `-c` must be given explicitly and must be a multiple of `N`.
-  - **Unified KV** (`--kv-unified`): `n_ctx` is **not** divided, and each group is created with the
-    full `C`. Here the per-request context *is* `n_ctx`, so dividing it would cut the longest
-    request the server accepts from `C` to `C/N`, which changes what `-c` means rather than how the
-    slots are arranged. The cost is that the KV memory is `N` times that of a single context; it is
-    included in the parameter fit, so if it does not fit, the fitter lowers `n_ctx` and says so.
+- Each context is created with `n_seq_max = P/N` and the **full** `n_ctx = C`. `n_ctx` is never
+  divided by the group count: `-c` is what every request should be able to reach, and splitting the
+  server into groups is an internal arrangement that should not redefine it. `-c` must still be
+  given explicitly, but it no longer has to be a multiple of `N`.
+
+  What that gives a single request depends on the KV mode, because `llama_context` derives the
+  per-request context differently:
+  - **Unified KV** (`--kv-unified`): the per-request context *is* `n_ctx`, so every request can
+    reach the full `C`. This is the intended arrangement.
+  - **Split KV**: the per-request context is `n_ctx / n_seq_max`, which here is `C*N/P`. That is
+    `N` times what a slot got when `n_ctx` was divided as well, so slots gain context rather than
+    lose it, but a single request still cannot reach `C` unless the KV is unified.
+
+  The cost either way is that the KV memory over all groups is roughly `N` times that of a single
+  context, rather than equal to it. That is included in the parameter fit, so if it does not fit,
+  the fitter lowers `n_ctx` and reports it rather than the server quietly serving less than asked.
 - Slot selection for an incoming request still runs over *all* slots, so prompt cache similarity and
   the slot save / restore endpoints work exactly as before: a returning conversation lands on the
   slot that still holds its prefix, whichever group that slot belongs to.

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -2111,9 +2111,16 @@ Details:
 
 - The slots are partitioned contiguously: with `--parallel P` and `--pipeline-groups N`, group `g`
   owns slots `[g*P/N, (g+1)*P/N)`. `--parallel` must be a positive multiple of `--pipeline-groups`.
-- Each context is created with `n_seq_max = P/N` and `n_ctx = C/N`, so the per-slot context and the
-  total KV memory over all groups are the same as with a single context. `-c` must be given
-  explicitly and must be a multiple of `N`.
+- Each context is created with `n_seq_max = P/N`. What happens to `n_ctx` depends on the KV mode,
+  because `llama_context` derives the per-request context differently in each:
+  - **Split KV** (the default): `n_ctx = C/N`. Since the per-request context is `n_ctx / n_seq_max`,
+    dividing both leaves it at `C/P`, and the total KV memory over all groups is the same as with a
+    single context. `-c` must be given explicitly and must be a multiple of `N`.
+  - **Unified KV** (`--kv-unified`): `n_ctx` is **not** divided, and each group is created with the
+    full `C`. Here the per-request context *is* `n_ctx`, so dividing it would cut the longest
+    request the server accepts from `C` to `C/N`, which changes what `-c` means rather than how the
+    slots are arranged. The cost is that the KV memory is `N` times that of a single context; it is
+    included in the parameter fit, so if it does not fit, the fitter lowers `n_ctx` and says so.
 - Slot selection for an incoming request still runs over *all* slots, so prompt cache similarity and
   the slot save / restore endpoints work exactly as before: a returning conversation lands on the
   slot that still holds its prefix, whichever group that slot belongs to.

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -2109,14 +2109,10 @@ while group A is being computed on the second stage, group B is being computed o
 
 Details:
 
-- The value may also be given as `LLAMA_ARG_PIPELINE_GROUPS`. This is deliberate and is how router
-  mode reaches its children, which are spawned rather than given a command line; an explicit
-  `--pipeline-groups` always wins over the environment.
-- The flag is read by a small pre-scan that runs before the option table exists, and is removed
-  from `argv` before the normal parser sees it. The scan stops at a bare `--`, so operands after
-  the separator are untouched, but before it the scan cannot distinguish an option from the value
-  of a preceding option: a literal `--pipeline-groups` passed as another option's value is
-  consumed. Registering the option with the parser would remove that limitation.
+- The option is registered with the normal argument parser, so it appears in `--help` and accepts
+  `LLAMA_ARG_PIPELINE_GROUPS` from the environment like any other option, with an explicit flag
+  winning over the environment. That environment path is how router mode reaches its children,
+  which are spawned rather than given a command line.
 - The slots are partitioned contiguously: with `--parallel P` and `--pipeline-groups N`, group `g`
   owns slots `[g*P/N, (g+1)*P/N)`. `--parallel` must be a positive multiple of `--pipeline-groups`.
 - Each context is created with `n_seq_max = P/N` and the **full** `n_ctx = C`. `n_ctx` is never

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -2109,6 +2109,14 @@ while group A is being computed on the second stage, group B is being computed o
 
 Details:
 
+- The value may also be given as `LLAMA_ARG_PIPELINE_GROUPS`. This is deliberate and is how router
+  mode reaches its children, which are spawned rather than given a command line; an explicit
+  `--pipeline-groups` always wins over the environment.
+- The flag is read by a small pre-scan that runs before the option table exists, and is removed
+  from `argv` before the normal parser sees it. The scan stops at a bare `--`, so operands after
+  the separator are untouched, but before it the scan cannot distinguish an option from the value
+  of a preceding option: a literal `--pipeline-groups` passed as another option's value is
+  consumed. Registering the option with the parser would remove that limitation.
 - The slots are partitioned contiguously: with `--parallel P` and `--pipeline-groups N`, group `g`
   owns slots `[g*P/N, (g+1)*P/N)`. `--parallel` must be a positive multiple of `--pipeline-groups`.
 - Each context is created with `n_seq_max = P/N` and the **full** `n_ctx = C`. `n_ctx` is never

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -2127,11 +2127,11 @@ Details:
 - `N > 1` is refused at startup together with multimodal (`--mmproj`), `--control-vector` and
   `--sleep-idle-seconds`.
 - With `N = 1` nothing changes: one context, one batch and one update loop on the main thread.
-- Each group samples its own rows over a small worker pool, because a serial pass over the slots
-  costs tens of milliseconds per step between the decode and the next submit and, at `N > 1`,
-  competes for memory bandwidth with the other group's GPU work. The total number of sampling
-  threads is the same however many groups there are; `LLAMA_SERVER_SAMPLE_THREADS=1` turns the
-  pool off. The sampled tokens do not depend on how the pass is scheduled.
+- Each group samples its rows serially, on its own decode thread. Sampling them over a worker pool
+  was tried and removed: `common_sampler_sample` begins with `llama_synchronize`, which does
+  non-atomic read-modify-writes on the context's timing counters, and `set_logits` then re-enters
+  the same context through six more getters, so the workers raced on a context they shared. Making
+  that safe means duplicating a large part of the context API.
 - Use `--cache-ram 0` with a layer split. The RAM prompt cache moves a whole slot state on every
   slot handover, and on a split most of that state lives on the remote node, so it goes over the
   wire; at 32 concurrent clients on the pair it costs about a quarter of the throughput with one

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1621,9 +1621,15 @@ private:
         return true;
     }
 
-    // Stops every pipeline group so that the caller can touch slot and context state safely.
+    // Holds the engine so that the caller can look at the slot state safely, and, on request,
+    // waits for the in-flight decode of the groups whose context the caller is going to touch.
     // Constructing this is a no-op when there is a single group: the single update loop and the
     // task processing then run on the same thread, exactly as before.
+    //
+    // Taking mtx_engine already keeps every group out of a new iteration, so the slot state is
+    // stable as soon as the guard exists. Only touching a llama_context needs more than that,
+    // and only for the group that owns it: wait_for() blocks until that group's decode is done
+    // while the other groups keep computing. Tasks that touch no context wait for nobody.
     struct engine_guard {
         server_context_impl * srv = nullptr;
         std::unique_lock<std::mutex> lk;
@@ -1636,10 +1642,29 @@ private:
             srv = srv_;
             lk  = std::unique_lock<std::mutex>(srv->mtx_engine);
 
-            // ask every group to stop at the start of its next iteration, then wait for the
-            // decodes that are already in flight
+            // ask every group to stop at the start of its next iteration, so that the slot state
+            // cannot change under us while wait_for() releases the lock
             for (auto & grp : srv->groups) {
                 grp->n_pause_req++;
+            }
+        }
+
+        // wait until this group is not inside llama_decode, so its context can be touched
+        void wait_for(int id_group) {
+            if (srv == nullptr) {
+                return;
+            }
+
+            GGML_ASSERT(id_group >= 0 && id_group < (int) srv->groups.size());
+            server_group * grp = srv->groups[id_group].get();
+
+            srv->cv_engine.wait(lk, [&] { return !grp->busy; });
+        }
+
+        // wait for every group, for tasks that are not tied to one slot
+        void wait_for_all() {
+            if (srv == nullptr) {
+                return;
             }
 
             srv->cv_engine.wait(lk, [&] {
@@ -2568,8 +2593,10 @@ private:
             return false;
         }
 
-        // with more than one group the update loops run on their own threads, so pause them while
-        // we look at and modify the slots. no-op with a single group.
+        // with more than one group the update loops run on their own threads. Holding the engine
+        // is enough to look at and modify the slot state; the cases below additionally wait for
+        // the in-flight decode of the group whose context they touch, and only for that group.
+        // no-op with a single group.
         engine_guard guard(this);
 
         switch (task.type) {
@@ -2608,6 +2635,10 @@ private:
                         break;
                     }
 
+                    // from here on the slot's context is touched (prompt cache, KV), so the group
+                    // that owns it has to finish its decode. the other groups keep computing.
+                    guard.wait_for(slot->id_group);
+
                     if (task.is_parent()) {
                         // try getting free slots for all child tasks
                         size_t n_child_tasks = task.child_tasks.size();
@@ -2636,6 +2667,9 @@ private:
                     }
 
                     if (params_base.cache_idle_slots) {
+                        // this walks every slot of every group
+                        guard.wait_for_all();
+
                         for (auto & slot : slots) {
                             if (!slot.is_processing()) {
                                 SLT_TRC(slot, "%s", "saving idle slot to prompt cache\n");
@@ -2658,6 +2692,7 @@ private:
                     // release slot linked with the task id
                     for (auto & slot : slots) {
                         if (slot.task && slot.task->id == task.id_target) {
+                            guard.wait_for(slot.id_group);
                             slot.release();
                             break;
                         }
@@ -2677,6 +2712,9 @@ private:
                         queue_results.send(std::move(res));
                         break;
                     }
+
+                    // the sampler of this slot is used by its group between decodes
+                    guard.wait_for(slot->id_group);
 
                     if (task.params.control_action == "reasoning_end") {
                         // the budget sampler only exists when reasoning control was armed
@@ -2759,6 +2797,9 @@ private:
                         break;
                     }
 
+                    // reads this slot's KV out of its context
+                    guard.wait_for(slot->id_group);
+
                     const int64_t t_start = ggml_time_us();
 
                     std::string filename = task.slot_action.filename;
@@ -2808,6 +2849,9 @@ private:
                         queue_tasks.defer(std::move(task));
                         break;
                     }
+
+                    // writes this slot's KV into its context
+                    guard.wait_for(slot->id_group);
 
                     const int64_t t_start = ggml_time_us();
 
@@ -2874,6 +2918,9 @@ private:
                         break;
                     }
 
+                    // prompt_clear() drops this slot's KV from its context
+                    guard.wait_for(slot->id_group);
+
                     // Erase token cache
                     const size_t n_erased = slot->prompt.tokens.size();
 
@@ -2913,6 +2960,9 @@ private:
                 } break;
             case SERVER_TASK_TYPE_SET_LORA:
                 {
+                    // the adapters are applied to every context
+                    guard.wait_for_all();
+
                     auto new_loras = construct_lora_list(task.set_lora);
                     // logging
                     for (size_t i = 0; i < new_loras.size(); ++i) {

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -35,6 +35,12 @@
 #include <windows.h>
 #endif
 
+// used by the --pipeline-groups decode threads
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
 constexpr int HTTP_POLLING_SECONDS = 1;
 
 static common_speculative_output_limits server_output_limits(const common_params & params) {
@@ -68,7 +74,8 @@ struct server_batch {
     bool batch_rendered = false;
 
     struct token {
-        int32_t id_slot;
+        int32_t id_slot; // global slot id, used to attribute stats
+        int32_t seq_id;  // sequence id inside the context of the slot's pipeline group
         llama_token token;
         llama_pos pos;
         bool output;
@@ -108,22 +115,22 @@ struct server_batch {
         tokens.reserve(n_tokens_alloc);
     }
 
-    bool add(int32_t id_slot, llama_token token, llama_pos pos, bool output, bool is_prompt) {
+    bool add(int32_t id_slot, int32_t seq_id, llama_token token, llama_pos pos, bool output, bool is_prompt) {
         GGML_ASSERT(!has_embd); // cannot mix tokens + embd in same batch
         GGML_ASSERT(batch.pos != nullptr);
         if ((int32_t)tokens.size() >= n_tokens_alloc) {
             return false;
         }
-        tokens.push_back({ id_slot, token, pos, output, is_prompt });
+        tokens.push_back({ id_slot, seq_id, token, pos, output, is_prompt });
         return true;
     }
 
-    bool add(int32_t id_slot, const std::vector<float> & embd_in, llama_pos pos, bool output, bool is_prompt) {
+    bool add(int32_t id_slot, int32_t seq_id, const std::vector<float> & embd_in, llama_pos pos, bool output, bool is_prompt) {
         GGML_ASSERT(batch.pos != nullptr);
         if ((int32_t)tokens.size() >= n_tokens_alloc) {
             return false;
         }
-        tokens.push_back({ id_slot, LLAMA_TOKEN_NULL, pos, output, is_prompt });
+        tokens.push_back({ id_slot, seq_id, LLAMA_TOKEN_NULL, pos, output, is_prompt });
         has_embd = true;
         embd.insert(embd.end(), embd_in.begin(), embd_in.end());
         return true;
@@ -159,7 +166,7 @@ struct server_batch {
         common_batch_clear(batch);
         for (int32_t i = 0; i < size(); i++) {
             const auto & t = tokens[i];
-            common_batch_add(batch, t.token, t.pos, { t.id_slot }, t.output);
+            common_batch_add(batch, t.token, t.pos, { t.seq_id }, t.output);
         }
         if (has_embd) {
             batch.token = nullptr; // will be restored on clear()
@@ -193,6 +200,14 @@ struct server_batch {
 
 struct server_slot {
     int id;
+
+    // pipeline group that owns this slot, i.e. the index of ctx_tgt in server_context_impl::groups
+    // always 0 unless --pipeline-groups > 1
+    int id_group = 0;
+
+    // sequence id of this slot inside ctx_tgt / ctx_dft
+    // equal to id unless --pipeline-groups > 1, where each context only holds n_parallel/N sequences
+    int seq_id = 0;
 
     llama_context * ctx_tgt = nullptr;
     llama_context * ctx_dft = nullptr;
@@ -255,8 +270,8 @@ struct server_slot {
             return false;
         }
 
-        const size_t cur_size_tgt =           llama_state_seq_get_size_ext(ctx_tgt, id, LLAMA_STATE_SEQ_FLAGS_NONE);
-        const size_t cur_size_dft = ctx_dft ? llama_state_seq_get_size_ext(ctx_dft, id, LLAMA_STATE_SEQ_FLAGS_NONE) : 0;
+        const size_t cur_size_tgt =           llama_state_seq_get_size_ext(ctx_tgt, seq_id, LLAMA_STATE_SEQ_FLAGS_NONE);
+        const size_t cur_size_dft = ctx_dft ? llama_state_seq_get_size_ext(ctx_dft, seq_id, LLAMA_STATE_SEQ_FLAGS_NONE) : 0;
 
         const size_t cur_size = cur_size_tgt + cur_size_dft;
 
@@ -268,16 +283,16 @@ struct server_slot {
             return false;
         }
 
-        llama_state_seq_get_data_ext(ctx_tgt, cur->data.main.data(), cur_size_tgt, id, LLAMA_STATE_SEQ_FLAGS_NONE);
+        llama_state_seq_get_data_ext(ctx_tgt, cur->data.main.data(), cur_size_tgt, seq_id, LLAMA_STATE_SEQ_FLAGS_NONE);
         if (ctx_dft) {
-            llama_state_seq_get_data_ext(ctx_dft, cur->data.drft.data(), cur_size_dft, id, LLAMA_STATE_SEQ_FLAGS_NONE);
+            llama_state_seq_get_data_ext(ctx_dft, cur->data.drft.data(), cur_size_dft, seq_id, LLAMA_STATE_SEQ_FLAGS_NONE);
         }
 
         return true;
     }
 
     bool prompt_load(server_prompt_cache & prompt_cache, const server_tokens & tokens) {
-        bool res = prompt_cache.load(prompt, tokens, ctx_tgt, ctx_dft, id);
+        bool res = prompt_cache.load(prompt, tokens, ctx_tgt, ctx_dft, seq_id);
         if (!res) {
             SLT_WRN(*this, "%s", "failed to load prompt from cache\n");
         }
@@ -288,7 +303,7 @@ struct server_slot {
     void prompt_clear() {
         SLT_TRC(*this, "clearing prompt with %zu tokens\n", prompt.tokens.size());
 
-        mem.seq_rm(id, -1, -1);
+        mem.seq_rm(seq_id, -1, -1);
 
         prompt.clear();
     }
@@ -351,7 +366,7 @@ struct server_slot {
 
         n_predict_max = -1;
 
-        llama_set_sampler(ctx_tgt, id, nullptr);
+        llama_set_sampler(ctx_tgt, seq_id, nullptr);
 
         // clear alora start
         alora_invocation_start = -1;
@@ -463,9 +478,9 @@ struct server_slot {
             i_batch = batch.size();
 
             if (!inp_embd.empty()) {
-                add_ok &= batch.add(id, inp_embd, prompt.tokens.pos_next(), true, false);
+                add_ok &= batch.add(id, seq_id, inp_embd, prompt.tokens.pos_next(), true, false);
             } else {
-                add_ok &= batch.add(id, sampled, prompt.tokens.pos_next(), true, false);
+                add_ok &= batch.add(id, seq_id, sampled, prompt.tokens.pos_next(), true, false);
             }
 
             SLT_DBG(*this, "slot decode token, id=%d, n_ctx = %d, n_tokens = %d, truncated = %d\n",
@@ -483,9 +498,9 @@ struct server_slot {
 
             auto pos0 = prompt.tokens.pos_next();
 
-            add_ok &= batch.add(id, sampled, pos0++, true, false);
+            add_ok &= batch.add(id, seq_id, sampled, pos0++, true, false);
             for (auto token : spec_draft) {
-                add_ok &= batch.add(this->id, token, pos0++, true, false);
+                add_ok &= batch.add(this->id, seq_id, token, pos0++, true, false);
             }
         }
 
@@ -676,8 +691,9 @@ struct server_slot {
     void copy_state_to(server_slot & other) const {
         GGML_ASSERT(state == SLOT_STATE_DONE_PROMPT);
 
-        mem.seq_rm(other.id,     -1, -1);
-        mem.seq_cp(id, other.id, -1, -1);
+        // note: parent and child slots are always in the same pipeline group, see get_free_slots()
+        mem.seq_rm(other.seq_id,         -1, -1);
+        mem.seq_cp(seq_id, other.seq_id, -1, -1);
 
         other.i_batch = i_batch;
 
@@ -780,6 +796,29 @@ static int process_mtmd_chunk(const server_slot & slot, mtmd::batch_ptr & mbatch
     return try_decode();
 }
 
+// A pipeline group is one llama_context with its own batch, its own decode loop and its own
+// contiguous range of slots. With --pipeline-groups 1 (the default) there is exactly one group:
+// it owns ctx_tgt and every slot, and its update loop runs on the main thread, as before.
+//
+// With N > 1 the point is that while group A's batch is being computed on the second stage of a
+// layer split (the RPC peer), group B's batch can be computed on the first stage (the local GPU),
+// so both devices are busy instead of each idling half of every decode step.
+struct server_group {
+    int id = 0;
+
+    llama_context * ctx = nullptr;
+
+    server_batch batch;
+
+    // slots owned by this group, in slot id order (slots are partitioned contiguously)
+    std::vector<server_slot *> slots;
+
+    // only used when n_groups > 1, all guarded by server_context_impl::mtx_engine
+    std::thread thread;
+    bool busy        = false; // a decode is in flight, no one may touch ctx
+    int  n_pause_req = 0;     // someone wants the engine stopped, do not start a new iteration
+};
+
 //
 // server_context_impl (private implementation)
 //
@@ -803,6 +842,9 @@ public:
     server_chat_params chat_params;
 
     server_state_callback_t callback_state = [](server_state, json) -> void {};
+
+    // number of pipeline groups requested via --pipeline-groups, must be set before load_model()
+    int n_pipeline_groups_req = 1;
 
     server_context_impl() {
         mtmd_helper_log_set(common_log_default_callback, nullptr);
@@ -835,7 +877,18 @@ private:
 
     llama_context * ctx_tgt = nullptr;
 
-    server_batch batch;
+    // pipeline groups, see --pipeline-groups and struct server_group
+    // groups[0]->ctx is always ctx_tgt; n_groups == 1 unless the user asked for more
+    int n_groups = 1;
+    std::vector<std::unique_ptr<server_group>> groups;
+
+    // number of sequences per context, == params_base.n_parallel when n_groups == 1
+    int n_seq_per_group = 1;
+
+    // the following are only ever touched when n_groups > 1
+    std::mutex              mtx_engine;
+    std::condition_variable cv_engine;
+    bool                    groups_stop = false;
 
     llama_model   * model_dft = nullptr;
     llama_context * ctx_dft   = nullptr;
@@ -893,6 +946,15 @@ private:
 
         ctx_dft   = nullptr;
         model_dft = nullptr;
+
+        // groups[0]->ctx is owned by llama_init, the rest were created by llama_init_from_model()
+        for (size_t g = 1; g < groups.size(); ++g) {
+            if (groups[g]->ctx != nullptr) {
+                llama_free(groups[g]->ctx);
+                groups[g]->ctx = nullptr;
+            }
+        }
+        groups.clear();
 
         llama_init.reset();
 
@@ -1048,10 +1110,43 @@ private:
             params_base.load_progress_callback_user_data = &load_progress_text;
         }
 
-        llama_init = common_init_from_params(params_base);
+        // --pipeline-groups: run the slots over N independent contexts of one model, so that the
+        // stages of a layer split can be busy at the same time. N == 1 is the default and keeps
+        // every code path below exactly as it was.
+        n_groups = std::max(1, n_pipeline_groups_req);
+
+        if (n_groups > 1 && !validate_pipeline_groups(params_base, has_spec, has_mmproj)) {
+            return false;
+        }
+
+        n_seq_per_group = params_base.n_parallel / n_groups;
+
+        // note: with a single group this reference IS params_base, so nothing changes
+        common_params   params_grp = n_groups > 1 ? params_base : common_params{};
+        common_params & params_ctx = n_groups > 1 ? params_grp  : params_base;
+
+        if (n_groups > 1) {
+            // each context gets 1/N of the sequences and 1/N of the total context, so the per-slot
+            // context (n_ctx / n_seq_max) and the total KV memory over all contexts are unchanged
+            params_ctx.n_parallel = n_seq_per_group;
+            params_ctx.n_ctx      = params_base.n_ctx / n_groups;
+        }
+
+        llama_init = common_init_from_params(params_ctx);
 
         model_tgt = llama_init->model();
         ctx_tgt   = llama_init->context();
+
+        if (n_groups > 1) {
+            // pick up whatever the parameter fitting resolved, but keep the totals the user asked for
+            const int n_parallel_total = params_base.n_parallel;
+            const int n_ctx_total      = params_base.n_ctx;
+
+            params_base = params_ctx;
+
+            params_base.n_parallel = n_parallel_total;
+            params_base.n_ctx      = n_ctx_total;
+        }
 
         if (model_tgt == nullptr) {
             SRV_ERR("failed to load model, '%s'\n", params_base.model.path.c_str());
@@ -1065,7 +1160,38 @@ private:
 
         vocab = llama_model_get_vocab(model_tgt);
 
-        n_ctx = llama_n_ctx(ctx_tgt);
+        // the remaining contexts of the pipeline are created from the same model
+        {
+            groups.clear();
+            groups.reserve(n_groups);
+
+            for (int g = 0; g < n_groups; ++g) {
+                groups.emplace_back(new server_group());
+                groups[g]->id = g;
+            }
+
+            groups[0]->ctx = ctx_tgt;
+
+            for (int g = 1; g < n_groups; ++g) {
+                llama_context_params cparams = common_context_params_to_llama(params_ctx);
+
+                // make sure the extra contexts are identical to the one common_init_from_params made
+                cparams.n_ctx     = llama_n_ctx(ctx_tgt);
+                cparams.n_seq_max = llama_n_seq_max(ctx_tgt);
+
+                groups[g]->ctx = llama_init_from_model(model_tgt, cparams);
+                if (groups[g]->ctx == nullptr) {
+                    SRV_ERR("failed to create llama_context for pipeline group %d\n", g);
+                    return false;
+                }
+
+                SRV_INF("created llama_context for pipeline group %d, n_ctx = %d, n_seq_max = %d\n",
+                        g, (int) llama_n_ctx(groups[g]->ctx), (int) llama_n_seq_max(groups[g]->ctx));
+            }
+        }
+
+        // the total context over all groups, as requested by the user
+        n_ctx = llama_n_ctx(ctx_tgt) * n_groups;
 
         add_bos_token = llama_vocab_get_add_bos(vocab);
 
@@ -1182,7 +1308,9 @@ private:
         }
 
         // try speculative decoding
-        if (ctx_tgt_seq_rm_type != COMMON_CONTEXT_SEQ_RM_TYPE_NO) {
+        // note: a common_speculative is bound to one target context, and its code paths yield to
+        //       the task queue, which only one thread may do - so it is off with several groups
+        if (ctx_tgt_seq_rm_type != COMMON_CONTEXT_SEQ_RM_TYPE_NO && n_groups == 1) {
             try {
                 spec.reset(common_speculative_init(params_base.speculative, params_base.n_parallel));
             } catch (const std::exception & e) {
@@ -1205,10 +1333,17 @@ private:
         for (int i = 0; i < params_base.n_parallel; i++) {
             server_slot & slot = slots[i];
 
-            slot.id      = i;
-            slot.ctx_tgt = ctx_tgt;
-            slot.ctx_dft = ctx_dft;
-            slot.mem.init(ctx_tgt, ctx_dft);
+            // slots are partitioned contiguously: group g owns slots [g*S, (g+1)*S)
+            server_group & grp = *groups[i / n_seq_per_group];
+
+            slot.id       = i;
+            slot.id_group = grp.id;
+            slot.seq_id   = i % n_seq_per_group;
+            slot.ctx_tgt  = grp.ctx;
+            slot.ctx_dft  = ctx_dft;
+            slot.mem.init(grp.ctx, ctx_dft);
+
+            grp.slots.push_back(&slot);
             slot.spec    = spec.get();
             slot.n_ctx   = n_ctx_slot;
 
@@ -1263,7 +1398,9 @@ private:
         {
             const int32_t n_batch = llama_n_batch(ctx_tgt);
             const int32_t n_embd  = llama_model_n_embd_inp(model_tgt);
-            batch.init(std::max(n_batch, params_base.n_parallel), n_embd);
+            for (auto & grp : groups) {
+                grp->batch.init(std::max(n_batch, n_seq_per_group), n_embd);
+            }
         }
 
         if (params_base.cache_ram_mib != 0) {
@@ -1315,6 +1452,48 @@ private:
         return true;
     }
 
+    // refuse everything we cannot make safe with more than one context, rather than half-support it
+    bool validate_pipeline_groups(const common_params & params, bool has_spec, bool has_mmproj) const {
+        auto refuse = [](const char * what) {
+            SRV_ERR("--pipeline-groups > 1 is not supported together with %s\n", what);
+            return false;
+        };
+
+        if (params.n_parallel < n_groups || params.n_parallel % n_groups != 0) {
+            SRV_ERR("--parallel (%d) must be a positive multiple of --pipeline-groups (%d)\n",
+                    params.n_parallel, n_groups);
+            return false;
+        }
+
+        if (params.n_ctx <= 0) {
+            SRV_ERR("%s", "--pipeline-groups > 1 requires an explicit context size, pass -c N\n");
+            return false;
+        }
+
+        if (params.n_ctx % n_groups != 0) {
+            SRV_ERR("--ctx-size (%d) must be a multiple of --pipeline-groups (%d)\n", params.n_ctx, n_groups);
+            return false;
+        }
+
+        // a common_speculative and its draft context are bound to one target context
+        if (has_spec) {
+            return refuse("speculative decoding (--model-draft / MTP)");
+        }
+
+        // mtmd_context is bound to one llama_context
+        if (has_mmproj) {
+            return refuse("multimodal (--mmproj)");
+        }
+
+        // entering / leaving the sleeping state destroys and rebuilds the contexts under the
+        // running group threads
+        if (params.sleep_idle_seconds >= 0) {
+            return refuse("--sleep-idle");
+        }
+
+        return true;
+    }
+
     // unlike load_model(), this is only called once during initialization
     bool init() {
         GGML_ASSERT(ctx_tgt   != nullptr);
@@ -1327,7 +1506,11 @@ private:
             return process_single_task(std::move(task), is_yielding);
         });
         queue_tasks.on_update_slots([this]() {
-            update_slots();
+            if (n_groups > 1) {
+                // each pipeline group runs its own update loop on its own thread
+                return;
+            }
+            update_slots(*groups[0]);
         });
         queue_tasks.on_sleeping_state([this](bool sleeping) {
             handle_sleeping_state(sleeping);
@@ -1422,6 +1605,107 @@ private:
         }
 
         return true;
+    }
+
+    // Stops every pipeline group so that the caller can touch slot and context state safely.
+    // Constructing this is a no-op when there is a single group: the single update loop and the
+    // task processing then run on the same thread, exactly as before.
+    struct engine_guard {
+        server_context_impl * srv = nullptr;
+        std::unique_lock<std::mutex> lk;
+
+        explicit engine_guard(server_context_impl * srv_) {
+            if (srv_->n_groups <= 1) {
+                return;
+            }
+
+            srv = srv_;
+            lk  = std::unique_lock<std::mutex>(srv->mtx_engine);
+
+            // ask every group to stop at the start of its next iteration, then wait for the
+            // decodes that are already in flight
+            for (auto & grp : srv->groups) {
+                grp->n_pause_req++;
+            }
+
+            srv->cv_engine.wait(lk, [&] {
+                for (auto & grp : srv->groups) {
+                    if (grp->busy) {
+                        return false;
+                    }
+                }
+                return true;
+            });
+        }
+
+        ~engine_guard() {
+            if (srv == nullptr) {
+                return;
+            }
+
+            for (auto & grp : srv->groups) {
+                grp->n_pause_req--;
+            }
+
+            lk.unlock();
+            srv->cv_engine.notify_all();
+        }
+
+        engine_guard(const engine_guard &) = delete;
+        engine_guard & operator=(const engine_guard &) = delete;
+    };
+
+    // the decode loop of one pipeline group, only used when n_groups > 1
+    void group_loop(server_group & grp) {
+        while (true) {
+            {
+                std::unique_lock<std::mutex> lk(mtx_engine);
+                if (groups_stop) {
+                    return;
+                }
+            }
+
+            if (update_slots(grp)) {
+                continue;
+            }
+
+            // nothing to do for this group, wait for a task to be assigned to one of its slots
+            std::unique_lock<std::mutex> lk(mtx_engine);
+            cv_engine.wait_for(lk, std::chrono::milliseconds(5), [&] { return groups_stop; });
+        }
+    }
+
+    void start_groups() {
+        if (n_groups <= 1) {
+            return;
+        }
+
+        groups_stop = false;
+
+        for (auto & grp : groups) {
+            server_group * g = grp.get();
+            g->thread = std::thread([this, g]() { group_loop(*g); });
+        }
+
+        SRV_INF("started %d pipeline group decode threads\n", n_groups);
+    }
+
+    void stop_groups() {
+        if (n_groups <= 1) {
+            return;
+        }
+
+        {
+            std::unique_lock<std::mutex> lk(mtx_engine);
+            groups_stop = true;
+        }
+        cv_engine.notify_all();
+
+        for (auto & grp : groups) {
+            if (grp->thread.joinable()) {
+                grp->thread.join();
+            }
+        }
     }
 
     server_slot * get_slot_by_id(int id_slot) {
@@ -1571,14 +1855,17 @@ private:
     //       - smarter decision which slot to clear (LRU or longest prompt?)
     //       - move slot to level 2 cache instead of removing?
     //       - instead of purging, try to store and resume later?
-    bool try_clear_idle_slots() {
+    bool try_clear_idle_slots(server_group & grp) {
         bool res = false;
 
         if (!params_base.kv_unified) {
             return res;
         }
 
-        for (auto & slot : slots) {
+        // only slots of this group, their KV lives in this group's context
+        for (auto * slot_ptr : grp.slots) {
+            auto & slot = *slot_ptr;
+
             if (slot.is_processing()) {
                 continue;
             }
@@ -1703,9 +1990,9 @@ private:
 
             // TODO: tmp until backend sampling is fully implemented
             if (use_backend_sampling) {
-                llama_set_sampler(ctx_tgt, slot.id, common_sampler_get(slot.smpl.get()));
+                llama_set_sampler(slot.ctx_tgt, slot.seq_id, common_sampler_get(slot.smpl.get()));
             } else {
-                llama_set_sampler(ctx_tgt, slot.id, nullptr);
+                llama_set_sampler(slot.ctx_tgt, slot.seq_id, nullptr);
             }
 
             SLT_TRC(slot, "sampler chain: %s\n", common_sampler_print(slot.smpl.get()).c_str());
@@ -1893,7 +2180,7 @@ private:
                 });
             }
         } else {
-            std::vector<llama_token_data> cur = get_token_probabilities(ctx_tgt, idx, n_probs_request);
+            std::vector<llama_token_data> cur = get_token_probabilities(slot.ctx_tgt, idx, n_probs_request);
             const size_t max_probs = cur.size();
             const size_t n_probs = std::min(max_probs, n_probs_request);
 
@@ -2061,7 +2348,7 @@ private:
         std::vector<float> embd_res(n_embd_out, 0.0f);
 
         for (int i = 0; i < batch.n_tokens; ++i) {
-            if (!batch.logits[i] || batch.seq_id[i][0] != slot.id) {
+            if (!batch.logits[i] || batch.seq_id[i][0] != slot.seq_id) {
                 continue;
             }
 
@@ -2101,13 +2388,13 @@ private:
         res->n_tokens = slot.task->n_tokens();
 
         for (int i = 0; i < batch.n_tokens; ++i) {
-            if (!batch.logits[i] || batch.seq_id[i][0] != slot.id) {
+            if (!batch.logits[i] || batch.seq_id[i][0] != slot.seq_id) {
                 continue;
             }
 
-            const float * embd = llama_get_embeddings_seq(ctx_tgt, batch.seq_id[i][0]);
+            const float * embd = llama_get_embeddings_seq(slot.ctx_tgt, batch.seq_id[i][0]);
             if (embd == NULL) {
-                embd = llama_get_embeddings_ith(ctx_tgt, i);
+                embd = llama_get_embeddings_ith(slot.ctx_tgt, i);
             }
 
             if (embd == NULL) {
@@ -2147,9 +2434,13 @@ private:
         return true;
     }
 
-    std::vector<server_slot *> get_free_slots(size_t n_slots_needed, int exclude_id_slot) {
+    std::vector<server_slot *> get_free_slots(size_t n_slots_needed, int exclude_id_slot, int id_group) {
         std::vector<server_slot *> free_slots;
         for (auto & slot : slots) {
+            // the parent copies its KV into the children, so they must live in the same context
+            if (slot.id_group != id_group) {
+                continue;
+            }
             if (!slot.is_processing() && slot.id != exclude_id_slot) {
                 free_slots.push_back(&slot);
             }
@@ -2244,8 +2535,8 @@ private:
         //       this is not true for SWA models: https://github.com/ggml-org/llama.cpp/pull/24411#issuecomment-4677983225
         cur.update_pos(slot.prompt.n_tokens() - n_tokens_cur, pos_min, pos_max);
 
-        cur.update_tgt(ctx_tgt, slot.id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
-        cur.update_dft(ctx_dft, slot.id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
+        cur.update_tgt(slot.ctx_tgt, slot.seq_id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
+        cur.update_dft(slot.ctx_dft, slot.seq_id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
         // stash the draft's speculative state with the checkpoint
         common_speculative_get_state(spec.get(), slot.id, cur.data_spec);
 
@@ -2262,6 +2553,10 @@ private:
             SRV_DBG("decoding, decline task, id_task = %d\n", task.id);
             return false;
         }
+
+        // with more than one group the update loops run on their own threads, so pause them while
+        // we look at and modify the slots. no-op with a single group.
+        engine_guard guard(this);
 
         switch (task.type) {
             case SERVER_TASK_TYPE_COMPLETION:
@@ -2302,7 +2597,7 @@ private:
                     if (task.is_parent()) {
                         // try getting free slots for all child tasks
                         size_t n_child_tasks = task.child_tasks.size();
-                        std::vector<server_slot *> child_slots = get_free_slots(n_child_tasks, slot->id);
+                        std::vector<server_slot *> child_slots = get_free_slots(n_child_tasks, slot->id, slot->id_group);
                         if (child_slots.size() < n_child_tasks) {
                             SRV_DBG("not enough free slots for child tasks, n_free = %zu, n_children = %zu, defer task, id_task = %d\n", child_slots.size(), n_child_tasks, id_task);
                             queue_tasks.defer(std::move(task));
@@ -2456,7 +2751,7 @@ private:
 
                     GGML_ASSERT(packed.size() % sizeof(llama_token) == 0);
                     const size_t nwrite = llama_state_seq_save_file(
-                        ctx_tgt, filepath.c_str(), slot->id,
+                        slot->ctx_tgt, filepath.c_str(), slot->seq_id,
                         reinterpret_cast<const llama_token *>(packed.data()), packed.size() / sizeof(llama_token));
                     if (nwrite == 0) {
                         send_error(task, "Unable to save slot", ERROR_TYPE_SERVER);
@@ -2500,10 +2795,10 @@ private:
                     try {
                         size_t n_packed = 0;
                         llama_tokens packed;
-                        nread = llama_state_seq_load_file(ctx_tgt, filepath.c_str(), slot->id, nullptr, 0, &n_packed);
+                        nread = llama_state_seq_load_file(slot->ctx_tgt, filepath.c_str(), slot->seq_id, nullptr, 0, &n_packed);
                         if (nread != 0) {
                             packed.resize(std::max<size_t>(1, n_packed));
-                            nread = llama_state_seq_load_file(ctx_tgt, filepath.c_str(), slot->id, packed.data(), packed.size(), &n_packed);
+                            nread = llama_state_seq_load_file(slot->ctx_tgt, filepath.c_str(), slot->seq_id, packed.data(), packed.size(), &n_packed);
                         }
                         if (nread == 0) {
                             throw std::runtime_error("No available space in KV cache or invalid slot save file");
@@ -2516,7 +2811,7 @@ private:
                             throw std::runtime_error("Restored prompt does not fit in the slot context");
                         }
 
-                        if (!restored.validate(ctx_tgt)) {
+                        if (!restored.validate(slot->ctx_tgt)) {
                             throw std::runtime_error("Invalid tokens in slot save file");
                         }
 
@@ -2635,11 +2930,11 @@ private:
         }
     }
 
-    void abort_all_slots(const std::string & reason) {
-        for (auto & slot : slots) {
-            if (slot.is_processing()) {
-                send_error(slot, reason, ERROR_TYPE_SERVER);
-                slot.release();
+    void abort_all_slots(server_group & grp, const std::string & reason) {
+        for (auto * slot : grp.slots) {
+            if (slot->is_processing()) {
+                send_error(*slot, reason, ERROR_TYPE_SERVER);
+                slot->release();
             }
         }
     }
@@ -2674,7 +2969,24 @@ private:
     };
 #endif
 
-    void update_slots() {
+    // runs one iteration of the decode loop of a single pipeline group
+    // returns true if the group had work to do
+    bool update_slots(server_group & grp) {
+        // shadow the single-context members - everything below operates on this group only
+        auto * ctx_tgt = grp.ctx;
+        auto & batch   = grp.batch;
+        auto & slots   = grp.slots;
+
+        // when there is only one group there is only one thread and this lock is never engaged
+        std::unique_lock<std::mutex> lk;
+        if (n_groups > 1) {
+            lk = std::unique_lock<std::mutex>(mtx_engine);
+            cv_engine.wait(lk, [&]{ return groups_stop || grp.n_pause_req == 0; });
+            if (groups_stop) {
+                return false;
+            }
+        }
+
 #ifdef DEBUG_TIMINGS
         static int64_t t_prev = 0;
         int64_t t_start = ggml_time_us();
@@ -2692,8 +3004,8 @@ private:
         {
             bool all_idle = true;
 
-            for (auto & slot : slots) {
-                if (slot.is_processing()) {
+            for (auto * slot : slots) {
+                if (slot->is_processing()) {
                     all_idle = false;
                     break;
                 }
@@ -2702,29 +3014,31 @@ private:
             if (all_idle) {
                 SRV_TRC("%s", "all slots are idle\n");
 
-                metrics_flush_idle();
+                metrics_flush_idle(grp);
 
-                return; // skip further processing
+                return false; // skip further processing
 
-            } else {
+            } else if (n_groups == 1) {
                 SRV_DBG("%s", "posting NEXT_RESPONSE\n");
 
                 server_task task(SERVER_TASK_TYPE_NEXT_RESPONSE);
                 task.id = queue_tasks.get_new_id();
                 queue_tasks.post(std::move(task));
             }
+            // note: with more than one group each group drives its own loop, so there is no need
+            //       to keep the shared task loop spinning
         }
 
         try {
             scoped_timer t(t_pre_decode, n_pre_decode);
-            pre_decode();
+            pre_decode(grp);
             batch.render();
         } catch (const std::exception & e) {
             SRV_ERR("pre_decode() failed: %s\n", e.what());
-            abort_all_slots("pre_decode() failed: " + std::string(e.what()));
+            abort_all_slots(grp, "pre_decode() failed: " + std::string(e.what()));
 
             // the batch is half-built and not rendered, skip now to avoid UB
-            return;
+            return true;
         }
 
         GGML_ASSERT(batch.slot_batched || batch.size() == 0);
@@ -2758,7 +3072,7 @@ private:
                 // TODO @ngxson : maybe handle n_batch == 1 here instead of inside decode()
 
                 batch_view = batch.get_view(off, n_tokens);
-                bool ok = decode(n_batch, off, batch_view);
+                bool ok = decode(grp, lk, n_batch, off, batch_view);
 #ifdef DEBUG_TIMINGS
                 llama_synchronize(ctx_tgt);
 #endif
@@ -2775,22 +3089,28 @@ private:
                 }
             } catch (const std::exception & e) {
                 SRV_ERR("decode() failed: %s\n", e.what());
-                abort_all_slots("decode() failed: " + std::string(e.what()));
+                abort_all_slots(grp, "decode() failed: " + std::string(e.what()));
                 break; // stop any further processing
             }
 
             try {
                 scoped_timer t(t_post_decode, n_post_decode);
-                post_decode(n_tokens, off, batch_view);
+                post_decode(grp, n_tokens, off, batch_view);
             } catch (const std::exception & e) {
                 SRV_ERR("post_decode() failed: %s\n", e.what());
-                abort_all_slots("post_decode() failed: " + std::string(e.what()));
+                abort_all_slots(grp, "post_decode() failed: " + std::string(e.what()));
                 break; // stop any further processing
             }
         }
+
+        return true;
     }
 
-    void pre_decode() {
+    void pre_decode(server_group & grp) {
+        auto * ctx_tgt = grp.ctx;
+        auto & batch   = grp.batch;
+        auto & slots   = grp.slots;
+        (void) ctx_tgt;
         // apply context-shift if needed
         // TODO: simplify and improve
         iterate(slots, [&](server_slot & slot) {
@@ -2832,8 +3152,8 @@ private:
 
                 SLT_WRN(slot, "slot context shift, n_keep = %d, n_left = %d, n_discard = %d\n", n_keep, n_left, n_discard);
 
-                slot.mem.seq_rm (slot.id, n_keep            , n_keep + n_discard);
-                slot.mem.seq_add(slot.id, n_keep + n_discard, slot.prompt.tokens.pos_next(), -n_discard);
+                slot.mem.seq_rm (slot.seq_id, n_keep            , n_keep + n_discard);
+                slot.mem.seq_add(slot.seq_id, n_keep + n_discard, slot.prompt.tokens.pos_next(), -n_discard);
 
                 // add generated tokens to cache
                 // ref: https://github.com/ggml-org/llama.cpp/pull/16818#discussion_r2473269481
@@ -2900,11 +3220,11 @@ private:
 
                         slot.spec_ckpt.update_pos(
                                 slot.prompt.n_tokens(),
-                                llama_memory_seq_pos_min(llama_get_memory(ctx_tgt), slot.id),
-                                llama_memory_seq_pos_max(llama_get_memory(ctx_tgt), slot.id));
+                                llama_memory_seq_pos_min(llama_get_memory(slot.ctx_tgt), slot.seq_id),
+                                llama_memory_seq_pos_max(llama_get_memory(slot.ctx_tgt), slot.seq_id));
 
                         if (use_ckpt_dft) {
-                            slot.spec_ckpt.update_dft(ctx_dft, slot.id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
+                            slot.spec_ckpt.update_dft(slot.ctx_dft, slot.seq_id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
                         }
 
                         slot.spec_prompt = slot.prompt.tokens.get_text_tokens();
@@ -2943,11 +3263,11 @@ private:
 
             if (ctx_dft) {
                 if (use_ckpt_dft) {
-                    ckpt.load_dft(ctx_dft, slot.id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
+                    ckpt.load_dft(slot.ctx_dft, slot.seq_id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
                 }
 
-                if (!llama_memory_seq_rm(llama_get_memory(ctx_dft), slot.id, ckpt.pos_max + 1, -1)) {
-                    GGML_ABORT("failed to remove sequence %d\n", slot.id);
+                if (!llama_memory_seq_rm(llama_get_memory(slot.ctx_dft), slot.seq_id, ckpt.pos_max + 1, -1)) {
+                    GGML_ABORT("failed to remove sequence %d\n", slot.seq_id);
                 }
             }
 
@@ -2962,7 +3282,7 @@ private:
                 if (use_ckpt_tgt) {
                     //const int64_t t_start = ggml_time_us();
 
-                    ckpt.update_tgt(ctx_tgt, slot.id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
+                    ckpt.update_tgt(slot.ctx_tgt, slot.seq_id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
 
                     //const int64_t t_total = ggml_time_us() - t_start;
                     //printf("checkpoint total: %f ms\n", t_total / 1000.0);
@@ -2974,7 +3294,7 @@ private:
                 }
 
                 if (use_ckpt_dft) {
-                    ckpt.update_dft(ctx_dft, slot.id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
+                    ckpt.update_dft(slot.ctx_dft, slot.seq_id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
                 }
             }
         });
@@ -3150,8 +3470,8 @@ private:
 
                                             const int64_t kv_shift = (int64_t) head_p - (int64_t) head_c;
 
-                                            slot.mem.seq_rm (slot.id, head_p, head_c);
-                                            slot.mem.seq_add(slot.id, head_c, head_c + n_match, kv_shift);
+                                            slot.mem.seq_rm (slot.seq_id, head_p, head_c);
+                                            slot.mem.seq_add(slot.seq_id, head_c, head_c + n_match, kv_shift);
 
                                             for (size_t i = 0; i < n_match; i++) {
                                                 slot.prompt.tokens.set_token(head_p + i, slot.prompt.tokens[head_c + i]);
@@ -3181,9 +3501,9 @@ private:
                             const auto pos_min_thold = std::max(0, pos_next - n_swa - (has_new_tokens ? 0 : 1));
 
                             if (n_past > 0 && n_past <= slot.prompt.n_tokens()) {
-                                const auto pos_min = llama_memory_seq_pos_min(llama_get_memory(ctx_tgt), slot.id);
+                                const auto pos_min = llama_memory_seq_pos_min(llama_get_memory(slot.ctx_tgt), slot.seq_id);
                                 if (pos_min == -1) {
-                                    SLT_ERR(slot, "n_past = %d, slot.prompt.tokens.size() = %d, seq_id = %d, pos_min = %d\n", n_past, (int) slot.prompt.tokens.size(), slot.id, pos_min);
+                                    SLT_ERR(slot, "n_past = %d, slot.prompt.tokens.size() = %d, seq_id = %d, pos_min = %d\n", n_past, (int) slot.prompt.tokens.size(), slot.seq_id, pos_min);
                                     GGML_ABORT("pos_min == -1, but n_past > 0 - should not happen: https://github.com/ggml-org/llama.cpp/pull/13833#discussion_r2116181237");
                                 }
 
@@ -3250,8 +3570,8 @@ private:
 
                                     if (!do_reset) {
                                         // restore the context checkpoint
-                                        it->load_tgt(ctx_tgt, slot.id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
-                                        it->load_dft(ctx_dft, slot.id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
+                                        it->load_tgt(slot.ctx_tgt, slot.seq_id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
+                                        it->load_dft(slot.ctx_dft, slot.seq_id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
                                         // restore the draft's speculative state
                                         common_speculative_set_state(spec.get(), slot.id, it->data_spec);
 
@@ -3325,7 +3645,7 @@ private:
 
                     SLT_TRC(slot, "cached n_tokens = %d, memory_seq_rm [%d, end)\n", slot.prompt.n_tokens(), p0);
 
-                    slot.mem.seq_rm(slot.id, p0, -1);
+                    slot.mem.seq_rm(slot.seq_id, p0, -1);
 
                     // If using an alora, there may be uncached tokens that come
                     // before the invocation sequence. When this happens, the
@@ -3423,7 +3743,7 @@ private:
                         // embedding requires all tokens in the batch to be output;
                         // MTP also wants logits at every prompt position so the
                         // streaming hook can mirror t_h_nextn into ctx_dft.
-                        add_ok &= batch.add(slot.id,
+                        add_ok &= batch.add(slot.id, slot.seq_id,
                             cur_tok,
                             /* pos       = */ slot.prompt.tokens.pos_next(),
                             /* output    = */ slot.need_embd(),
@@ -3493,8 +3813,8 @@ private:
                         }
                     }
 
-                    const auto pos_min = llama_memory_seq_pos_min(llama_get_memory(ctx_tgt), slot.id);
-                    const auto pos_max = llama_memory_seq_pos_max(llama_get_memory(ctx_tgt), slot.id);
+                    const auto pos_min = llama_memory_seq_pos_min(llama_get_memory(slot.ctx_tgt), slot.seq_id);
+                    const auto pos_max = llama_memory_seq_pos_max(llama_get_memory(slot.ctx_tgt), slot.seq_id);
 
                     // nothing to checkpoint yet
                     // TODO: is this check needed?
@@ -3528,7 +3848,11 @@ private:
 
     // returns true = success ; false = retry with smaller batch size
     // throw std::runtime_error on fatal error
-    bool decode(int32_t & n_batch, int32_t off, llama_batch & batch_view) {
+    bool decode(server_group & grp, std::unique_lock<std::mutex> & lk, int32_t & n_batch, int32_t off, llama_batch & batch_view) {
+        auto * ctx_tgt = grp.ctx;
+        auto & batch   = grp.batch;
+        auto & slots   = grp.slots;
+
         SRV_DBG("n_batch (effective) = %d, off = %d\n", n_batch, off);
 
         metrics_pre_decode();
@@ -3559,15 +3883,32 @@ private:
             has_output |= batch.tokens[i].output;
         }
 
-        // yield to the queue, so we can still handle metrics tasks while decoding
-        // note: the sync is done here too, so that the wait is also covered by the yield
         int ret = 0;
-        queue_tasks.yield_to_queue([&]() {
+        if (n_groups > 1) {
+            // release the engine for the duration of the compute - this is the whole point of the
+            // feature: while this group is on one stage of the layer split, the other group can
+            // run its own pre_decode / post_decode and submit its batch to the other stage
+            grp.busy = true;
+            lk.unlock();
+
             ret = llama_decode(ctx_tgt, batch_view);
             if (ret == 0 && has_output) {
                 llama_synchronize(ctx_tgt);
             }
-        });
+
+            lk.lock();
+            grp.busy = false;
+            cv_engine.notify_all();
+        } else {
+            // yield to the queue, so we can still handle metrics tasks while decoding
+            // note: the sync is done here too, so that the wait is also covered by the yield
+            queue_tasks.yield_to_queue([&]() {
+                ret = llama_decode(ctx_tgt, batch_view);
+                if (ret == 0 && has_output) {
+                    llama_synchronize(ctx_tgt);
+                }
+            });
+        }
 
         if (ret != 0) {
             {
@@ -3593,14 +3934,14 @@ private:
                 if (!err.empty()) {
                     SRV_ERR("%s off = %d, n_batch = %d, ret = %d\n", err.c_str(), off, n_batch, ret);
 
-                    for (auto & slot : slots) {
-                        if (slot.is_processing()) {
-                            send_error(slot, err);
-                            slot.release();
+                    for (auto * slot : slots) {
+                        if (slot->is_processing()) {
+                            send_error(*slot, err);
+                            slot->release();
 
                             // note: it's complicated to keep track of how much of the current batch has been
                             //       processed before the error occurred, so we simply clear the entire context
-                            slot.prompt_clear();
+                            slot->prompt_clear();
                         }
                     }
 
@@ -3610,7 +3951,7 @@ private:
             }
 
             // retry with half the batch size to try to find a free slot in the KV cache
-            if (!try_clear_idle_slots()) {
+            if (!try_clear_idle_slots(grp)) {
                 n_batch /= 2;
             }
 
@@ -3619,12 +3960,14 @@ private:
             return false; // retry with the updated n_batch
         } else {
             // success, apply batch metrics
-            metrics_post_decode(off, batch_view.n_tokens, has_output);
+            metrics_post_decode(grp, off, batch_view.n_tokens, has_output);
         }
 
         // TODO: avoid restoring the draft context and re-evaluating the drafted tokens when not needed [TAG_SPEC_AVOID_DRAFT_REEVAL]
         //       for now, always re-evaluate for simplicity
         //       ref: https://github.com/ggml-org/llama.cpp/pull/22728#issuecomment-4400925384
+        // note: speculative decoding is refused with more than one group, so this always runs on
+        //       the main thread and yield_to_queue() is safe here
         if (spec) {
             bool ok = true;
             queue_tasks.yield_to_queue([&]() {
@@ -3640,12 +3983,14 @@ private:
         }
 
         // handle `n_cmpl > 1` tasks - when the main prompt is processed, activate all child tasks too
-        for (auto & slot : slots) {
+        // note: children are always in the same group as the parent, see get_free_slots()
+        for (auto * slot_ptr : slots) {
+            auto & slot = *slot_ptr;
             if (slot.state == SLOT_STATE_DONE_PROMPT && slot.task->is_parent()) {
                 std::vector<server_slot *> children;
-                for (auto & other : slots) {
-                    if (other.state == SLOT_STATE_WAIT_OTHER && slot.task->id == other.task->id_parent) {
-                        children.push_back(&other);
+                for (auto * other : slots) {
+                    if (other->state == SLOT_STATE_WAIT_OTHER && slot.task->id == other->task->id_parent) {
+                        children.push_back(other);
                     }
                 }
 
@@ -3665,7 +4010,9 @@ private:
         return true;
     }
 
-    void post_decode(int32_t n_batch_tokens, int32_t off, llama_batch & batch_view) {
+    void post_decode(server_group & grp, int32_t n_batch_tokens, int32_t off, llama_batch & batch_view) {
+        auto & slots = grp.slots;
+
         // for checking if a given batch index is inside batch_view
         auto is_inside_view = [&](int32_t idx) {
             return idx >= off && idx < off + n_batch_tokens;
@@ -3821,13 +4168,13 @@ private:
 
                         SLT_DBG(slot, "restoring speculative checkpoint (pos_min = %d, pos_max = %d, size = %zu)\n", ckpt.pos_min, ckpt.pos_max, ckpt.size());
 
-                        ckpt.load_tgt(slot.ctx_tgt, slot.id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
+                        ckpt.load_tgt(slot.ctx_tgt, slot.seq_id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
 
                         if (slot.ctx_dft) {
-                            ckpt.load_dft(slot.ctx_dft, slot.id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
+                            ckpt.load_dft(slot.ctx_dft, slot.seq_id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
                         }
 
-                        slot.mem.seq_rm(slot.id, ckpt.pos_max + 1, -1);
+                        slot.mem.seq_rm(slot.seq_id, ckpt.pos_max + 1, -1);
 
                         slot.prompt.tokens.keep_first(ckpt.n_tokens);
                         common_sampler_copy(smpl_save.get(), slot.smpl.get());
@@ -3874,7 +4221,7 @@ private:
             slot.sampled = ids.back(); // last accepted token
             SLT_DBG(slot, "add accepted tokens: sampled=%d, ids.size=%zu, n_draft=%zu\n", slot.sampled, ids.size(), n_draft);
 
-            slot.mem.seq_rm(slot.id, slot.prompt.tokens.pos_next(), -1);
+            slot.mem.seq_rm(slot.seq_id, slot.prompt.tokens.pos_next(), -1);
 
             for (size_t i = 0; i < ids.size(); ++i) {
                 completion_token_output result;
@@ -3940,7 +4287,9 @@ private:
     }
 
     // has_output is computed by the caller, which also already synchronized the context if it is set
-    void metrics_post_decode(int32_t off, int32_t n_tokens, bool has_output) {
+    void metrics_post_decode(server_group & grp, int32_t off, int32_t n_tokens, bool has_output) {
+        auto & batch = grp.batch;
+
         metrics.n_decode++;
         for (const auto & slot : slots) {
             if (slot.is_processing()) {
@@ -3989,12 +4338,12 @@ private:
     }
 
     // flush any queued prompt metrics if all slots are now idle
-    void metrics_flush_idle() {
+    void metrics_flush_idle(server_group & grp) {
         if (n_prompt_queued == 0) {
             return;
         }
 
-        llama_synchronize(ctx_tgt);
+        llama_synchronize(grp.ctx);
         metrics_flush_prompt();
     }
 
@@ -4035,7 +4384,17 @@ bool server_context::load_model(common_params & params) {
 
 void server_context::start_loop() {
     auto & params = impl->params_base;
+
+    // no-op unless --pipeline-groups > 1
+    impl->start_groups();
+
     impl->queue_tasks.start_loop(params.sleep_idle_seconds * 1000);
+
+    impl->stop_groups();
+}
+
+void server_context::set_pipeline_groups(int n_groups) {
+    impl->n_pipeline_groups_req = n_groups;
 }
 
 void server_context::terminate() {

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -956,6 +956,19 @@ struct server_group {
     // slots owned by this group, in slot id order (slots are partitioned contiguously)
     std::vector<server_slot *> slots;
 
+    // speculative decoding state of this group
+    // note: a common_speculative and its draft (or MTP) context are bound to one target context,
+    //       so each group owns its own set, sized for the group's sequences and indexed by
+    //       slot.seq_id (which is slot.id with a single group)
+    common_speculative_init_result_ptr spec_init;
+
+    llama_model   * model_dft = nullptr;
+    llama_context * ctx_dft   = nullptr;
+
+    common_speculative_ptr spec;
+
+    common_context_seq_rm_type ctx_dft_seq_rm_type = COMMON_CONTEXT_SEQ_RM_TYPE_NO;
+
     // queued prompt stats - llama_decode() is async, so the timing is only valid after a sync
     // note: kept out of server_metrics, which is copied as-is into the task result
     int64_t  t_decode_start  = 0; // start of the last submitted decode of this group
@@ -1059,15 +1072,9 @@ private:
     std::mutex mtx_metrics;
     std::mutex mtx_prompt_cache;
 
-    llama_model   * model_dft = nullptr;
-    llama_context * ctx_dft   = nullptr;
-
-    common_speculative_init_result_ptr spec_init;
-
+    // note: the speculative decoding state (draft / MTP context, common_speculative) lives in
+    //       the groups, see struct server_group
     common_context_seq_rm_type ctx_tgt_seq_rm_type = COMMON_CONTEXT_SEQ_RM_TYPE_NO;
-    common_context_seq_rm_type ctx_dft_seq_rm_type = COMMON_CONTEXT_SEQ_RM_TYPE_NO;
-
-    common_speculative_ptr spec;
 
     bool add_bos_token = true;
 
@@ -1102,11 +1109,14 @@ private:
     int64_t t_last_load_progress_ms = 0;
 
     void destroy() {
-        spec.reset();
-        spec_init.reset();
+        // the draft / MTP context of a group refers to the group's context, so it goes first
+        for (auto & grp : groups) {
+            grp->spec.reset();
+            grp->spec_init.reset();
 
-        ctx_dft   = nullptr;
-        model_dft = nullptr;
+            grp->ctx_dft   = nullptr;
+            grp->model_dft = nullptr;
+        }
 
         // groups[0]->ctx is owned by llama_init, the rest were created by llama_init_from_model()
         for (size_t g = 1; g < groups.size(); ++g) {
@@ -1276,7 +1286,7 @@ private:
         // every code path below exactly as it was.
         n_groups = std::max(1, n_pipeline_groups_req);
 
-        if (n_groups > 1 && !validate_pipeline_groups(params_base, has_spec, has_mmproj)) {
+        if (n_groups > 1 && !validate_pipeline_groups(params_base, has_mmproj)) {
             return false;
         }
 
@@ -1366,30 +1376,40 @@ private:
             load_progress_callback(0.0f, &load_progress_spec);
             load_progress_spec.t_last_load_progress_ms = 0;  // reset so internal cbs aren't delayed
 
-            {
-                common_params params_dft = common_base_params_to_speculative(params_base);
+            // one draft / MTP context per group, each bound to the context of its group and sized
+            // for the group's sequences (with a single group params_ctx is params_base, as before)
+            // note: with --model-draft the draft model is loaded once per group
+            for (int g = 0; g < n_groups; ++g) {
+                server_group & grp = *groups[g];
+
+                common_params params_dft = common_base_params_to_speculative(params_ctx);
 
                 // progress callback
                 params_dft.load_progress_callback           = load_progress_callback;
                 params_dft.load_progress_callback_user_data = &load_progress_spec;
 
-                spec_init = common_speculative_init_from_params(params_dft, model_tgt, ctx_tgt);
-                model_dft = spec_init->model();
-                ctx_dft   = spec_init->context();
+                grp.spec_init = common_speculative_init_from_params(params_dft, model_tgt, grp.ctx);
+                grp.model_dft = grp.spec_init->model();
+                grp.ctx_dft   = grp.spec_init->context();
 
-                if (has_draft && model_dft == nullptr) {
+                if (has_draft && grp.model_dft == nullptr) {
                     SRV_ERR("failed to load draft model, '%s'\n", params_dft.model.path.c_str());
                     return false;
                 }
 
-                if (ctx_dft == nullptr) {
+                if (grp.ctx_dft == nullptr) {
                     SRV_ERR("%s", "failed to create MTP context\n");
                     return false;
                 }
 
-                params_base.speculative.draft.ctx_tgt = ctx_tgt;
-                params_base.speculative.draft.ctx_dft = ctx_dft;
+                if (n_groups > 1) {
+                    SRV_INF("created draft context for pipeline group %d, n_ctx = %d, n_seq_max = %d\n",
+                            g, (int) llama_n_ctx(grp.ctx_dft), (int) llama_n_seq_max(grp.ctx_dft));
+                }
             }
+
+            params_base.speculative.draft.ctx_tgt = ctx_tgt;
+            params_base.speculative.draft.ctx_dft = groups[0]->ctx_dft;
 
             load_progress_callback(1.0f, &load_progress_spec);
         }
@@ -1474,26 +1494,33 @@ private:
         }
 
         // try speculative decoding
-        // note: a common_speculative is bound to one target context, and its code paths yield to
-        //       the task queue, which only one thread may do - so it is off with several groups
-        if (ctx_tgt_seq_rm_type != COMMON_CONTEXT_SEQ_RM_TYPE_NO && n_groups == 1) {
-            try {
-                spec.reset(common_speculative_init(params_base.speculative, params_base.n_parallel));
-            } catch (const std::exception & e) {
-                SRV_ERR("failed to initialize speculative decoding context: %s\n", e.what());
+        // note: a common_speculative is bound to one target context, so each group gets its own,
+        //       sized for the group's sequences (n_seq_per_group == n_parallel with one group)
+        for (auto & grp : groups) {
+            if (ctx_tgt_seq_rm_type != COMMON_CONTEXT_SEQ_RM_TYPE_NO) {
+                common_params_speculative params_spec = params_base.speculative;
+
+                params_spec.draft.ctx_tgt = grp->ctx;
+                params_spec.draft.ctx_dft = grp->ctx_dft;
+
+                try {
+                    grp->spec.reset(common_speculative_init(params_spec, n_seq_per_group));
+                } catch (const std::exception & e) {
+                    SRV_ERR("failed to initialize speculative decoding context: %s\n", e.what());
+                }
             }
-        }
 
-        if (ctx_dft) {
-            ctx_dft_seq_rm_type = common_context_can_seq_rm(ctx_dft);
-        }
+            if (grp->ctx_dft) {
+                grp->ctx_dft_seq_rm_type = common_context_can_seq_rm(grp->ctx_dft);
+            }
 
-        if (spec) {
-            SRV_TRC("%s", "speculative decoding context initialized\n");
-        } else {
-            spec_init.reset();
-            ctx_dft   = nullptr;
-            model_dft = nullptr;
+            if (grp->spec) {
+                SRV_TRC("%s", "speculative decoding context initialized\n");
+            } else {
+                grp->spec_init.reset();
+                grp->ctx_dft   = nullptr;
+                grp->model_dft = nullptr;
+            }
         }
 
         for (int i = 0; i < params_base.n_parallel; i++) {
@@ -1506,11 +1533,11 @@ private:
             slot.id_group = grp.id;
             slot.seq_id   = i % n_seq_per_group;
             slot.ctx_tgt  = grp.ctx;
-            slot.ctx_dft  = ctx_dft;
-            slot.mem.init(grp.ctx, ctx_dft);
+            slot.ctx_dft  = grp.ctx_dft;
+            slot.mem.init(grp.ctx, grp.ctx_dft);
 
             grp.slots.push_back(&slot);
-            slot.spec    = spec.get();
+            slot.spec    = grp.spec.get();
             slot.n_ctx   = n_ctx_slot;
 
             slot.mctx                   = mctx;
@@ -1641,7 +1668,7 @@ private:
     }
 
     // refuse everything we cannot make safe with more than one context, rather than half-support it
-    bool validate_pipeline_groups(const common_params & params, bool has_spec, bool has_mmproj) const {
+    bool validate_pipeline_groups(const common_params & params, bool has_mmproj) const {
         auto refuse = [](const char * what) {
             SRV_ERR("--pipeline-groups > 1 is not supported together with %s\n", what);
             return false;
@@ -1663,10 +1690,8 @@ private:
             return false;
         }
 
-        // a common_speculative and its draft context are bound to one target context
-        if (has_spec) {
-            return refuse("speculative decoding (--model-draft / MTP)");
-        }
+        // note: speculative decoding is fine - every group owns a draft / MTP context and a
+        //       common_speculative of its own, see struct server_group
 
         // mtmd_context is bound to one llama_context
         if (has_mmproj) {
@@ -2783,7 +2808,7 @@ private:
         cur.update_tgt(slot.ctx_tgt, slot.seq_id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
         cur.update_dft(slot.ctx_dft, slot.seq_id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
         // stash the draft's speculative state with the checkpoint
-        common_speculative_get_state(spec.get(), slot.id, cur.data_spec);
+        common_speculative_get_state(slot.spec, slot.seq_id, cur.data_spec);
 
         SLT_TRC(slot,
                 "created context checkpoint %d of %d (pos_min = %d, pos_max = %d, n_tokens = %" PRId64 ", size = %.3f MiB)\n",
@@ -3447,6 +3472,11 @@ private:
         auto & batch   = grp.batch;
         auto & slots   = grp.slots;
         (void) ctx_tgt;
+
+        // the speculative state of this group
+        auto & spec    = grp.spec;
+        auto * ctx_dft = grp.ctx_dft;
+        const auto ctx_dft_seq_rm_type = grp.ctx_dft_seq_rm_type;
         // apply context-shift if needed
         // TODO: simplify and improve
         iterate(slots, [&](server_slot & slot) {
@@ -3536,7 +3566,7 @@ private:
             generating.push_back(&slot);
 
             if (spec) {
-                common_speculative_get_draft_params(spec.get(), slot.id).drafting = false;
+                common_speculative_get_draft_params(spec.get(), slot.seq_id).drafting = false;
 
                 const bool use_ckpt_tgt = ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL;
                 const bool use_ckpt_dft = ctx_dft_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL;
@@ -3565,7 +3595,7 @@ private:
 
                         slot.spec_prompt = slot.prompt.tokens.get_text_tokens();
 
-                        common_speculative_get_draft_params(spec.get(), slot.id) = {
+                        common_speculative_get_draft_params(spec.get(), slot.seq_id) = {
                             /* .drafting = */ true,
                             /* .n_max    = */ n_draft_max,
                             /* .n_past   = */ slot.prompt.n_tokens(),
@@ -3581,10 +3611,16 @@ private:
         });
 
         // generate the actual drafts (if any)
+        // note: only the main thread may yield to the task queue, and with several groups each
+        //       group drafts on its own thread and against its own draft context
         if (!drafting.empty()) {
-            queue_tasks.yield_to_queue([&]() {
+            if (n_groups > 1) {
                 common_speculative_draft(spec.get());
-            });
+            } else {
+                queue_tasks.yield_to_queue([&]() {
+                    common_speculative_draft(spec.get());
+                });
+            }
         }
 
         // make checkpoints if needed
@@ -3909,7 +3945,7 @@ private:
                                         it->load_tgt(slot.ctx_tgt, slot.seq_id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
                                         it->load_dft(slot.ctx_dft, slot.seq_id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
                                         // restore the draft's speculative state
-                                        common_speculative_set_state(spec.get(), slot.id, it->data_spec);
+                                        common_speculative_set_state(spec.get(), slot.seq_id, it->data_spec);
 
                                         pos_next = std::min(pos_next, std::max(it->pos_min + 1, it->pos_max));
                                         n_past   = std::min(slot.prompt.tokens.size_up_to_pos(pos_next), (size_t) it->n_tokens);
@@ -4192,6 +4228,10 @@ private:
         auto & batch   = grp.batch;
         auto & slots   = grp.slots;
 
+        // the speculative state of this group
+        auto & spec      = grp.spec;
+        auto * model_dft = grp.model_dft;
+
         SRV_DBG("n_batch (effective) = %d, off = %d\n", n_batch, off);
 
         metrics_pre_decode(grp);
@@ -4327,13 +4367,17 @@ private:
         // TODO: avoid restoring the draft context and re-evaluating the drafted tokens when not needed [TAG_SPEC_AVOID_DRAFT_REEVAL]
         //       for now, always re-evaluate for simplicity
         //       ref: https://github.com/ggml-org/llama.cpp/pull/22728#issuecomment-4400925384
-        // note: speculative decoding is refused with more than one group, so this always runs on
-        //       the main thread and yield_to_queue() is safe here
+        // note: only the main thread may yield to the task queue; with several groups the batch
+        //       goes through this group's draft context on this group's thread
         if (spec) {
             bool ok = true;
-            queue_tasks.yield_to_queue([&]() {
+            if (n_groups > 1) {
                 ok = common_speculative_process(spec.get(), batch_view);
-            });
+            } else {
+                queue_tasks.yield_to_queue([&]() {
+                    ok = common_speculative_process(spec.get(), batch_view);
+                });
+            }
 
             if (!ok) {
                 SRV_ERR("%s", "failed to process speculative batch\n");
@@ -4375,6 +4419,9 @@ private:
         // shadow the single-context members, as update_slots() does
         auto * ctx_tgt = grp.ctx;
         auto & slots   = grp.slots;
+
+        // the speculative state of this group
+        auto & spec = grp.spec;
         (void) ctx_tgt;
 
         // for checking if a given batch index is inside batch_view
@@ -4487,7 +4534,7 @@ private:
                 slot.state = SLOT_STATE_GENERATING;
 
                 if (slot.can_speculate()) {
-                    common_speculative_begin(spec.get(), slot.id, slot.prompt.tokens.get_text_tokens());
+                    common_speculative_begin(spec.get(), slot.seq_id, slot.prompt.tokens.get_text_tokens());
                 }
             } else if (slot.state != SLOT_STATE_GENERATING) {
                 return;
@@ -4619,7 +4666,7 @@ private:
                     SLT_INF(slot, "accepted %2zu/%2zu draft tokens\n", accepted.size() - 1, n_draft);
                 }
 
-                common_speculative_accept(spec.get(), slot.id, accepted.size() - 1);
+                common_speculative_accept(spec.get(), slot.seq_id, accepted.size() - 1);
 
                 slot.spec_draft = std::move(accepted);
             }

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -813,6 +813,14 @@ struct server_group {
     // slots owned by this group, in slot id order (slots are partitioned contiguously)
     std::vector<server_slot *> slots;
 
+    // queued prompt stats - llama_decode() is async, so the timing is only valid after a sync
+    // note: kept out of server_metrics, which is copied as-is into the task result
+    int64_t  t_decode_start  = 0; // start of the last submitted decode of this group
+    int64_t  t_prompt_start  = 0; // start of the oldest queued prompt decode of this group
+    uint64_t n_prompt_queued = 0;
+
+    int n_empty_consecutive = 0;
+
     // only used when n_groups > 1, all guarded by server_context_impl::mtx_engine
     std::thread thread;
     bool busy        = false; // a decode is in flight, no one may touch ctx
@@ -915,17 +923,9 @@ private:
     int slots_debug = 0;  // env: LLAMA_SERVER_SLOTS_DEBUG
     int slots_n_diff = 0; // env: LLAMA_SERVER_SLOTS_N_DIFF
 
-    int n_empty_consecutive = 0;
-
     std::unique_ptr<server_prompt_cache> prompt_cache;
 
     server_metrics metrics;
-
-    // queued prompt stats - llama_decode() is async, so the timing is only valid after a sync
-    // note: kept out of server_metrics, which is copied as-is into the task result
-    int64_t  t_decode_start  = 0; // start of the last submitted decode
-    int64_t  t_prompt_start  = 0; // start of the oldest queued prompt decode
-    uint64_t n_prompt_queued = 0;
 
     json json_ui_settings = json::object();
 
@@ -1182,6 +1182,11 @@ private:
                 groups[g]->ctx = llama_init_from_model(model_tgt, cparams);
                 if (groups[g]->ctx == nullptr) {
                     SRV_ERR("failed to create llama_context for pipeline group %d\n", g);
+                    for (int j = 1; j < g; ++j) {
+                        llama_free(groups[j]->ctx);
+                        groups[j]->ctx = nullptr;
+                    }
+                    groups.clear();
                     return false;
                 }
 
@@ -1485,6 +1490,12 @@ private:
             return refuse("multimodal (--mmproj)");
         }
 
+        // common_init_from_params() applies the control vector to the context it creates and only
+        // to that one, so the extra contexts would silently run without it
+        if (!params.control_vectors.empty()) {
+            return refuse("--control-vector");
+        }
+
         // entering / leaving the sleeping state destroys and rebuilds the contexts under the
         // running group threads
         if (params.sleep_idle_seconds >= 0) {
@@ -1509,6 +1520,9 @@ private:
             if (n_groups > 1) {
                 // each pipeline group runs its own update loop on its own thread
                 return;
+            }
+            if (groups.empty()) {
+                return; // no model loaded
             }
             update_slots(*groups[0]);
         });
@@ -2011,7 +2025,7 @@ private:
             : SLOT_STATE_STARTED;
 
         // reset server kill-switch counter
-        n_empty_consecutive = 0;
+        groups[slot.id_group]->n_empty_consecutive = 0;
 
         SLT_INF(slot, "processing task, is_child = %d\n", slot.task->is_child());
         return true;
@@ -2175,7 +2189,7 @@ private:
 
                 result.probs.push_back({
                     cur_p->data[i].id,
-                    common_token_to_piece(ctx_tgt, cur_p->data[i].id, special),
+                    common_token_to_piece(slot.ctx_tgt, cur_p->data[i].id, special),
                     cur_p->data[i].p
                 });
             }
@@ -2198,7 +2212,7 @@ private:
             for (size_t i = 0; i < n_probs; i++) {
                 result.probs.push_back({
                     cur[i].id,
-                    common_token_to_piece(ctx_tgt, cur[i].id, special),
+                    common_token_to_piece(slot.ctx_tgt, cur[i].id, special),
                     cur[i].p
                 });
             }
@@ -2295,7 +2309,7 @@ private:
             res->tokens      = std::move(slot.generated_tokens);
         }
         res->stats           = slot.stats;
-        res->prompt          = slot.task->tokens.detokenize(ctx_tgt, true);
+        res->prompt          = slot.task->tokens.detokenize(slot.ctx_tgt, true);
         res->response_fields = std::move(slot.task->params.response_fields);
 
         res->truncated             = slot.truncated;
@@ -2318,7 +2332,7 @@ private:
         // populate res.probs_output
         if (slot.task->params.sampling.n_probs > 0) {
             if (!slot.task->params.stream && slot.stop == STOP_TYPE_WORD) {
-                const llama_tokens stop_word_toks = common_tokenize(ctx_tgt, slot.stopping_word, false);
+                const llama_tokens stop_word_toks = common_tokenize(slot.ctx_tgt, slot.stopping_word, false);
 
                 size_t safe_offset = std::min(slot.generated_token_probs.size(), stop_word_toks.size());
                 res->probs_output = std::vector<completion_token_output>(
@@ -2597,6 +2611,15 @@ private:
                     if (task.is_parent()) {
                         // try getting free slots for all child tasks
                         size_t n_child_tasks = task.child_tasks.size();
+                        // the children take their KV from the parent, so they must fit in the
+                        // parent's group. with a single group this is the limit the request
+                        // schema already enforces, so nothing changes there.
+                        if ((int) n_child_tasks + 1 > n_seq_per_group) {
+                            send_error(task, string_format(
+                                "n_cmpl must not exceed the number of slots per pipeline group (%d)", n_seq_per_group),
+                                ERROR_TYPE_INVALID_REQUEST);
+                            break;
+                        }
                         std::vector<server_slot *> child_slots = get_free_slots(n_child_tasks, slot->id, slot->id_group);
                         if (child_slots.size() < n_child_tasks) {
                             SRV_DBG("not enough free slots for child tasks, n_free = %zu, n_children = %zu, defer task, id_task = %d\n", child_slots.size(), n_child_tasks, id_task);
@@ -3691,7 +3714,7 @@ private:
                         // process the mtmd chunk
                         // note: it submits its own decode, potentially be async
                         //       so the timing is queued and flushed on the next sync
-                        metrics_pre_decode();
+                        metrics_pre_decode(grp);
 
                         // encode on the worker thread, so we can still handle metrics tasks
                         size_t n_tokens_out = 0;
@@ -3707,7 +3730,7 @@ private:
                             return; // the slot is done, skip it entirely
                         }
 
-                        metrics_queue_prompt(n_tokens_out);
+                        metrics_queue_prompt(grp, n_tokens_out);
                         slot.stats.n_prompt_processed += n_tokens_out;
                         slot.stats.update_prompt_last();
 
@@ -3855,18 +3878,18 @@ private:
 
         SRV_DBG("n_batch (effective) = %d, off = %d\n", n_batch, off);
 
-        metrics_pre_decode();
+        metrics_pre_decode(grp);
 
         if (batch.size() == 0) {
             SRV_WRN("%s", "no tokens to decode\n");
 
-            if (++n_empty_consecutive > 3) {
+            if (++grp.n_empty_consecutive > 3) {
                 GGML_ABORT("fatal error - please provide logs and repro in %s\n", "https://github.com/ggml-org/llama.cpp/pull/20277");
             }
 
             return true; // nothing to decode
         } else {
-            n_empty_consecutive = 0;
+            grp.n_empty_consecutive = 0;
         }
 
         // TODO @ngxson : dft model may have different n_embd than the tgt model, so we check & reject if that's the case
@@ -3888,17 +3911,28 @@ private:
             // release the engine for the duration of the compute - this is the whole point of the
             // feature: while this group is on one stage of the layer split, the other group can
             // run its own pre_decode / post_decode and submit its batch to the other stage
-            grp.busy = true;
-            lk.unlock();
+            // note: RAII, so a throwing decode cannot leave the group marked busy forever, nor
+            //       return to the caller's error handling without the engine lock held
+            struct decode_window {
+                server_context_impl * srv;
+                server_group * grp;
+                std::unique_lock<std::mutex> * lk;
+                decode_window(server_context_impl * srv, server_group * grp, std::unique_lock<std::mutex> * lk)
+                        : srv(srv), grp(grp), lk(lk) {
+                    grp->busy = true;
+                    lk->unlock();
+                }
+                ~decode_window() {
+                    lk->lock();
+                    grp->busy = false;
+                    srv->cv_engine.notify_all();
+                }
+            } window(this, &grp, &lk);
 
             ret = llama_decode(ctx_tgt, batch_view);
             if (ret == 0 && has_output) {
                 llama_synchronize(ctx_tgt);
             }
-
-            lk.lock();
-            grp.busy = false;
-            cv_engine.notify_all();
         } else {
             // yield to the queue, so we can still handle metrics tasks while decoding
             // note: the sync is done here too, so that the wait is also covered by the yield
@@ -4011,7 +4045,10 @@ private:
     }
 
     void post_decode(server_group & grp, int32_t n_batch_tokens, int32_t off, llama_batch & batch_view) {
-        auto & slots = grp.slots;
+        // shadow the single-context members, as update_slots() does
+        auto * ctx_tgt = grp.ctx;
+        auto & slots   = grp.slots;
+        (void) ctx_tgt;
 
         // for checking if a given batch index is inside batch_view
         auto is_inside_view = [&](int32_t idx) {
@@ -4262,28 +4299,28 @@ private:
     //
 
     // call before submitting a decode, so that the queued prompt stats can be timed
-    void metrics_pre_decode() {
-        t_decode_start = ggml_time_us();
+    void metrics_pre_decode(server_group & grp) {
+        grp.t_decode_start = ggml_time_us();
     }
 
     // the batch is submitted, but its compute may not be done yet
-    void metrics_queue_prompt(uint64_t n_tokens) {
+    void metrics_queue_prompt(server_group & grp, uint64_t n_tokens) {
         if (n_tokens == 0) {
             return;
         }
-        if (n_prompt_queued == 0) {
-            t_prompt_start = t_decode_start;
+        if (grp.n_prompt_queued == 0) {
+            grp.t_prompt_start = grp.t_decode_start;
         }
-        n_prompt_queued += n_tokens;
+        grp.n_prompt_queued += n_tokens;
     }
 
     // call only after the context is synchronized, otherwise the time is meaningless
-    void metrics_flush_prompt() {
-        if (n_prompt_queued == 0) {
+    void metrics_flush_prompt(server_group & grp) {
+        if (grp.n_prompt_queued == 0) {
             return;
         }
-        metrics.add_prompt(n_prompt_queued, ggml_time_us() - t_prompt_start);
-        n_prompt_queued = 0;
+        metrics.add_prompt(grp.n_prompt_queued, ggml_time_us() - grp.t_prompt_start);
+        grp.n_prompt_queued = 0;
     }
 
     // has_output is computed by the caller, which also already synchronized the context if it is set
@@ -4318,11 +4355,11 @@ private:
             }
         }
 
-        metrics_queue_prompt(n_prompt_tokens);
+        metrics_queue_prompt(grp, n_prompt_tokens);
 
         if (has_output) {
             // the context is already synchronized, so the timings are correct
-            metrics_flush_prompt();
+            metrics_flush_prompt(grp);
         }
 
         // advance the prompt timing of the slots that had tokens in this batch
@@ -4339,12 +4376,12 @@ private:
 
     // flush any queued prompt metrics if all slots are now idle
     void metrics_flush_idle(server_group & grp) {
-        if (n_prompt_queued == 0) {
+        if (grp.n_prompt_queued == 0) {
             return;
         }
 
         llama_synchronize(grp.ctx);
-        metrics_flush_prompt();
+        metrics_flush_prompt(grp);
     }
 
     void metrics_on_prediction(const server_slot & slot) {

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -318,6 +318,10 @@ struct server_slot {
 
     llama_token sampled; // in speculative mode, this is the last accepted token
 
+    // token produced by the parallel sampling pass of post_decode, LLAMA_TOKEN_NULL if that pass
+    // did not run for this slot (then the sequential path samples it as before)
+    llama_token pre_sampled = LLAMA_TOKEN_NULL;
+
     // for TTS models, this is the embd generated from prev step, decode this to generate next hidden state
     // corresponding to one token position (size = n_embd)
     std::vector<float> inp_embd;
@@ -336,6 +340,7 @@ struct server_slot {
     int32_t n_gen_last = 0;
 
     void reset() {
+        pre_sampled = LLAMA_TOKEN_NULL;
         SLT_DBG(*this, "%s", "\n");
 
         spec_is_replay = false;
@@ -803,6 +808,144 @@ static int process_mtmd_chunk(const server_slot & slot, mtmd::batch_ptr & mbatch
 // With N > 1 the point is that while group A's batch is being computed on the second stage of a
 // layer split (the RPC peer), group B's batch can be computed on the first stage (the local GPU),
 // so both devices are busy instead of each idling half of every decode step.
+
+// -----------------------------------------------------------------------------
+// per-group host-path profiling, enabled with LLAMA_SERVER_PIPE_PROF=1
+// -----------------------------------------------------------------------------
+
+static bool pipe_prof_enabled() {
+    const char * e = getenv("LLAMA_SERVER_PIPE_PROF");
+    return e != nullptr && atoi(e) != 0;
+}
+
+struct server_group_prof {
+    int64_t n_iter = 0;
+    int64_t n_tok  = 0;
+
+    int64_t t_lock   = 0; // waiting for the engine lock at the top of the iteration
+    int64_t t_pre    = 0; // pre_decode + render
+    int64_t t_submit = 0; // llama_decode
+    int64_t t_sync   = 0; // llama_synchronize
+    int64_t t_relock = 0; // re-taking the engine lock after the decode
+    int64_t t_post   = 0; // post_decode
+    int64_t t_sampl  = 0; //   of which: common_sampler_sample
+    int64_t t_sampl_par = 0; //   of which: the parallel sampling pass
+    int64_t t_piece  = 0; //   of which: common_token_to_piece
+    int64_t t_proc   = 0; //   of which: process_token (stop strings, streaming)
+    int64_t t_send   = 0; //   of which: queue_results.send
+    int64_t t_iter   = 0; // the whole iteration
+};
+
+struct prof_timer {
+    int64_t * acc;
+    int64_t   t0;
+    prof_timer(int64_t * acc_, bool on) : acc(on ? acc_ : nullptr) {
+        if (acc) { t0 = ggml_time_us(); }
+    }
+    ~prof_timer() {
+        if (acc) { *acc += ggml_time_us() - t0; }
+    }
+    prof_timer(const prof_timer &) = delete;
+    prof_timer & operator=(const prof_timer &) = delete;
+};
+
+
+// A tiny fixed worker pool used to sample the slots of one group in parallel.
+//
+// Sampling one row of a 250k-token vocabulary costs about 0.6 ms on this hardware, and it costs
+// six times that while the other pipeline group is driving the GPUs, so a serial pass over the
+// slots is tens of milliseconds sitting on the critical path between the decode and the next
+// submit. The rows are independent - each slot has its own sampler and reads its own row of the
+// logits - so they can be done at the same time. The output is identical either way.
+struct server_par_for {
+    std::vector<std::thread>        workers;
+    std::mutex                      mtx;
+    std::condition_variable         cv_work;
+    std::condition_variable         cv_done;
+    const std::function<void(int)> * fn = nullptr;
+    int      n         = 0;
+    int      next      = 0;
+    int      n_running = 0;
+    uint64_t gen       = 0;
+    bool     stop      = false;
+
+    void start(int n_threads) {
+        for (int i = 0; i < n_threads; ++i) {
+            workers.emplace_back([this]() { worker(); });
+        }
+    }
+
+    // run fn(0..n_-1), the calling thread takes its share too
+    void run(int n_, const std::function<void(int)> & f) {
+        if (workers.empty() || n_ <= 1) {
+            for (int i = 0; i < n_; ++i) {
+                f(i);
+            }
+            return;
+        }
+
+        std::unique_lock<std::mutex> lk(mtx);
+
+        fn   = &f;
+        n    = n_;
+        next = 0;
+        gen++;
+
+        cv_work.notify_all();
+
+        take_jobs(lk);
+
+        cv_done.wait(lk, [&] { return next >= n && n_running == 0; });
+    }
+
+    ~server_par_for() {
+        {
+            std::lock_guard<std::mutex> lk(mtx);
+            stop = true;
+        }
+        cv_work.notify_all();
+        for (auto & t : workers) {
+            if (t.joinable()) {
+                t.join();
+            }
+        }
+    }
+
+private:
+    void take_jobs(std::unique_lock<std::mutex> & lk) {
+        while (next < n) {
+            const int i = next++;
+            n_running++;
+            lk.unlock();
+            // note: the job itself must not throw, the callers wrap it
+            (*fn)(i);
+            lk.lock();
+            n_running--;
+        }
+        if (n_running == 0) {
+            cv_done.notify_all();
+        }
+    }
+
+    void worker() {
+        std::unique_lock<std::mutex> lk(mtx);
+        uint64_t seen = 0;
+        while (true) {
+            cv_work.wait(lk, [&] { return stop || gen != seen; });
+            if (stop) {
+                return;
+            }
+            seen = gen;
+            take_jobs(lk);
+        }
+    }
+};
+
+struct server_group;
+
+// the group whose decode loop is running on this thread, used by the deep call sites
+static thread_local server_group * tls_group = nullptr;
+
 struct server_group {
     int id = 0;
 
@@ -821,10 +964,22 @@ struct server_group {
 
     int n_empty_consecutive = 0;
 
-    // only used when n_groups > 1, all guarded by server_context_impl::mtx_engine
+    // host-path profiling, only filled in when LLAMA_SERVER_PIPE_PROF=1
+    server_group_prof prof;
+
+    // sampling of this group's slots, run over several threads (see server_par_for)
+    server_par_for            pool;
+    std::vector<server_slot *> to_sample;
+
+    // only used when n_groups > 1
+    // note: the lock is per group on purpose - the whole point of the feature is that the host
+    //       path of one group (pre_decode, sampling, streaming, post_decode) runs while the other
+    //       group is on the GPU, so nothing here may be shared between groups
     std::thread thread;
+    std::mutex              mtx;  // guards this group's slots, batch and the two fields below
+    std::condition_variable cv;
     bool busy        = false; // a decode is in flight, no one may touch ctx
-    int  n_pause_req = 0;     // someone wants the engine stopped, do not start a new iteration
+    int  n_pause_req = 0;     // someone wants this group stopped, do not start a new iteration
 };
 
 //
@@ -890,13 +1045,19 @@ private:
     int n_groups = 1;
     std::vector<std::unique_ptr<server_group>> groups;
 
+    // LLAMA_SERVER_PIPE_PROF=1: time the host path of each group separately
+    const bool prof_on = pipe_prof_enabled();
+
     // number of sequences per context, == params_base.n_parallel when n_groups == 1
     int n_seq_per_group = 1;
 
     // the following are only ever touched when n_groups > 1
-    std::mutex              mtx_engine;
-    std::condition_variable cv_engine;
-    bool                    groups_stop = false;
+    std::atomic<bool> groups_stop { false };
+
+    // server_metrics and the prompt cache are shared by every group, so they get their own locks
+    // instead of riding on a global engine lock. Both are off the per-token path.
+    std::mutex mtx_metrics;
+    std::mutex mtx_prompt_cache;
 
     llama_model   * model_dft = nullptr;
     llama_context * ctx_dft   = nullptr;
@@ -1408,6 +1569,28 @@ private:
             }
         }
 
+        // sampling threads. The budget is the same however many groups there are, so that a
+        // pipeline-groups run is not simply given more CPU than the single-context run.
+        {
+            int n_sampling_threads = 8;
+
+            if (const char * e = getenv("LLAMA_SERVER_SAMPLE_THREADS")) {
+                n_sampling_threads = atoi(e);
+            }
+
+            n_sampling_threads = std::min(n_sampling_threads, (int) std::thread::hardware_concurrency());
+            n_sampling_threads = std::max(0, n_sampling_threads / n_groups);
+
+            // the calling thread takes a share too, so this many extra workers
+            const int n_workers = std::max(0, n_sampling_threads - 1);
+
+            for (auto & grp : groups) {
+                grp->pool.start(n_workers);
+            }
+
+            SRV_INF("sampling threads per pipeline group: %d\n", n_sampling_threads);
+        }
+
         if (params_base.cache_ram_mib != 0) {
             if (params_base.cache_ram_mib < 0) {
                 SRV_TRC("prompt cache is enabled, size limit: %s\n", "no limit");
@@ -1626,13 +1809,13 @@ private:
     // Constructing this is a no-op when there is a single group: the single update loop and the
     // task processing then run on the same thread, exactly as before.
     //
-    // Taking mtx_engine already keeps every group out of a new iteration, so the slot state is
+    // Taking every group's lock keeps every group out of a new iteration, so the slot state is
     // stable as soon as the guard exists. Only touching a llama_context needs more than that,
-    // and only for the group that owns it: wait_for() blocks until that group's decode is done
-    // while the other groups keep computing. Tasks that touch no context wait for nobody.
+    // and only for the group that owns it: wait_for() drops the other groups' locks first, so
+    // their host path keeps running, then blocks until that group's decode is done.
     struct engine_guard {
         server_context_impl * srv = nullptr;
-        std::unique_lock<std::mutex> lk;
+        std::vector<std::unique_lock<std::mutex>> lks;
 
         explicit engine_guard(server_context_impl * srv_) {
             if (srv_->n_groups <= 1) {
@@ -1640,25 +1823,35 @@ private:
             }
 
             srv = srv_;
-            lk  = std::unique_lock<std::mutex>(srv->mtx_engine);
 
-            // ask every group to stop at the start of its next iteration, so that the slot state
-            // cannot change under us while wait_for() releases the lock
-            for (auto & grp : srv->groups) {
-                grp->n_pause_req++;
+            // take every group's lock, in group order, so that the slot state of the whole server
+            // is stable while the task is being routed. This blocks the host path of the groups,
+            // not their decodes, and it is released again as soon as the task knows which group
+            // it needs.
+            lks.resize(srv->groups.size());
+
+            for (size_t g = 0; g < srv->groups.size(); ++g) {
+                lks[g] = std::unique_lock<std::mutex>(srv->groups[g]->mtx);
+                srv->groups[g]->n_pause_req++;
             }
         }
 
-        // wait until this group is not inside llama_decode, so its context can be touched
+        // let every group except id_group go, then wait until this one is not inside llama_decode
         void wait_for(int id_group) {
             if (srv == nullptr) {
                 return;
             }
 
             GGML_ASSERT(id_group >= 0 && id_group < (int) srv->groups.size());
-            server_group * grp = srv->groups[id_group].get();
 
-            srv->cv_engine.wait(lk, [&] { return !grp->busy; });
+            for (size_t g = 0; g < srv->groups.size(); ++g) {
+                if ((int) g != id_group) {
+                    release(g);
+                }
+            }
+
+            server_group * grp = srv->groups[id_group].get();
+            grp->cv.wait(lks[id_group], [&] { return !grp->busy; });
         }
 
         // wait for every group, for tasks that are not tied to one slot
@@ -1667,14 +1860,10 @@ private:
                 return;
             }
 
-            srv->cv_engine.wait(lk, [&] {
-                for (auto & grp : srv->groups) {
-                    if (grp->busy) {
-                        return false;
-                    }
-                }
-                return true;
-            });
+            for (size_t g = 0; g < srv->groups.size(); ++g) {
+                server_group * grp = srv->groups[g].get();
+                grp->cv.wait(lks[g], [&] { return !grp->busy; });
+            }
         }
 
         ~engine_guard() {
@@ -1682,26 +1871,30 @@ private:
                 return;
             }
 
-            for (auto & grp : srv->groups) {
-                grp->n_pause_req--;
+            for (size_t g = 0; g < srv->groups.size(); ++g) {
+                release(g);
             }
-
-            lk.unlock();
-            srv->cv_engine.notify_all();
         }
 
         engine_guard(const engine_guard &) = delete;
         engine_guard & operator=(const engine_guard &) = delete;
+
+    private:
+        void release(size_t g) {
+            if (!lks[g].owns_lock()) {
+                return;
+            }
+            srv->groups[g]->n_pause_req--;
+            lks[g].unlock();
+            srv->groups[g]->cv.notify_all();
+        }
     };
 
     // the decode loop of one pipeline group, only used when n_groups > 1
     void group_loop(server_group & grp) {
         while (true) {
-            {
-                std::unique_lock<std::mutex> lk(mtx_engine);
-                if (groups_stop) {
-                    return;
-                }
+            if (groups_stop.load(std::memory_order_relaxed)) {
+                return;
             }
 
             if (update_slots(grp)) {
@@ -1709,8 +1902,9 @@ private:
             }
 
             // nothing to do for this group, wait for a task to be assigned to one of its slots
-            std::unique_lock<std::mutex> lk(mtx_engine);
-            cv_engine.wait_for(lk, std::chrono::milliseconds(5), [&] { return groups_stop; });
+            std::unique_lock<std::mutex> lk(grp.mtx);
+            grp.cv.wait_for(lk, std::chrono::milliseconds(5),
+                    [&] { return groups_stop.load(std::memory_order_relaxed); });
         }
     }
 
@@ -1719,7 +1913,7 @@ private:
             return;
         }
 
-        groups_stop = false;
+        groups_stop.store(false);
 
         for (auto & grp : groups) {
             server_group * g = grp.get();
@@ -1734,11 +1928,11 @@ private:
             return;
         }
 
-        {
-            std::unique_lock<std::mutex> lk(mtx_engine);
-            groups_stop = true;
+        for (auto & grp : groups) {
+            std::unique_lock<std::mutex> lk(grp->mtx);
+            groups_stop.store(true);
+            grp->cv.notify_all();
         }
-        cv_engine.notify_all();
 
         for (auto & grp : groups) {
             if (grp->thread.joinable()) {
@@ -1774,7 +1968,7 @@ private:
         return nullptr;
     }
 
-    server_slot * get_available_slot(const server_task & task) {
+    server_slot * get_available_slot(const server_task & task, bool & need_cache_update) {
         server_slot * ret = nullptr;
 
         bool update_cache = false;
@@ -1868,25 +2062,34 @@ private:
 
             // cache prompts only for completion tasks
             update_cache = update_cache && task.type == SERVER_TASK_TYPE_COMPLETION;
-
-            if (update_cache) {
-                SRV_TRC("%s", "updating prompt cache\n");
-
-                const int64_t t_start = ggml_time_us();
-
-                ret->prompt_save(*prompt_cache);
-
-                if (!ret->prompt_load(*prompt_cache, task.tokens)) {
-                    ret->prompt_clear();
-                }
-
-                prompt_cache->update();
-
-                SRV_TRC("prompt cache update took %.2f ms\n", (ggml_time_us() - t_start) / 1000.0);
-            }
+        } else {
+            update_cache = false;
         }
 
+        // note: the caller runs update_prompt_cache() once it knows the slot is free and the group
+        //       that owns it is not decoding - reading and writing the sequence KV of a context
+        //       while that context is computing is not allowed
+        need_cache_update = update_cache;
+
         return ret;
+    }
+
+    // moves the slot's current prompt into the RAM cache and loads the best prefix for the new
+    // task. Touches the slot's context, so the owning group must be out of llama_decode.
+    void update_prompt_cache(server_slot & slot, const server_task & task) {
+        SRV_TRC("%s", "updating prompt cache\n");
+
+        const int64_t t_start = ggml_time_us();
+
+        slot.prompt_save(*prompt_cache);
+
+        if (!slot.prompt_load(*prompt_cache, task.tokens)) {
+            slot.prompt_clear();
+        }
+
+        prompt_cache->update();
+
+        SRV_TRC("prompt cache update took %.2f ms\n", (ggml_time_us() - t_start) / 1000.0);
     }
 
     // return true if at least one slot has been cleared
@@ -2309,7 +2512,10 @@ private:
             res->stats = slot.stats;
         }
 
-        queue_results.send(std::move(res));
+        {
+            prof_timer psnd(tls_group ? &tls_group->prof.t_send : nullptr, prof_on && tls_group != nullptr);
+            queue_results.send(std::move(res));
+        }
     }
 
     void send_final_response(server_slot & slot) {
@@ -2615,7 +2821,8 @@ private:
 
                     const int id_task = task.id;
 
-                    server_slot * slot = get_available_slot(task);
+                    bool need_cache_update = false;
+                    server_slot * slot = get_available_slot(task, need_cache_update);
 
                     //
                     // slot scheduling logic
@@ -2638,6 +2845,10 @@ private:
                     // from here on the slot's context is touched (prompt cache, KV), so the group
                     // that owns it has to finish its decode. the other groups keep computing.
                     guard.wait_for(slot->id_group);
+
+                    if (need_cache_update) {
+                        update_prompt_cache(*slot, task);
+                    }
 
                     if (task.is_parent()) {
                         // try getting free slots for all child tasks
@@ -3042,6 +3253,47 @@ private:
     };
 #endif
 
+    // LLAMA_SERVER_PIPE_PROF=1: dump the host path of every group every 5 s and start a new window
+    // note: called with the group's own lock held when n_groups > 1
+    std::atomic<int64_t> t_prof_last { 0 };
+
+    void prof_report() {
+        const int64_t t_now = ggml_time_us();
+        int64_t t_last = t_prof_last.load();
+
+        if (t_last != 0 && t_now - t_last < 5 * 1000 * 1000) {
+            return;
+        }
+        if (!t_prof_last.compare_exchange_strong(t_last, t_now)) {
+            return;
+        }
+        if (t_last == 0) {
+            return; // first call only arms the window
+        }
+
+        const double t_win = (t_now - t_last) / 1000.0; // ms
+
+        for (auto & g : groups) {
+            auto & pr = g->prof;
+
+            const double n_it  = std::max<int64_t>(1, pr.n_iter);
+            const double n_tk  = std::max<int64_t>(1, pr.n_tok);
+            auto per_it = [&](int64_t v) { return v / 1000.0 / n_it; };
+            auto per_tk = [&](int64_t v) { return v / 1000.0 / n_tk; };
+
+            SRV_INF("PROF g%d win %.0f ms iters %" PRId64 " toks %" PRId64
+                    " | per iter ms: lock %.2f pre %.2f submit %.2f sync %.2f relock %.2f post %.2f iter %.2f"
+                    " | per tok ms: sampl %.3f sampl_par %.3f piece %.3f proc %.3f send %.3f post %.3f\n",
+                    g->id, t_win, pr.n_iter, pr.n_tok,
+                    per_it(pr.t_lock), per_it(pr.t_pre), per_it(pr.t_submit), per_it(pr.t_sync),
+                    per_it(pr.t_relock), per_it(pr.t_post), per_it(pr.t_iter),
+                    per_tk(pr.t_sampl), per_tk(pr.t_sampl_par), per_tk(pr.t_piece), per_tk(pr.t_proc),
+                    per_tk(pr.t_send), per_tk(pr.t_post));
+
+            pr = server_group_prof();
+        }
+    }
+
     // runs one iteration of the decode loop of a single pipeline group
     // returns true if the group had work to do
     bool update_slots(server_group & grp) {
@@ -3050,14 +3302,23 @@ private:
         auto & batch   = grp.batch;
         auto & slots   = grp.slots;
 
+        tls_group = &grp;
+
         // when there is only one group there is only one thread and this lock is never engaged
         std::unique_lock<std::mutex> lk;
         if (n_groups > 1) {
-            lk = std::unique_lock<std::mutex>(mtx_engine);
-            cv_engine.wait(lk, [&]{ return groups_stop || grp.n_pause_req == 0; });
-            if (groups_stop) {
+            prof_timer tl(&grp.prof.t_lock, prof_on);
+            lk = std::unique_lock<std::mutex>(grp.mtx);
+            grp.cv.wait(lk, [&]{ return groups_stop.load(std::memory_order_relaxed) || grp.n_pause_req == 0; });
+            if (groups_stop.load(std::memory_order_relaxed)) {
                 return false;
             }
+        }
+
+        prof_timer ti(&grp.prof.t_iter, prof_on);
+        if (prof_on) {
+            grp.prof.n_iter++;
+            prof_report();
         }
 
 #ifdef DEBUG_TIMINGS
@@ -3104,6 +3365,7 @@ private:
 
         try {
             scoped_timer t(t_pre_decode, n_pre_decode);
+            prof_timer tp(&grp.prof.t_pre, prof_on);
             pre_decode(grp);
             batch.render();
         } catch (const std::exception & e) {
@@ -3168,6 +3430,7 @@ private:
 
             try {
                 scoped_timer t(t_post_decode, n_post_decode);
+                prof_timer tp(&grp.prof.t_post, prof_on);
                 post_decode(grp, n_tokens, off, batch_view);
             } catch (const std::exception & e) {
                 SRV_ERR("post_decode() failed: %s\n", e.what());
@@ -3686,7 +3949,10 @@ private:
                         slot.stats.n_prompt_cached    = n_past;
                         slot.stats.n_prompt_processed = 0;
 
-                        metrics.add_prompt_cached(n_past);
+                        {
+                            std::lock_guard<std::mutex> lk(mtx_metrics);
+                            metrics.add_prompt_cached(n_past);
+                        }
 
                         slot.prompt.tokens.keep_first(n_past);
 
@@ -3973,22 +4239,33 @@ private:
                     lk->unlock();
                 }
                 ~decode_window() {
-                    lk->lock();
+                    {
+                        prof_timer tr(&grp->prof.t_relock, srv->prof_on);
+                        lk->lock();
+                    }
                     grp->busy = false;
-                    srv->cv_engine.notify_all();
+                    grp->cv.notify_all();
                 }
             } window(this, &grp, &lk);
 
-            ret = llama_decode(ctx_tgt, batch_view);
+            {
+                prof_timer ts(&grp.prof.t_submit, prof_on);
+                ret = llama_decode(ctx_tgt, batch_view);
+            }
             if (ret == 0 && has_output) {
+                prof_timer ts(&grp.prof.t_sync, prof_on);
                 llama_synchronize(ctx_tgt);
             }
         } else {
             // yield to the queue, so we can still handle metrics tasks while decoding
             // note: the sync is done here too, so that the wait is also covered by the yield
             queue_tasks.yield_to_queue([&]() {
-                ret = llama_decode(ctx_tgt, batch_view);
+                {
+                    prof_timer ts(&grp.prof.t_submit, prof_on);
+                    ret = llama_decode(ctx_tgt, batch_view);
+                }
                 if (ret == 0 && has_output) {
+                    prof_timer ts(&grp.prof.t_sync, prof_on);
                     llama_synchronize(ctx_tgt);
                 }
             });
@@ -4120,6 +4397,61 @@ private:
                 slot.task->params.sampling.preserved_tokens.find(token) != slot.task->params.sampling.preserved_tokens.end();
         };
 
+        // sample the rows of this sub-batch in parallel, before the sequential pass below walks
+        // the slots. Each row has its own sampler and its own row of the logits, so the tokens
+        // are exactly the ones the sequential path would have produced.
+        {
+            auto & to_sample = grp.to_sample;
+
+            to_sample.clear();
+
+            for (auto * slot : slots) {
+                if (!is_inside_view(slot->i_batch)) {
+                    continue;
+                }
+                if (slot->state == SLOT_STATE_DONE_PROMPT) {
+                    if (slot->task->type == SERVER_TASK_TYPE_EMBEDDING ||
+                        slot->task->type == SERVER_TASK_TYPE_RERANK) {
+                        continue;
+                    }
+                } else if (slot->state != SLOT_STATE_GENERATING) {
+                    continue;
+                }
+                if (slot->can_speculate()) {
+                    continue; // the speculative pass owns the sampler of this slot
+                }
+                if (slot->task->params.sampling.backend_sampling) {
+                    continue; // the token comes from the device, leave it to the sequential path
+                }
+                if (slot->task->params.sampling.n_probs > 0) {
+                    continue; // populate_token_probs() reads the sampler state right after
+                }
+
+                slot->pre_sampled = LLAMA_TOKEN_NULL;
+                to_sample.push_back(slot);
+            }
+
+            if (to_sample.size() > 1) {
+                prof_timer ps(&grp.prof.t_sampl_par, prof_on);
+
+                // resolve the first row on this thread: the first call after a decode may have to
+                // un-permute the output rows, which mutates the context
+                llama_get_logits_ith(grp.ctx, to_sample[0]->i_batch - off);
+
+                grp.pool.run((int) to_sample.size(), [&](int i) {
+                    server_slot * slot = to_sample[i];
+                    try {
+                        slot->pre_sampled = common_sampler_sample(slot->smpl.get(), slot->ctx_tgt, slot->i_batch - off);
+                    } catch (const std::exception & e) {
+                        // leave it unsampled, the sequential pass below will hit the same error
+                        // in the place that knows how to report it
+                        SLT_ERR(*slot, "parallel sampling failed: %s\n", e.what());
+                        slot->pre_sampled = LLAMA_TOKEN_NULL;
+                    }
+                });
+            }
+        }
+
         iterate(slots, [&](server_slot & slot) {
             // optionally send prompt processing progress
             if (slot.state == SLOT_STATE_PROCESSING_PROMPT || slot.state == SLOT_STATE_DONE_PROMPT) {
@@ -4169,10 +4501,15 @@ private:
             const int tok_idx = slot.i_batch - off;
 
             llama_token id;
-            {
+            if (slot.pre_sampled != LLAMA_TOKEN_NULL) {
+                id = slot.pre_sampled;
+                slot.pre_sampled = LLAMA_TOKEN_NULL;
+            } else {
                 scoped_timer timer(t_sampl, n_sampl);
+                prof_timer ps(&grp.prof.t_sampl, prof_on);
                 id = common_sampler_sample(slot.smpl.get(), slot.ctx_tgt, tok_idx);
             }
+            if (prof_on) { grp.prof.n_tok++; }
 
             slot.i_batch = -1;
 
@@ -4193,14 +4530,22 @@ private:
 
             completion_token_output result;
             result.tok          = id;
-            result.text_to_send = common_token_to_piece(slot.ctx_tgt, result.tok, accept_special_token(slot, result.tok));
+            {
+                prof_timer pp(&grp.prof.t_piece, prof_on);
+                result.text_to_send = common_token_to_piece(slot.ctx_tgt, result.tok, accept_special_token(slot, result.tok));
+            }
             result.prob         = 1.0f; // TODO: set it here instead of doing inside populate_token_probs
 
             if (slot.task->params.sampling.n_probs > 0) {
                 populate_token_probs(slot, result, slot.task->params.post_sampling_probs, params_base.special, tok_idx);
             }
 
-            if (!process_token(result, slot)) {
+            bool keep_going;
+            {
+                prof_timer pt(&grp.prof.t_proc, prof_on);
+                keep_going = process_token(result, slot);
+            }
+            if (!keep_going) {
                 // release slot because of stop condition
                 slot.print_timings();
                 send_final_response(slot);
@@ -4369,7 +4714,10 @@ private:
         if (grp.n_prompt_queued == 0) {
             return;
         }
-        metrics.add_prompt(grp.n_prompt_queued, ggml_time_us() - grp.t_prompt_start);
+        {
+            std::lock_guard<std::mutex> lk(mtx_metrics);
+            metrics.add_prompt(grp.n_prompt_queued, ggml_time_us() - grp.t_prompt_start);
+        }
         grp.n_prompt_queued = 0;
     }
 
@@ -4377,12 +4725,18 @@ private:
     void metrics_post_decode(server_group & grp, int32_t off, int32_t n_tokens, bool has_output) {
         auto & batch = grp.batch;
 
-        metrics.n_decode++;
-        for (const auto & slot : slots) {
-            if (slot.is_processing()) {
-                metrics.n_busy_slots++;
+        {
+            // note: only this group's slots - the other groups count their own, and their state
+            //       may not be read from here
+            std::lock_guard<std::mutex> lk(mtx_metrics);
+
+            metrics.n_decode++;
+            for (const auto * slot : grp.slots) {
+                if (slot->is_processing()) {
+                    metrics.n_busy_slots++;
+                }
+                metrics.n_tokens_max = std::max(metrics.n_tokens_max, (uint64_t) slot->prompt.n_tokens());
             }
-            metrics.n_tokens_max = std::max(metrics.n_tokens_max, (uint64_t) slot.prompt.n_tokens());
         }
 
         // apply enqueued prompt tokens stats
@@ -4438,6 +4792,8 @@ private:
         const uint64_t t_us    = slot.stats.t_gen_us();
         const uint64_t n       = slot.stats.n_gen;
         const uint64_t n_steps = slot.stats.n_gen_steps();
+
+        std::lock_guard<std::mutex> lk(mtx_metrics);
 
         metrics.predict       .add(n, n_steps, t_us);
         metrics.predict_bucket.add(n, n_steps, t_us);

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -315,9 +315,6 @@ struct server_slot {
 
     llama_token sampled; // in speculative mode, this is the last accepted token
 
-    // token from the parallel sampling pass of post_decode, LLAMA_TOKEN_NULL if it did not run
-    llama_token pre_sampled = LLAMA_TOKEN_NULL;
-
     // for TTS models, this is the embd generated from prev step, decode this to generate next hidden state
     // corresponding to one token position (size = n_embd)
     std::vector<float> inp_embd;
@@ -336,7 +333,6 @@ struct server_slot {
     int32_t n_gen_last = 0;
 
     void reset() {
-        pre_sampled = LLAMA_TOKEN_NULL;
         SLT_DBG(*this, "%s", "\n");
 
         spec_is_replay = false;
@@ -813,11 +809,12 @@ struct server_group_prof {
     int64_t t_relock = 0; // re-taking the engine lock after the decode
     int64_t t_post   = 0; // post_decode
     int64_t t_sampl  = 0; //   of which: common_sampler_sample
-    int64_t t_sampl_par = 0; //   of which: the parallel sampling pass
     int64_t t_piece  = 0; //   of which: common_token_to_piece
     int64_t t_proc   = 0; //   of which: process_token (stop strings, streaming)
     int64_t t_send   = 0; //   of which: queue_results.send
     int64_t t_iter   = 0; // the whole iteration
+
+    int64_t t_prof_last = 0; // start of this group's reporting window
 };
 
 struct prof_timer {
@@ -833,91 +830,6 @@ struct prof_timer {
     prof_timer & operator=(const prof_timer &) = delete;
 };
 
-
-// each slot has its own sampler and its own row of the logits, so parallel sampling is exact
-struct server_par_for {
-    std::vector<std::thread>        workers;
-    std::mutex                      mtx;
-    std::condition_variable         cv_work;
-    std::condition_variable         cv_done;
-    const std::function<void(int)> * fn = nullptr;
-    int      n         = 0;
-    int      next      = 0;
-    int      n_running = 0;
-    uint64_t gen       = 0;
-    bool     stop      = false;
-
-    void start(int n_threads) {
-        for (int i = 0; i < n_threads; ++i) {
-            workers.emplace_back([this]() { worker(); });
-        }
-    }
-
-    // run fn(0..n_-1), the calling thread takes its share too
-    void run(int n_, const std::function<void(int)> & f) {
-        if (workers.empty() || n_ <= 1) {
-            for (int i = 0; i < n_; ++i) {
-                f(i);
-            }
-            return;
-        }
-
-        std::unique_lock<std::mutex> lk(mtx);
-
-        fn   = &f;
-        n    = n_;
-        next = 0;
-        gen++;
-
-        cv_work.notify_all();
-
-        take_jobs(lk);
-
-        cv_done.wait(lk, [&] { return next >= n && n_running == 0; });
-    }
-
-    ~server_par_for() {
-        {
-            std::lock_guard<std::mutex> lk(mtx);
-            stop = true;
-        }
-        cv_work.notify_all();
-        for (auto & t : workers) {
-            if (t.joinable()) {
-                t.join();
-            }
-        }
-    }
-
-private:
-    void take_jobs(std::unique_lock<std::mutex> & lk) {
-        while (next < n) {
-            const int i = next++;
-            n_running++;
-            lk.unlock();
-            // note: the job itself must not throw, the callers wrap it
-            (*fn)(i);
-            lk.lock();
-            n_running--;
-        }
-        if (n_running == 0) {
-            cv_done.notify_all();
-        }
-    }
-
-    void worker() {
-        std::unique_lock<std::mutex> lk(mtx);
-        uint64_t seen = 0;
-        while (true) {
-            cv_work.wait(lk, [&] { return stop || gen != seen; });
-            if (stop) {
-                return;
-            }
-            seen = gen;
-            take_jobs(lk);
-        }
-    }
-};
 
 struct server_group;
 
@@ -950,9 +862,6 @@ struct server_group {
     int n_empty_consecutive = 0;
 
     server_group_prof prof;
-
-    server_par_for            pool;
-    std::vector<server_slot *> to_sample;
 
     // note: per group on purpose - one group's host path runs while the other is on the GPU
     std::thread thread;
@@ -1543,26 +1452,6 @@ private:
             }
         }
 
-        // the budget is split across the groups, so a pipeline run is not given more CPU
-        {
-            int n_sampling_threads = 8;
-
-            if (const char * e = getenv("LLAMA_SERVER_SAMPLE_THREADS")) {
-                n_sampling_threads = atoi(e);
-            }
-
-            n_sampling_threads = std::min(n_sampling_threads, (int) std::thread::hardware_concurrency());
-            n_sampling_threads = std::max(0, n_sampling_threads / n_groups);
-
-            const int n_workers = std::max(0, n_sampling_threads - 1);
-
-            for (auto & grp : groups) {
-                grp->pool.start(n_workers);
-            }
-
-            SRV_INF("sampling threads per pipeline group: %d\n", n_sampling_threads);
-        }
-
         if (params_base.cache_ram_mib != 0) {
             if (params_base.cache_ram_mib < 0) {
                 SRV_TRC("prompt cache is enabled, size limit: %s\n", "no limit");
@@ -1812,6 +1701,19 @@ private:
                 return;
             }
 
+            // a preceding wait_for() released every other group, and waiting on an unowned
+            // unique_lock is undefined. drop what is left and retake all of them in group order,
+            // the same order the constructor uses, so two guards still cannot deadlock.
+            for (size_t g = 0; g < srv->groups.size(); ++g) {
+                release(g);
+            }
+
+            for (size_t g = 0; g < srv->groups.size(); ++g) {
+                lks[g].lock();
+                srv->groups[g]->n_pause_req++;
+            }
+
+            // a group cannot set busy without its own lock, so one already waited out stays idle
             for (size_t g = 0; g < srv->groups.size(); ++g) {
                 server_group * grp = srv->groups[g].get();
                 grp->cv.wait(lks[g], [&] { return !grp->busy; });
@@ -3186,44 +3088,42 @@ private:
     };
 #endif
 
-    // note: called with the group's own lock held when n_groups > 1
-    std::atomic<int64_t> t_prof_last { 0 };
+    // each group reports and resets only its own counters, under its own lock: a reporter elected
+    // across groups would read and clear the others while their workers are still updating them
+    void prof_report(server_group & grp) {
+        auto & pr = grp.prof;
 
-    void prof_report() {
-        const int64_t t_now = ggml_time_us();
-        int64_t t_last = t_prof_last.load();
+        const int64_t t_now  = ggml_time_us();
+        const int64_t t_last = pr.t_prof_last;
 
         if (t_last != 0 && t_now - t_last < 5 * 1000 * 1000) {
             return;
         }
-        if (!t_prof_last.compare_exchange_strong(t_last, t_now)) {
-            return;
-        }
+
+        pr.t_prof_last = t_now;
+
         if (t_last == 0) {
             return; // first call only arms the window
         }
 
         const double t_win = (t_now - t_last) / 1000.0; // ms
 
-        for (auto & g : groups) {
-            auto & pr = g->prof;
+        const double n_it  = std::max<int64_t>(1, pr.n_iter);
+        const double n_tk  = std::max<int64_t>(1, pr.n_tok);
+        auto per_it = [&](int64_t v) { return v / 1000.0 / n_it; };
+        auto per_tk = [&](int64_t v) { return v / 1000.0 / n_tk; };
 
-            const double n_it  = std::max<int64_t>(1, pr.n_iter);
-            const double n_tk  = std::max<int64_t>(1, pr.n_tok);
-            auto per_it = [&](int64_t v) { return v / 1000.0 / n_it; };
-            auto per_tk = [&](int64_t v) { return v / 1000.0 / n_tk; };
+        SRV_INF("PROF g%d win %.0f ms iters %" PRId64 " toks %" PRId64
+                " | per iter ms: lock %.2f pre %.2f submit %.2f sync %.2f relock %.2f post %.2f iter %.2f"
+                " | per tok ms: sampl %.3f piece %.3f proc %.3f send %.3f post %.3f\n",
+                grp.id, t_win, pr.n_iter, pr.n_tok,
+                per_it(pr.t_lock), per_it(pr.t_pre), per_it(pr.t_submit), per_it(pr.t_sync),
+                per_it(pr.t_relock), per_it(pr.t_post), per_it(pr.t_iter),
+                per_tk(pr.t_sampl), per_tk(pr.t_piece), per_tk(pr.t_proc),
+                per_tk(pr.t_send), per_tk(pr.t_post));
 
-            SRV_INF("PROF g%d win %.0f ms iters %" PRId64 " toks %" PRId64
-                    " | per iter ms: lock %.2f pre %.2f submit %.2f sync %.2f relock %.2f post %.2f iter %.2f"
-                    " | per tok ms: sampl %.3f sampl_par %.3f piece %.3f proc %.3f send %.3f post %.3f\n",
-                    g->id, t_win, pr.n_iter, pr.n_tok,
-                    per_it(pr.t_lock), per_it(pr.t_pre), per_it(pr.t_submit), per_it(pr.t_sync),
-                    per_it(pr.t_relock), per_it(pr.t_post), per_it(pr.t_iter),
-                    per_tk(pr.t_sampl), per_tk(pr.t_sampl_par), per_tk(pr.t_piece), per_tk(pr.t_proc),
-                    per_tk(pr.t_send), per_tk(pr.t_post));
-
-            pr = server_group_prof();
-        }
+        pr = server_group_prof();
+        pr.t_prof_last = t_now;
     }
 
     // one iteration of the decode loop of a single group, returns true if it had work to do
@@ -3248,7 +3148,7 @@ private:
         prof_timer ti(&grp.prof.t_iter, prof_on);
         if (prof_on) {
             grp.prof.n_iter++;
-            prof_report();
+            prof_report(grp);
         }
 
 #ifdef DEBUG_TIMINGS
@@ -4190,7 +4090,9 @@ private:
                 prof_timer ts(&grp.prof.t_submit, prof_on);
                 ret = llama_decode(ctx_tgt, batch_view);
             }
-            if (ret == 0 && has_output) {
+            // sync even with no output to read: ~decode_window clears busy, and a task thread that
+            // takes the guard must not touch ctx while the decode is still in flight
+            if (ret == 0) {
                 prof_timer ts(&grp.prof.t_sync, prof_on);
                 llama_synchronize(ctx_tgt);
             }
@@ -4336,56 +4238,6 @@ private:
                 slot.task->params.sampling.preserved_tokens.find(token) != slot.task->params.sampling.preserved_tokens.end();
         };
 
-        {
-            auto & to_sample = grp.to_sample;
-
-            to_sample.clear();
-
-            for (auto * slot : slots) {
-                if (!is_inside_view(slot->i_batch)) {
-                    continue;
-                }
-                if (slot->state == SLOT_STATE_DONE_PROMPT) {
-                    if (slot->task->type == SERVER_TASK_TYPE_EMBEDDING ||
-                        slot->task->type == SERVER_TASK_TYPE_RERANK) {
-                        continue;
-                    }
-                } else if (slot->state != SLOT_STATE_GENERATING) {
-                    continue;
-                }
-                if (slot->can_speculate()) {
-                    continue; // the speculative pass owns the sampler of this slot
-                }
-                if (slot->task->params.sampling.backend_sampling) {
-                    continue; // the token comes from the device, leave it to the sequential path
-                }
-                if (slot->task->params.sampling.n_probs > 0) {
-                    continue; // populate_token_probs() reads the sampler state right after
-                }
-
-                slot->pre_sampled = LLAMA_TOKEN_NULL;
-                to_sample.push_back(slot);
-            }
-
-            if (to_sample.size() > 1) {
-                prof_timer ps(&grp.prof.t_sampl_par, prof_on);
-
-                // the first call after a decode may un-permute the rows, which mutates the context
-                llama_get_logits_ith(grp.ctx, to_sample[0]->i_batch - off);
-
-                grp.pool.run((int) to_sample.size(), [&](int i) {
-                    server_slot * slot = to_sample[i];
-                    try {
-                        slot->pre_sampled = common_sampler_sample(slot->smpl.get(), slot->ctx_tgt, slot->i_batch - off);
-                    } catch (const std::exception & e) {
-                        // leave it unsampled, the sequential pass below reports the same error
-                        SLT_ERR(*slot, "parallel sampling failed: %s\n", e.what());
-                        slot->pre_sampled = LLAMA_TOKEN_NULL;
-                    }
-                });
-            }
-        }
-
         iterate(slots, [&](server_slot & slot) {
             // optionally send prompt processing progress
             if (slot.state == SLOT_STATE_PROCESSING_PROMPT || slot.state == SLOT_STATE_DONE_PROMPT) {
@@ -4435,10 +4287,7 @@ private:
             const int tok_idx = slot.i_batch - off;
 
             llama_token id;
-            if (slot.pre_sampled != LLAMA_TOKEN_NULL) {
-                id = slot.pre_sampled;
-                slot.pre_sampled = LLAMA_TOKEN_NULL;
-            } else {
+            {
                 scoped_timer timer(t_sampl, n_sampl);
                 prof_timer ps(&grp.prof.t_sampl, prof_on);
                 id = common_sampler_sample(slot.smpl.get(), slot.ctx_tgt, tok_idx);

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1697,7 +1697,10 @@ private:
 
         std::vector<size_t> added(params_ctx.fit_params_target.size(), 0);
 
-        auto reserve = [&](common_params p, bool as_mtp, bool count_weights) {
+        // device order the margins are indexed by, taken from the target measurement below
+        std::vector<ggml_backend_dev_t> devs_tgt;
+
+        auto reserve = [&](common_params p, bool as_mtp, bool count_weights, bool is_target) {
             auto mparams = common_model_params_to_llama(p);
             auto cparams = common_context_params_to_llama(p);
             if (as_mtp) {
@@ -1710,21 +1713,51 @@ private:
             const auto mem = common_get_device_memory_data(p.model.path.c_str(), &mparams, &cparams,
                                  devs, ngl, n_ctx_train, n_expert, GGML_LOG_LEVEL_ERROR);
 
-            // margins and the memory data are indexed by the same device order
-            for (size_t i = 0; i < mem.size() && i < params_ctx.fit_params_target.size(); ++i) {
-                size_t per_group = mem[i].context + mem[i].compute;
-                if (count_weights) {
-                    per_group += mem[i].model;
+            if (is_target) {
+                devs_tgt = devs;
+            }
+
+            auto charge = [&](size_t id, const common_device_memory_data & md) {
+                if (id >= params_ctx.fit_params_target.size()) {
+                    return;
                 }
-                params_ctx.fit_params_target[i] += n_extra * per_group;
-                added[i] += n_extra * per_group;
+                size_t per_group = md.context + md.compute;
+                if (count_weights) {
+                    per_group += md.model;
+                }
+                params_ctx.fit_params_target[id] += n_extra * per_group;
+                added[id]                        += n_extra * per_group;
+            };
+
+            // mem holds one entry per device plus a host entry at the back, while fit_params_target
+            // is indexed by device alone (common/fit.cpp builds margins over the nd devices). With
+            // no device at all that single margin is the host one, so only then is the host entry
+            // charged; otherwise charging it would bill host memory to a device's margin.
+            if (devs_tgt.empty()) {
+                if (!mem.empty()) {
+                    charge(0, mem.back());
+                }
+                return;
+            }
+
+            for (size_t j = 0; j + 1 < mem.size() && j < devs.size(); ++j) {
+                // --device-draft may order the draft devices differently from the target, so match
+                // on device identity rather than position, the same way common_params_fit_impl maps
+                // its extra model. By position a draft allocation would be billed to another
+                // device's margin, approving a placement that then fails on the second context.
+                for (size_t id = 0; id < devs_tgt.size(); ++id) {
+                    if (devs[j] == devs_tgt[id]) {
+                        charge(id, mem[j]);
+                        break;
+                    }
+                }
             }
         };
 
-        reserve(params_ctx, false, false);
+        reserve(params_ctx, false, false, true);
 
         if (has_draft || spec_mtp) {
-            reserve(common_base_params_to_speculative(params_ctx), spec_mtp, has_draft);
+            reserve(common_base_params_to_speculative(params_ctx), spec_mtp, has_draft, false);
         }
 
         for (size_t i = 0; i < added.size(); ++i) {

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -35,7 +35,6 @@
 #include <windows.h>
 #endif
 
-// used by the --pipeline-groups decode threads
 #include <chrono>
 #include <condition_variable>
 #include <mutex>
@@ -201,12 +200,10 @@ struct server_batch {
 struct server_slot {
     int id;
 
-    // pipeline group that owns this slot, i.e. the index of ctx_tgt in server_context_impl::groups
-    // always 0 unless --pipeline-groups > 1
+    // pipeline group that owns this slot, index into server_context_impl::groups
     int id_group = 0;
 
-    // sequence id of this slot inside ctx_tgt / ctx_dft
-    // equal to id unless --pipeline-groups > 1, where each context only holds n_parallel/N sequences
+    // sequence id of this slot inside ctx_tgt / ctx_dft, equal to id unless --pipeline-groups > 1
     int seq_id = 0;
 
     llama_context * ctx_tgt = nullptr;
@@ -318,8 +315,7 @@ struct server_slot {
 
     llama_token sampled; // in speculative mode, this is the last accepted token
 
-    // token produced by the parallel sampling pass of post_decode, LLAMA_TOKEN_NULL if that pass
-    // did not run for this slot (then the sequential path samples it as before)
+    // token from the parallel sampling pass of post_decode, LLAMA_TOKEN_NULL if it did not run
     llama_token pre_sampled = LLAMA_TOKEN_NULL;
 
     // for TTS models, this is the embd generated from prev step, decode this to generate next hidden state
@@ -801,18 +797,6 @@ static int process_mtmd_chunk(const server_slot & slot, mtmd::batch_ptr & mbatch
     return try_decode();
 }
 
-// A pipeline group is one llama_context with its own batch, its own decode loop and its own
-// contiguous range of slots. With --pipeline-groups 1 (the default) there is exactly one group:
-// it owns ctx_tgt and every slot, and its update loop runs on the main thread, as before.
-//
-// With N > 1 the point is that while group A's batch is being computed on the second stage of a
-// layer split (the RPC peer), group B's batch can be computed on the first stage (the local GPU),
-// so both devices are busy instead of each idling half of every decode step.
-
-// -----------------------------------------------------------------------------
-// per-group host-path profiling, enabled with LLAMA_SERVER_PIPE_PROF=1
-// -----------------------------------------------------------------------------
-
 static bool pipe_prof_enabled() {
     const char * e = getenv("LLAMA_SERVER_PIPE_PROF");
     return e != nullptr && atoi(e) != 0;
@@ -850,13 +834,7 @@ struct prof_timer {
 };
 
 
-// A tiny fixed worker pool used to sample the slots of one group in parallel.
-//
-// Sampling one row of a 250k-token vocabulary costs about 0.6 ms on this hardware, and it costs
-// six times that while the other pipeline group is driving the GPUs, so a serial pass over the
-// slots is tens of milliseconds sitting on the critical path between the decode and the next
-// submit. The rows are independent - each slot has its own sampler and reads its own row of the
-// logits - so they can be done at the same time. The output is identical either way.
+// each slot has its own sampler and its own row of the logits, so parallel sampling is exact
 struct server_par_for {
     std::vector<std::thread>        workers;
     std::mutex                      mtx;
@@ -943,7 +921,6 @@ private:
 
 struct server_group;
 
-// the group whose decode loop is running on this thread, used by the deep call sites
 static thread_local server_group * tls_group = nullptr;
 
 struct server_group {
@@ -953,13 +930,9 @@ struct server_group {
 
     server_batch batch;
 
-    // slots owned by this group, in slot id order (slots are partitioned contiguously)
     std::vector<server_slot *> slots;
 
-    // speculative decoding state of this group
-    // note: a common_speculative and its draft (or MTP) context are bound to one target context,
-    //       so each group owns its own set, sized for the group's sequences and indexed by
-    //       slot.seq_id (which is slot.id with a single group)
+    // note: bound to one target context, so each group owns its own set, indexed by slot.seq_id
     common_speculative_init_result_ptr spec_init;
 
     llama_model   * model_dft = nullptr;
@@ -969,25 +942,19 @@ struct server_group {
 
     common_context_seq_rm_type ctx_dft_seq_rm_type = COMMON_CONTEXT_SEQ_RM_TYPE_NO;
 
-    // queued prompt stats - llama_decode() is async, so the timing is only valid after a sync
-    // note: kept out of server_metrics, which is copied as-is into the task result
+    // note: async, so only valid after a sync; kept out of server_metrics, which is copied as-is
     int64_t  t_decode_start  = 0; // start of the last submitted decode of this group
     int64_t  t_prompt_start  = 0; // start of the oldest queued prompt decode of this group
     uint64_t n_prompt_queued = 0;
 
     int n_empty_consecutive = 0;
 
-    // host-path profiling, only filled in when LLAMA_SERVER_PIPE_PROF=1
     server_group_prof prof;
 
-    // sampling of this group's slots, run over several threads (see server_par_for)
     server_par_for            pool;
     std::vector<server_slot *> to_sample;
 
-    // only used when n_groups > 1
-    // note: the lock is per group on purpose - the whole point of the feature is that the host
-    //       path of one group (pre_decode, sampling, streaming, post_decode) runs while the other
-    //       group is on the GPU, so nothing here may be shared between groups
+    // note: per group on purpose - one group's host path runs while the other is on the GPU
     std::thread thread;
     std::mutex              mtx;  // guards this group's slots, batch and the two fields below
     std::condition_variable cv;
@@ -1019,7 +986,6 @@ public:
 
     server_state_callback_t callback_state = [](server_state, json) -> void {};
 
-    // number of pipeline groups requested via --pipeline-groups, must be set before load_model()
     int n_pipeline_groups_req = 1;
 
     server_context_impl() {
@@ -1053,27 +1019,18 @@ private:
 
     llama_context * ctx_tgt = nullptr;
 
-    // pipeline groups, see --pipeline-groups and struct server_group
-    // groups[0]->ctx is always ctx_tgt; n_groups == 1 unless the user asked for more
     int n_groups = 1;
     std::vector<std::unique_ptr<server_group>> groups;
 
-    // LLAMA_SERVER_PIPE_PROF=1: time the host path of each group separately
     const bool prof_on = pipe_prof_enabled();
 
-    // number of sequences per context, == params_base.n_parallel when n_groups == 1
     int n_seq_per_group = 1;
 
-    // the following are only ever touched when n_groups > 1
     std::atomic<bool> groups_stop { false };
 
-    // server_metrics and the prompt cache are shared by every group, so they get their own locks
-    // instead of riding on a global engine lock. Both are off the per-token path.
     std::mutex mtx_metrics;
     std::mutex mtx_prompt_cache;
 
-    // note: the speculative decoding state (draft / MTP context, common_speculative) lives in
-    //       the groups, see struct server_group
     common_context_seq_rm_type ctx_tgt_seq_rm_type = COMMON_CONTEXT_SEQ_RM_TYPE_NO;
 
     bool add_bos_token = true;
@@ -1281,9 +1238,6 @@ private:
             params_base.load_progress_callback_user_data = &load_progress_text;
         }
 
-        // --pipeline-groups: run the slots over N independent contexts of one model, so that the
-        // stages of a layer split can be busy at the same time. N == 1 is the default and keeps
-        // every code path below exactly as it was.
         n_groups = std::max(1, n_pipeline_groups_req);
 
         if (n_groups > 1 && !validate_pipeline_groups(params_base, has_mmproj)) {
@@ -1297,8 +1251,7 @@ private:
         common_params & params_ctx = n_groups > 1 ? params_grp  : params_base;
 
         if (n_groups > 1) {
-            // each context gets 1/N of the sequences and 1/N of the total context, so the per-slot
-            // context (n_ctx / n_seq_max) and the total KV memory over all contexts are unchanged
+            // 1/N of the sequences and of the context each, so per-slot context and total KV hold
             params_ctx.n_parallel = n_seq_per_group;
             params_ctx.n_ctx      = params_base.n_ctx / n_groups;
         }
@@ -1331,7 +1284,6 @@ private:
 
         vocab = llama_model_get_vocab(model_tgt);
 
-        // the remaining contexts of the pipeline are created from the same model
         {
             groups.clear();
             groups.reserve(n_groups);
@@ -1366,7 +1318,6 @@ private:
             }
         }
 
-        // the total context over all groups, as requested by the user
         n_ctx = llama_n_ctx(ctx_tgt) * n_groups;
 
         add_bos_token = llama_vocab_get_add_bos(vocab);
@@ -1376,8 +1327,6 @@ private:
             load_progress_callback(0.0f, &load_progress_spec);
             load_progress_spec.t_last_load_progress_ms = 0;  // reset so internal cbs aren't delayed
 
-            // one draft / MTP context per group, each bound to the context of its group and sized
-            // for the group's sequences (with a single group params_ctx is params_base, as before)
             // note: with --model-draft the draft model is loaded once per group
             for (int g = 0; g < n_groups; ++g) {
                 server_group & grp = *groups[g];
@@ -1494,8 +1443,6 @@ private:
         }
 
         // try speculative decoding
-        // note: a common_speculative is bound to one target context, so each group gets its own,
-        //       sized for the group's sequences (n_seq_per_group == n_parallel with one group)
         for (auto & grp : groups) {
             if (ctx_tgt_seq_rm_type != COMMON_CONTEXT_SEQ_RM_TYPE_NO) {
                 common_params_speculative params_spec = params_base.speculative;
@@ -1596,8 +1543,7 @@ private:
             }
         }
 
-        // sampling threads. The budget is the same however many groups there are, so that a
-        // pipeline-groups run is not simply given more CPU than the single-context run.
+        // the budget is split across the groups, so a pipeline run is not given more CPU
         {
             int n_sampling_threads = 8;
 
@@ -1608,7 +1554,6 @@ private:
             n_sampling_threads = std::min(n_sampling_threads, (int) std::thread::hardware_concurrency());
             n_sampling_threads = std::max(0, n_sampling_threads / n_groups);
 
-            // the calling thread takes a share too, so this many extra workers
             const int n_workers = std::max(0, n_sampling_threads - 1);
 
             for (auto & grp : groups) {
@@ -1667,7 +1612,6 @@ private:
         return true;
     }
 
-    // refuse everything we cannot make safe with more than one context, rather than half-support it
     bool validate_pipeline_groups(const common_params & params, bool has_mmproj) const {
         auto refuse = [](const char * what) {
             SRV_ERR("--pipeline-groups > 1 is not supported together with %s\n", what);
@@ -1690,22 +1634,17 @@ private:
             return false;
         }
 
-        // note: speculative decoding is fine - every group owns a draft / MTP context and a
-        //       common_speculative of its own, see struct server_group
-
         // mtmd_context is bound to one llama_context
         if (has_mmproj) {
             return refuse("multimodal (--mmproj)");
         }
 
-        // common_init_from_params() applies the control vector to the context it creates and only
-        // to that one, so the extra contexts would silently run without it
+        // common_init_from_params() applies it only to the context it creates
         if (!params.control_vectors.empty()) {
             return refuse("--control-vector");
         }
 
-        // entering / leaving the sleeping state destroys and rebuilds the contexts under the
-        // running group threads
+        // entering / leaving it rebuilds the contexts under the running group threads
         if (params.sleep_idle_seconds >= 0) {
             return refuse("--sleep-idle");
         }
@@ -1829,15 +1768,8 @@ private:
         return true;
     }
 
-    // Holds the engine so that the caller can look at the slot state safely, and, on request,
-    // waits for the in-flight decode of the groups whose context the caller is going to touch.
-    // Constructing this is a no-op when there is a single group: the single update loop and the
-    // task processing then run on the same thread, exactly as before.
-    //
-    // Taking every group's lock keeps every group out of a new iteration, so the slot state is
-    // stable as soon as the guard exists. Only touching a llama_context needs more than that,
-    // and only for the group that owns it: wait_for() drops the other groups' locks first, so
-    // their host path keeps running, then blocks until that group's decode is done.
+    // holds every group's lock, so the slot state is stable while the guard exists; a no-op with a
+    // single group. wait_for() then drops the other groups' locks and waits out one group's decode.
     struct engine_guard {
         server_context_impl * srv = nullptr;
         std::vector<std::unique_lock<std::mutex>> lks;
@@ -1849,10 +1781,7 @@ private:
 
             srv = srv_;
 
-            // take every group's lock, in group order, so that the slot state of the whole server
-            // is stable while the task is being routed. This blocks the host path of the groups,
-            // not their decodes, and it is released again as soon as the task knows which group
-            // it needs.
+            // always in group order, so two guards cannot deadlock against each other
             lks.resize(srv->groups.size());
 
             for (size_t g = 0; g < srv->groups.size(); ++g) {
@@ -1861,7 +1790,6 @@ private:
             }
         }
 
-        // let every group except id_group go, then wait until this one is not inside llama_decode
         void wait_for(int id_group) {
             if (srv == nullptr) {
                 return;
@@ -1879,7 +1807,6 @@ private:
             grp->cv.wait(lks[id_group], [&] { return !grp->busy; });
         }
 
-        // wait for every group, for tasks that are not tied to one slot
         void wait_for_all() {
             if (srv == nullptr) {
                 return;
@@ -1915,7 +1842,6 @@ private:
         }
     };
 
-    // the decode loop of one pipeline group, only used when n_groups > 1
     void group_loop(server_group & grp) {
         while (true) {
             if (groups_stop.load(std::memory_order_relaxed)) {
@@ -1926,7 +1852,6 @@ private:
                 continue;
             }
 
-            // nothing to do for this group, wait for a task to be assigned to one of its slots
             std::unique_lock<std::mutex> lk(grp.mtx);
             grp.cv.wait_for(lk, std::chrono::milliseconds(5),
                     [&] { return groups_stop.load(std::memory_order_relaxed); });
@@ -2091,16 +2016,12 @@ private:
             update_cache = false;
         }
 
-        // note: the caller runs update_prompt_cache() once it knows the slot is free and the group
-        //       that owns it is not decoding - reading and writing the sequence KV of a context
-        //       while that context is computing is not allowed
         need_cache_update = update_cache;
 
         return ret;
     }
 
-    // moves the slot's current prompt into the RAM cache and loads the best prefix for the new
-    // task. Touches the slot's context, so the owning group must be out of llama_decode.
+    // reads and writes the slot's sequence KV, so the owning group must be out of llama_decode
     void update_prompt_cache(server_slot & slot, const server_task & task) {
         SRV_TRC("%s", "updating prompt cache\n");
 
@@ -2129,7 +2050,6 @@ private:
             return res;
         }
 
-        // only slots of this group, their KV lives in this group's context
         for (auto * slot_ptr : grp.slots) {
             auto & slot = *slot_ptr;
 
@@ -2707,7 +2627,6 @@ private:
     std::vector<server_slot *> get_free_slots(size_t n_slots_needed, int exclude_id_slot, int id_group) {
         std::vector<server_slot *> free_slots;
         for (auto & slot : slots) {
-            // the parent copies its KV into the children, so they must live in the same context
             if (slot.id_group != id_group) {
                 continue;
             }
@@ -2824,10 +2743,6 @@ private:
             return false;
         }
 
-        // with more than one group the update loops run on their own threads. Holding the engine
-        // is enough to look at and modify the slot state; the cases below additionally wait for
-        // the in-flight decode of the group whose context they touch, and only for that group.
-        // no-op with a single group.
         engine_guard guard(this);
 
         switch (task.type) {
@@ -2867,8 +2782,7 @@ private:
                         break;
                     }
 
-                    // from here on the slot's context is touched (prompt cache, KV), so the group
-                    // that owns it has to finish its decode. the other groups keep computing.
+                    // from here the slot's context is touched, so its group must finish its decode
                     guard.wait_for(slot->id_group);
 
                     if (need_cache_update) {
@@ -2878,9 +2792,7 @@ private:
                     if (task.is_parent()) {
                         // try getting free slots for all child tasks
                         size_t n_child_tasks = task.child_tasks.size();
-                        // the children take their KV from the parent, so they must fit in the
-                        // parent's group. with a single group this is the limit the request
-                        // schema already enforces, so nothing changes there.
+                        // the children take their KV from the parent, so they must fit its group
                         if ((int) n_child_tasks + 1 > n_seq_per_group) {
                             send_error(task, string_format(
                                 "n_cmpl must not exceed the number of slots per pipeline group (%d)", n_seq_per_group),
@@ -2903,7 +2815,6 @@ private:
                     }
 
                     if (params_base.cache_idle_slots) {
-                        // this walks every slot of every group
                         guard.wait_for_all();
 
                         for (auto & slot : slots) {
@@ -3033,7 +2944,6 @@ private:
                         break;
                     }
 
-                    // reads this slot's KV out of its context
                     guard.wait_for(slot->id_group);
 
                     const int64_t t_start = ggml_time_us();
@@ -3086,7 +2996,6 @@ private:
                         break;
                     }
 
-                    // writes this slot's KV into its context
                     guard.wait_for(slot->id_group);
 
                     const int64_t t_start = ggml_time_us();
@@ -3154,7 +3063,6 @@ private:
                         break;
                     }
 
-                    // prompt_clear() drops this slot's KV from its context
                     guard.wait_for(slot->id_group);
 
                     // Erase token cache
@@ -3278,7 +3186,6 @@ private:
     };
 #endif
 
-    // LLAMA_SERVER_PIPE_PROF=1: dump the host path of every group every 5 s and start a new window
     // note: called with the group's own lock held when n_groups > 1
     std::atomic<int64_t> t_prof_last { 0 };
 
@@ -3319,8 +3226,7 @@ private:
         }
     }
 
-    // runs one iteration of the decode loop of a single pipeline group
-    // returns true if the group had work to do
+    // one iteration of the decode loop of a single group, returns true if it had work to do
     bool update_slots(server_group & grp) {
         // shadow the single-context members - everything below operates on this group only
         auto * ctx_tgt = grp.ctx;
@@ -3329,7 +3235,6 @@ private:
 
         tls_group = &grp;
 
-        // when there is only one group there is only one thread and this lock is never engaged
         std::unique_lock<std::mutex> lk;
         if (n_groups > 1) {
             prof_timer tl(&grp.prof.t_lock, prof_on);
@@ -3384,8 +3289,7 @@ private:
                 task.id = queue_tasks.get_new_id();
                 queue_tasks.post(std::move(task));
             }
-            // note: with more than one group each group drives its own loop, so there is no need
-            //       to keep the shared task loop spinning
+            // note: each group drives its own loop, so the shared task loop need not keep spinning
         }
 
         try {
@@ -3473,7 +3377,6 @@ private:
         auto & slots   = grp.slots;
         (void) ctx_tgt;
 
-        // the speculative state of this group
         auto & spec    = grp.spec;
         auto * ctx_dft = grp.ctx_dft;
         const auto ctx_dft_seq_rm_type = grp.ctx_dft_seq_rm_type;
@@ -3611,8 +3514,7 @@ private:
         });
 
         // generate the actual drafts (if any)
-        // note: only the main thread may yield to the task queue, and with several groups each
-        //       group drafts on its own thread and against its own draft context
+        // note: only the main thread may yield to the task queue
         if (!drafting.empty()) {
             if (n_groups > 1) {
                 common_speculative_draft(spec.get());
@@ -4228,7 +4130,6 @@ private:
         auto & batch   = grp.batch;
         auto & slots   = grp.slots;
 
-        // the speculative state of this group
         auto & spec      = grp.spec;
         auto * model_dft = grp.model_dft;
 
@@ -4264,11 +4165,8 @@ private:
 
         int ret = 0;
         if (n_groups > 1) {
-            // release the engine for the duration of the compute - this is the whole point of the
-            // feature: while this group is on one stage of the layer split, the other group can
-            // run its own pre_decode / post_decode and submit its batch to the other stage
-            // note: RAII, so a throwing decode cannot leave the group marked busy forever, nor
-            //       return to the caller's error handling without the engine lock held
+            // note: RAII, or a throwing decode leaves the group busy forever, or returns to the
+            //       caller's error handling without the engine lock held
             struct decode_window {
                 server_context_impl * srv;
                 server_group * grp;
@@ -4367,8 +4265,6 @@ private:
         // TODO: avoid restoring the draft context and re-evaluating the drafted tokens when not needed [TAG_SPEC_AVOID_DRAFT_REEVAL]
         //       for now, always re-evaluate for simplicity
         //       ref: https://github.com/ggml-org/llama.cpp/pull/22728#issuecomment-4400925384
-        // note: only the main thread may yield to the task queue; with several groups the batch
-        //       goes through this group's draft context on this group's thread
         if (spec) {
             bool ok = true;
             if (n_groups > 1) {
@@ -4388,7 +4284,6 @@ private:
         }
 
         // handle `n_cmpl > 1` tasks - when the main prompt is processed, activate all child tasks too
-        // note: children are always in the same group as the parent, see get_free_slots()
         for (auto * slot_ptr : slots) {
             auto & slot = *slot_ptr;
             if (slot.state == SLOT_STATE_DONE_PROMPT && slot.task->is_parent()) {
@@ -4416,12 +4311,9 @@ private:
     }
 
     void post_decode(server_group & grp, int32_t n_batch_tokens, int32_t off, llama_batch & batch_view) {
-        // shadow the single-context members, as update_slots() does
         auto * ctx_tgt = grp.ctx;
         auto & slots   = grp.slots;
-
-        // the speculative state of this group
-        auto & spec = grp.spec;
+        auto & spec    = grp.spec;
         (void) ctx_tgt;
 
         // for checking if a given batch index is inside batch_view
@@ -4444,9 +4336,6 @@ private:
                 slot.task->params.sampling.preserved_tokens.find(token) != slot.task->params.sampling.preserved_tokens.end();
         };
 
-        // sample the rows of this sub-batch in parallel, before the sequential pass below walks
-        // the slots. Each row has its own sampler and its own row of the logits, so the tokens
-        // are exactly the ones the sequential path would have produced.
         {
             auto & to_sample = grp.to_sample;
 
@@ -4481,8 +4370,7 @@ private:
             if (to_sample.size() > 1) {
                 prof_timer ps(&grp.prof.t_sampl_par, prof_on);
 
-                // resolve the first row on this thread: the first call after a decode may have to
-                // un-permute the output rows, which mutates the context
+                // the first call after a decode may un-permute the rows, which mutates the context
                 llama_get_logits_ith(grp.ctx, to_sample[0]->i_batch - off);
 
                 grp.pool.run((int) to_sample.size(), [&](int i) {
@@ -4490,8 +4378,7 @@ private:
                     try {
                         slot->pre_sampled = common_sampler_sample(slot->smpl.get(), slot->ctx_tgt, slot->i_batch - off);
                     } catch (const std::exception & e) {
-                        // leave it unsampled, the sequential pass below will hit the same error
-                        // in the place that knows how to report it
+                        // leave it unsampled, the sequential pass below reports the same error
                         SLT_ERR(*slot, "parallel sampling failed: %s\n", e.what());
                         slot->pre_sampled = LLAMA_TOKEN_NULL;
                     }
@@ -4773,8 +4660,7 @@ private:
         auto & batch = grp.batch;
 
         {
-            // note: only this group's slots - the other groups count their own, and their state
-            //       may not be read from here
+            // note: only this group's slots - another group's slot state may not be read here
             std::lock_guard<std::mutex> lk(mtx_metrics);
 
             metrics.n_decode++;
@@ -4875,7 +4761,6 @@ bool server_context::load_model(common_params & params) {
 void server_context::start_loop() {
     auto & params = impl->params_base;
 
-    // no-op unless --pipeline-groups > 1
     impl->start_groups();
 
     impl->queue_tasks.start_loop(params.sleep_idle_seconds * 1000);

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -846,6 +846,12 @@ struct server_group {
     // Declared after ctx so it outlives the llama_free() above groups.clear().
     std::unique_ptr<common_threadpools> threadpools;
 
+    // common_speculative_init_result owns only the model and the context and never attaches a
+    // pool, so the draft context falls back to a throwaway pool per graph and ignores the draft
+    // --cpu-mask-draft, --prio, --poll and --cpu-strict settings. Declared before spec_init so
+    // it is destroyed after the draft context it is attached to.
+    std::unique_ptr<common_threadpools> threadpools_dft;
+
     server_batch batch;
 
     std::vector<server_slot *> slots;
@@ -1279,6 +1285,11 @@ private:
                     SRV_ERR("%s", "failed to create MTP context\n");
                     return false;
                 }
+
+                // params_dft, not params_ctx: the draft has its own cpu params and this is the
+                // only place they can reach the draft context
+                grp.threadpools_dft = std::make_unique<common_threadpools>();
+                grp.threadpools_dft->init(grp.ctx_dft, params_dft);
 
                 if (n_groups > 1) {
                     SRV_INF("created draft context for pipeline group %d, n_ctx = %d, n_seq_max = %d\n",

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2552,14 +2552,17 @@ private:
 
         SRV_TRC("launching slots for parent task id_task = %d with %zu child tasks\n", id_parent, parent_task.child_tasks.size());
 
-        // to be called in case of failure to release all launched slots
-        auto release_slots = [this, id_parent]() {
-            for (auto & slot : slots) {
-                if (slot.is_processing() && (
-                        slot.task->id == id_parent ||
-                        slot.task->id_parent == id_parent
+        // to be called in case of failure to release all launched slots.
+        // only this group's slots: the parent and its children are guaranteed to share a group, and
+        // wait_for() released every other group's lock, so a global scan would read state and task
+        // while their workers write them
+        auto release_slots = [this, id_parent, &parent_slot]() {
+            for (auto * slot : groups[parent_slot.id_group]->slots) {
+                if (slot->is_processing() && (
+                        slot->task->id == id_parent ||
+                        slot->task->id_parent == id_parent
                 )) {
-                    slot.release();
+                    slot->release();
                 }
             }
         };

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1163,6 +1163,17 @@ private:
             // 1/N of the sequences and of the context each, so per-slot context and total KV hold
             params_ctx.n_parallel = n_seq_per_group;
             params_ctx.n_ctx      = params_base.n_ctx / n_groups;
+
+            // common_init_from_params fits ONE context and fixes the model placement from that
+            // estimate, but the n_groups - 1 other contexts are created afterwards, once placement
+            // can no longer change. Fitting the undivided n_ctx instead would not be enough:
+            // measured with common_get_device_memory_data on a 1.5B, KV tracks n_ctx (112, 224 and
+            // 448 MiB at 4k, 8k and 16k) but the compute buffer does not (536 MiB across the same
+            // range), so that would budget the KV and still miss n_groups - 1 compute buffers.
+            // Reserve what the fitter will not see in its per-device margin.
+            if (params_ctx.fit_params) {
+                reserve_extra_group_memory(params_ctx, has_draft, spec_mtp);
+            }
         }
 
         llama_init = common_init_from_params(params_ctx);
@@ -1655,6 +1666,53 @@ private:
         }
 
         return true;
+    }
+
+    // Add what the extra pipeline groups will allocate to the fitter's per-device margin. Only the
+    // context and compute buffers for the target contexts, plus the draft contexts when speculation
+    // is on; the target weights are shared and already counted, and an MTP draft shares them too, so
+    // only a separate --model-draft adds weights per group.
+    void reserve_extra_group_memory(common_params & params_ctx, bool has_draft, bool spec_mtp) const {
+        const size_t n_extra = n_groups - 1;
+
+        std::vector<size_t> added(params_ctx.fit_params_target.size(), 0);
+
+        auto reserve = [&](common_params p, bool as_mtp, bool count_weights) {
+            auto mparams = common_model_params_to_llama(p);
+            auto cparams = common_context_params_to_llama(p);
+            if (as_mtp) {
+                cparams.ctx_type = LLAMA_CONTEXT_TYPE_MTP;
+            }
+
+            std::vector<ggml_backend_dev_t> devs;
+            uint32_t ngl = 0, n_ctx_train = 0, n_expert = 0;
+
+            const auto mem = common_get_device_memory_data(p.model.path.c_str(), &mparams, &cparams,
+                                 devs, ngl, n_ctx_train, n_expert, GGML_LOG_LEVEL_ERROR);
+
+            // margins and the memory data are indexed by the same device order
+            for (size_t i = 0; i < mem.size() && i < params_ctx.fit_params_target.size(); ++i) {
+                size_t per_group = mem[i].context + mem[i].compute;
+                if (count_weights) {
+                    per_group += mem[i].model;
+                }
+                params_ctx.fit_params_target[i] += n_extra * per_group;
+                added[i] += n_extra * per_group;
+            }
+        };
+
+        reserve(params_ctx, false, false);
+
+        if (has_draft || spec_mtp) {
+            reserve(common_base_params_to_speculative(params_ctx), spec_mtp, has_draft);
+        }
+
+        for (size_t i = 0; i < added.size(); ++i) {
+            if (added[i] > 0) {
+                SRV_INF("pipeline groups: reserved %.0f MiB on device %zu for %zu extra context(s)\n",
+                        added[i] / 1048576.0, i, n_extra);
+            }
+        }
     }
 
     // holds every group's lock, so the slot state is stable while the guard exists; a no-op with a

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1174,21 +1174,23 @@ private:
         if (n_groups > 1) {
             params_ctx.n_parallel = n_seq_per_group;
 
-            // Dividing n_ctx is right for one KV mode and wrong for the other, so it is only done
-            // for the mode it holds in. llama_context derives n_ctx_seq = n_ctx / n_seq_max when
-            // the KV is split, so dividing both gives (C/N) / (P/N) = C/P and the context a single
-            // request may use is unchanged, which is the intent. With --kv-unified it instead sets
-            // n_ctx_seq = n_ctx, so the same division would cut what one request may use from C to
-            // C/N: not a tighter limit but a different meaning for -c, decided by an unrelated
-            // flag, and invisible until a long request is truncated.
+            // n_ctx is deliberately NOT divided, in either KV mode: -c is what the user asked
+            // every request to be able to reach, and splitting the server into groups is an
+            // internal arrangement that should not quietly redefine it. Each group is built with
+            // the full n_ctx.
             //
-            // So each group keeps the full n_ctx under unified KV. That does cost N times the
-            // unified KV, which reserve_extra_group_memory() below measures and charges to the fit
-            // margins like any other per-group cost, so a configuration that no longer fits comes
-            // back as a smaller n_ctx the fitter chose and reported, not as a silent halving.
-            if (!params_base.kv_unified) {
-                params_ctx.n_ctx = params_base.n_ctx / n_groups;
-            }
+            // What that means per slot differs by mode, because llama_context derives the
+            // per-request context differently. Unified KV sets n_ctx_seq = n_ctx, so every
+            // request can reach C, which is the point. Split KV sets n_ctx_seq = n_ctx /
+            // n_seq_max, and n_seq_max here is P/N, so a slot gets C*N/P: N times what it had when
+            // n_ctx was divided as well, not the same. That is more context per slot than before,
+            // never less, so nothing that used to fit stops fitting.
+            //
+            // The cost is aggregate KV of roughly N*C rather than C. That is real, and it is what
+            // reserve_extra_group_memory() below exists to account for: it measures each extra
+            // context and charges it to the fit margins, so a configuration that no longer fits
+            // comes back as an n_ctx the fitter lowered and reported rather than a silent
+            // shrinking of what was asked for.
 
             // common_init_from_params fits ONE context and fixes the model placement from that
             // estimate, but the n_groups - 1 other contexts are created afterwards, once placement
@@ -1560,12 +1562,6 @@ private:
 
         if (params.n_ctx <= 0) {
             SRV_ERR("%s", "--pipeline-groups > 1 requires an explicit context size, pass -c N\n");
-            return false;
-        }
-
-        // only the split-KV path divides n_ctx, so only it needs the size to divide evenly
-        if (!params.kv_unified && params.n_ctx % n_groups != 0) {
-            SRV_ERR("--ctx-size (%d) must be a multiple of --pipeline-groups (%d)\n", params.n_ctx, n_groups);
             return false;
         }
 

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -840,6 +840,12 @@ struct server_group {
 
     llama_context * ctx = nullptr;
 
+    // groups after the first are made by llama_init_from_model(), which does not attach the
+    // pool common_init_from_params() builds for group 0. Without one the CPU backend makes a
+    // throwaway pool per graph and ignores --cpu-mask, --prio, --poll and --cpu-strict.
+    // Declared after ctx so it outlives the llama_free() above groups.clear().
+    std::unique_ptr<common_threadpools> threadpools;
+
     server_batch batch;
 
     std::vector<server_slot *> slots;
@@ -1232,6 +1238,9 @@ private:
                     groups.clear();
                     return false;
                 }
+
+                groups[g]->threadpools = std::make_unique<common_threadpools>();
+                groups[g]->threadpools->init(groups[g]->ctx, params_ctx);
 
                 SRV_INF("created llama_context for pipeline group %d, n_ctx = %d, n_seq_max = %d\n",
                         g, (int) llama_n_ctx(groups[g]->ctx), (int) llama_n_seq_max(groups[g]->ctx));

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1172,9 +1172,23 @@ private:
         common_params & params_ctx = n_groups > 1 ? params_grp  : params_base;
 
         if (n_groups > 1) {
-            // 1/N of the sequences and of the context each, so per-slot context and total KV hold
             params_ctx.n_parallel = n_seq_per_group;
-            params_ctx.n_ctx      = params_base.n_ctx / n_groups;
+
+            // Dividing n_ctx is right for one KV mode and wrong for the other, so it is only done
+            // for the mode it holds in. llama_context derives n_ctx_seq = n_ctx / n_seq_max when
+            // the KV is split, so dividing both gives (C/N) / (P/N) = C/P and the context a single
+            // request may use is unchanged, which is the intent. With --kv-unified it instead sets
+            // n_ctx_seq = n_ctx, so the same division would cut what one request may use from C to
+            // C/N: not a tighter limit but a different meaning for -c, decided by an unrelated
+            // flag, and invisible until a long request is truncated.
+            //
+            // So each group keeps the full n_ctx under unified KV. That does cost N times the
+            // unified KV, which reserve_extra_group_memory() below measures and charges to the fit
+            // margins like any other per-group cost, so a configuration that no longer fits comes
+            // back as a smaller n_ctx the fitter chose and reported, not as a silent halving.
+            if (!params_base.kv_unified) {
+                params_ctx.n_ctx = params_base.n_ctx / n_groups;
+            }
 
             // common_init_from_params fits ONE context and fixes the model placement from that
             // estimate, but the n_groups - 1 other contexts are created afterwards, once placement
@@ -1549,7 +1563,8 @@ private:
             return false;
         }
 
-        if (params.n_ctx % n_groups != 0) {
+        // only the split-KV path divides n_ctx, so only it needs the size to divide evenly
+        if (!params.kv_unified && params.n_ctx % n_groups != 0) {
             SRV_ERR("--ctx-size (%d) must be a multiple of --pipeline-groups (%d)\n", params.n_ctx, n_groups);
             return false;
         }

--- a/tools/server/server-context.h
+++ b/tools/server/server-context.h
@@ -110,6 +110,11 @@ struct server_context {
 
     // note: must be set before load_model() is called
     void set_state_callback(server_state_callback_t callback);
+
+    // number of pipeline groups, i.e. independent llama_contexts over the one model, each with its
+    // own slots, batch and decode thread (--pipeline-groups, default 1)
+    // note: must be set before load_model() is called
+    void set_pipeline_groups(int n_groups);
 };
 
 

--- a/tools/server/server-context.h
+++ b/tools/server/server-context.h
@@ -111,8 +111,7 @@ struct server_context {
     // note: must be set before load_model() is called
     void set_state_callback(server_state_callback_t callback);
 
-    // number of pipeline groups, i.e. independent llama_contexts over the one model, each with its
-    // own slots, batch and decode thread (--pipeline-groups, default 1)
+    // independent llama_contexts over the one model, each with its own slots (default 1)
     // note: must be set before load_model() is called
     void set_pipeline_groups(int n_groups);
 };

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -400,6 +400,8 @@ void server_model_meta::update_caps() {
     }
 }
 
+int server_get_pipeline_groups();
+
 //
 // server_models
 //
@@ -1026,6 +1028,11 @@ void server_models::load(const std::string & name, const load_options & opts) {
         std::vector<std::string> child_args = inst.meta.args; // copy
         std::vector<std::string> child_env  = base_env; // copy
         child_env.push_back("LLAMA_SERVER_ROUTER_PORT=" + std::to_string(base_params.port));
+        // the router strips --pipeline-groups before base_preset is built, so it cannot ride
+        // the preset like other options; hand it over explicitly
+        if (const int n_pg = server_get_pipeline_groups(); n_pg > 1) {
+            child_env.push_back("LLAMA_ARG_PIPELINE_GROUPS=" + std::to_string(n_pg));
+        }
 
         if (opts.mode == SERVER_CHILD_MODE_DOWNLOAD) {
             inst.meta.status = SERVER_MODEL_STATUS_DOWNLOADING;

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -1029,9 +1029,17 @@ void server_models::load(const std::string & name, const load_options & opts) {
         std::vector<std::string> child_env  = base_env; // copy
         child_env.push_back("LLAMA_SERVER_ROUTER_PORT=" + std::to_string(base_params.port));
         // the router strips --pipeline-groups before base_preset is built, so it cannot ride
-        // the preset like other options; hand it over explicitly
-        if (const int n_pg = server_get_pipeline_groups(); n_pg > 1) {
-            child_env.push_back("LLAMA_ARG_PIPELINE_GROUPS=" + std::to_string(n_pg));
+        // the preset like other options; hand it over explicitly. base_env is a copy of our own
+        // environment, so an inherited LLAMA_ARG_PIPELINE_GROUPS would otherwise reach the child
+        // unchanged: appending cannot override it, because execve leaves duplicates in place and
+        // getenv() returns the first entry, and an explicit --pipeline-groups 1 would append
+        // nothing at all. Drop any inherited entry first, then always set the resolved value.
+        {
+            static const std::string pg_prefix = "LLAMA_ARG_PIPELINE_GROUPS=";
+            child_env.erase(std::remove_if(child_env.begin(), child_env.end(),
+                                [](const std::string & e) { return e.rfind(pg_prefix, 0) == 0; }),
+                            child_env.end());
+            child_env.push_back(pg_prefix + std::to_string(server_get_pipeline_groups()));
         }
 
         if (opts.mode == SERVER_CHILD_MODE_DOWNLOAD) {

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -14,8 +14,11 @@
 
 #include <atomic>
 #include <clocale>
+#include <cstdlib>
+#include <cstring>
 #include <exception>
 #include <signal.h>
+#include <string>
 #include <thread> // for std::thread::hardware_concurrency
 
 #if defined(_WIN32)
@@ -24,6 +27,48 @@
 
 static std::function<void(int)> shutdown_handler;
 static std::atomic_flag is_terminating = ATOMIC_FLAG_INIT;
+
+// --pipeline-groups N: run the slots over N independent llama_contexts of the same model, each
+// with its own batch and decode thread. Useful with a layer split over two nodes (--rpc), where a
+// single context leaves each stage idle for half of every decode step.
+// The option is parsed here instead of in common/arg.cpp because it only means anything for the
+// server; everything it changes lives under tools/server.
+static int g_pipeline_groups = 1;
+
+static void server_take_pipeline_groups(int & argc, char ** argv) {
+    static const char * opt = "--pipeline-groups";
+    const size_t opt_len = strlen(opt);
+
+    int n_kept = 1;
+
+    for (int i = 1; i < argc; i++) {
+        const std::string arg = argv[i];
+
+        if (arg == opt) {
+            if (i + 1 >= argc) {
+                fprintf(stderr, "error: %s requires a value\n", opt);
+                exit(1);
+            }
+            g_pipeline_groups = std::atoi(argv[++i]);
+            continue;
+        }
+
+        if (arg.size() > opt_len + 1 && arg.compare(0, opt_len, opt) == 0 && arg[opt_len] == '=') {
+            g_pipeline_groups = std::atoi(arg.c_str() + opt_len + 1);
+            continue;
+        }
+
+        argv[n_kept++] = argv[i];
+    }
+
+    argc = n_kept;
+    argv[n_kept] = nullptr;
+
+    if (g_pipeline_groups < 1) {
+        fprintf(stderr, "error: %s must be >= 1\n", opt);
+        exit(1);
+    }
+}
 
 static inline void signal_handler(int signal) {
     if (is_terminating.test_and_set()) {
@@ -95,6 +140,9 @@ int llama_server(int argc, char ** argv) {
 
     // own arguments required by this example
     common_params params;
+
+    // strip the server-only --pipeline-groups before the common parser sees it
+    server_take_pipeline_groups(argc, argv);
 
     common_init();
 
@@ -168,6 +216,7 @@ int llama_server(common_params & params, int argc, char ** argv) {
 
     // struct that contains llama context and inference
     server_context ctx_server;
+    ctx_server.set_pipeline_groups(g_pipeline_groups);
 
     server_http_context ctx_http;
     if (!ctx_http.init(params)) {

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -33,9 +33,11 @@ static int g_pipeline_groups = 1;
 
 static void server_take_pipeline_groups(int & argc, char ** argv) {
     static const char * opt = "--pipeline-groups";
+    static const char * env = "LLAMA_ARG_PIPELINE_GROUPS";
     const size_t opt_len = strlen(opt);
 
     int n_kept = 1;
+    bool from_cli = false;
 
     for (int i = 1; i < argc; i++) {
         const std::string arg = argv[i];
@@ -46,11 +48,13 @@ static void server_take_pipeline_groups(int & argc, char ** argv) {
                 exit(1);
             }
             g_pipeline_groups = std::atoi(argv[++i]);
+            from_cli = true;
             continue;
         }
 
         if (arg.size() > opt_len + 1 && arg.compare(0, opt_len, opt) == 0 && arg[opt_len] == '=') {
             g_pipeline_groups = std::atoi(arg.c_str() + opt_len + 1);
+            from_cli = true;
             continue;
         }
 
@@ -59,6 +63,17 @@ static void server_take_pipeline_groups(int & argc, char ** argv) {
 
     argc = n_kept;
     argv[n_kept] = nullptr;
+
+    // router mode strips the flag before server_models builds the preset it merges into every
+    // child, so the setting has to cross the process boundary in the environment instead
+    if (from_cli) {
+        common_set_env(env, std::to_string(g_pipeline_groups));
+    } else {
+        const std::string from_env = common_get_env(env);
+        if (!from_env.empty()) {
+            g_pipeline_groups = std::atoi(from_env.c_str());
+        }
+    }
 
     if (g_pipeline_groups < 1) {
         fprintf(stderr, "error: %s must be >= 1\n", opt);

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -28,79 +28,9 @@
 static std::function<void(int)> shutdown_handler;
 static std::atomic_flag is_terminating = ATOMIC_FLAG_INIT;
 
-// parsed here, not in common/arg.cpp: everything it changes lives under tools/server
+// set from params right after parsing, read by server_models::spawn to pass the setting on
 static int g_pipeline_groups = 1;
 
-static void server_take_pipeline_groups(int & argc, char ** argv) {
-    static const char * opt = "--pipeline-groups";
-    static const char * env = "LLAMA_ARG_PIPELINE_GROUPS";
-    const size_t opt_len = strlen(opt);
-
-    int n_kept = 1;
-    bool from_cli = false;
-
-    // Everything after a bare "--" is an operand by convention, never an option, so the scan
-    // stops there and leaves the separator and the rest of argv untouched. That is as far as a
-    // pre-scan can go: it runs before the option table exists, so it cannot tell an option from
-    // the value of a preceding option, and a literal "--pipeline-groups" passed as some other
-    // option's value earlier in the line is still consumed. Registering the option with the
-    // parser is the only complete fix; see the note in tools/server/README.md.
-    bool operands_only = false;
-
-    for (int i = 1; i < argc; i++) {
-        const std::string arg = argv[i];
-
-        if (!operands_only && arg == "--") {
-            operands_only = true;
-            argv[n_kept++] = argv[i];
-            continue;
-        }
-
-        if (operands_only) {
-            argv[n_kept++] = argv[i];
-            continue;
-        }
-
-        if (arg == opt) {
-            if (i + 1 >= argc) {
-                fprintf(stderr, "error: %s requires a value\n", opt);
-                exit(1);
-            }
-            g_pipeline_groups = std::atoi(argv[++i]);
-            from_cli = true;
-            continue;
-        }
-
-        if (arg.size() > opt_len + 1 && arg.compare(0, opt_len, opt) == 0 && arg[opt_len] == '=') {
-            g_pipeline_groups = std::atoi(arg.c_str() + opt_len + 1);
-            from_cli = true;
-            continue;
-        }
-
-        argv[n_kept++] = argv[i];
-    }
-
-    argc = n_kept;
-    argv[n_kept] = nullptr;
-
-    // the flag is stripped before server_models builds the preset it merges into every child, so
-    // router mode hands it to children as LLAMA_ARG_PIPELINE_GROUPS (see server_models::spawn) and
-    // they pick it up here. Not written into our own environment: get_environment() reads the Win32
-    // block while _putenv_s writes the CRT copy, and CRT to Win32 propagation is undocumented.
-    if (!from_cli) {
-        const std::string from_env = common_get_env(env);
-        if (!from_env.empty()) {
-            g_pipeline_groups = std::atoi(from_env.c_str());
-        }
-    }
-
-    if (g_pipeline_groups < 1) {
-        fprintf(stderr, "error: %s must be >= 1\n", opt);
-        exit(1);
-    }
-}
-
-// read by server_models::spawn to pass the setting to router children
 int server_get_pipeline_groups();
 int server_get_pipeline_groups() { return g_pipeline_groups; }
 
@@ -175,9 +105,6 @@ int llama_server(int argc, char ** argv) {
     // own arguments required by this example
     common_params params;
 
-    // must run before the common parser, which rejects the unknown option
-    server_take_pipeline_groups(argc, argv);
-
     common_init();
 
     // start the stream session manager GC right after common init, before any HTTP route can
@@ -187,6 +114,8 @@ int llama_server(int argc, char ** argv) {
     if (!common_params_parse(argc, argv, params, LLAMA_EXAMPLE_SERVER)) {
         return 1;
     }
+
+    g_pipeline_groups = params.n_pipeline_groups;
 
     llama_backend_init();
     llama_numa_init(params.numa);
@@ -250,7 +179,7 @@ int llama_server(common_params & params, int argc, char ** argv) {
 
     // struct that contains llama context and inference
     server_context ctx_server;
-    ctx_server.set_pipeline_groups(g_pipeline_groups);
+    ctx_server.set_pipeline_groups(params.n_pipeline_groups);
 
     server_http_context ctx_http;
     if (!ctx_http.init(params)) {

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -64,11 +64,11 @@ static void server_take_pipeline_groups(int & argc, char ** argv) {
     argc = n_kept;
     argv[n_kept] = nullptr;
 
-    // router mode strips the flag before server_models builds the preset it merges into every
-    // child, so the setting has to cross the process boundary in the environment instead
-    if (from_cli) {
-        common_set_env(env, std::to_string(g_pipeline_groups));
-    } else {
+    // the flag is stripped before server_models builds the preset it merges into every child, so
+    // router mode hands it to children as LLAMA_ARG_PIPELINE_GROUPS (see server_models::spawn) and
+    // they pick it up here. Not written into our own environment: get_environment() reads the Win32
+    // block while _putenv_s writes the CRT copy, and CRT to Win32 propagation is undocumented.
+    if (!from_cli) {
         const std::string from_env = common_get_env(env);
         if (!from_env.empty()) {
             g_pipeline_groups = std::atoi(from_env.c_str());
@@ -80,6 +80,10 @@ static void server_take_pipeline_groups(int & argc, char ** argv) {
         exit(1);
     }
 }
+
+// read by server_models::spawn to pass the setting to router children
+int server_get_pipeline_groups();
+int server_get_pipeline_groups() { return g_pipeline_groups; }
 
 static inline void signal_handler(int signal) {
     if (is_terminating.test_and_set()) {

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -39,8 +39,27 @@ static void server_take_pipeline_groups(int & argc, char ** argv) {
     int n_kept = 1;
     bool from_cli = false;
 
+    // Everything after a bare "--" is an operand by convention, never an option, so the scan
+    // stops there and leaves the separator and the rest of argv untouched. That is as far as a
+    // pre-scan can go: it runs before the option table exists, so it cannot tell an option from
+    // the value of a preceding option, and a literal "--pipeline-groups" passed as some other
+    // option's value earlier in the line is still consumed. Registering the option with the
+    // parser is the only complete fix; see the note in tools/server/README.md.
+    bool operands_only = false;
+
     for (int i = 1; i < argc; i++) {
         const std::string arg = argv[i];
+
+        if (!operands_only && arg == "--") {
+            operands_only = true;
+            argv[n_kept++] = argv[i];
+            continue;
+        }
+
+        if (operands_only) {
+            argv[n_kept++] = argv[i];
+            continue;
+        }
 
         if (arg == opt) {
             if (i + 1 >= argc) {

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -28,11 +28,7 @@
 static std::function<void(int)> shutdown_handler;
 static std::atomic_flag is_terminating = ATOMIC_FLAG_INIT;
 
-// --pipeline-groups N: run the slots over N independent llama_contexts of the same model, each
-// with its own batch and decode thread. Useful with a layer split over two nodes (--rpc), where a
-// single context leaves each stage idle for half of every decode step.
-// The option is parsed here instead of in common/arg.cpp because it only means anything for the
-// server; everything it changes lives under tools/server.
+// parsed here, not in common/arg.cpp: everything it changes lives under tools/server
 static int g_pipeline_groups = 1;
 
 static void server_take_pipeline_groups(int & argc, char ** argv) {
@@ -141,7 +137,7 @@ int llama_server(int argc, char ** argv) {
     // own arguments required by this example
     common_params params;
 
-    // strip the server-only --pipeline-groups before the common parser sees it
+    // must run before the common parser, which rejects the unknown option
     server_take_pipeline_groups(argc, argv);
 
     common_init();


### PR DESCRIPTION
Adds `--pipeline-groups N` to `llama-server`: the slots are run over `N` independent
`llama_context` objects created from the same model, each with its own batch, its own sampling
and its own decode thread. The model weights, the task queue, the results queue and the HTTP
layer are shared. With `N = 1` nothing changes.

The point is a layer split across two machines. With one context the split is a two-stage
pipeline fed one batch at a time, so each stage is idle while the other computes. With two
groups there are two batches in flight.

## Result

Two DGX Sparks (GB10, 111.9 Gb/s per rail), Qwen3.8-27B-UD-Q4_K_XL, layer split over one
`ggml-rpc-server` on the peer, `-c 16384 --parallel 32 --cache-ram 0 -fa on -ngl 99 -t 6`,
32 concurrent clients, 64 requests, npp 128 / ntg 256, best of two repeats, all cells inside one
clock state (2386 to 2402 MHz local, 2433 to 2463 MHz peer, no thermal cap markers).

| device order | groups | tok/s (run a / run b) | TPOT ms | TTFT median s | GPU busy local | GPU busy peer |
|---|---|---|---|---|---|---|
| `CUDA0,RPC0` | 1 | 94.9 / 92.9 | 310 / 311 | 7.4 / 7.6 | 44 / 47 pc | 43 / 41 pc |
| `CUDA0,RPC0` | 2 | 75.5 / 76.3 | 395 / 398 | 6.3 / 5.8 | 43 / 42 pc | 44 / 47 pc |
| `CUDA0,RPC0` | 2, sampling pool off | 73.9 / 75.3 | 408 / 404 | 6.5 / 5.8 | 44 / 43 pc | 45 / 46 pc |
| `RPC0,CUDA0` | 1 | 99.7 / 98.1 | 295 / 301 | 7.5 / 6.6 | 46 / 43 pc | 47 / 46 pc |
| `RPC0,CUDA0` | **2** | **130.4 / 131.3** | 223 / 220 | 5.7 / 6.1 | 76 / 76 pc | 79 / 76 pc |
| `RPC0,CUDA0` | 1, `--backend-sampling` | 94.8 / 94.9 | 309 / 311 | 7.5 / 7.4 | 42 / 42 pc | 44 / 43 pc |
| `RPC0,CUDA0` | 2, `--backend-sampling` | 120.4 / 123.7 | 233 / 230 | 8.0 / 6.4 | 71 / 74 pc | 73 / 75 pc |

1.32x over one context on the same split, at 76 to 79 percent GPU busy per node against 43 to 47
percent. Two things had to be true at once:

1. **The device order matters more than the feature.** With `-sm layer` the devices are filled in
   the order they are listed, so the last device holds the output layer. List the RPC device
   first and the local one last (`--device RPC0,CUDA0`): the logits are then produced locally,
   which removes a `n_vocab * n_rows * 4` byte return from every decode step (31.8 MB per step at
   32 rows on this 248320-token vocabulary) and lets the sampler read them out of local memory.
2. **Sampling had to come off the critical path.** See below.

Slot count sweep, `RPC0,CUDA0`, `--cache-ram 0`, `-c` sized so every slot keeps 512 tokens:

| slots | groups 1 | groups 2 | ratio |
|---|---|---|---|
| 32 | 99.7 tok/s | 130.4 tok/s | 1.31x |
| 64 | 117.2 | 157.2 | 1.34x |
| 128 | 124.2 | 170.1 | 1.37x |
| 256 | 124.1 (1 request in error) | 130.5 (126 of 512 in error) | not comparable, see limits |

## What the cost was, and how it was found

`LLAMA_SERVER_PIPE_PROF=1` (added here) prints, per group and every five seconds, how long an
iteration spends waiting for the engine, in `pre_decode`, in `llama_decode`, in
`llama_synchronize` and in `post_decode`, and splits `post_decode` per token into sampling,
detokenization, stop-string handling and the result queue. On the pair, per group iteration:

| | groups 1, 32 rows | groups 2, 16 rows per group |
|---|---|---|
| wait for the engine lock | 0.00 ms | 0.00 ms |
| `pre_decode` | 0.01 ms | 0.01 ms |
| `llama_decode` | 145 ms | 200 to 262 ms |
| `llama_synchronize` | 148 ms | 95 to 126 ms |
| re-take the engine lock | 0.00 ms | 0.00 ms |
| `post_decode` | 21 ms | 54 to 76 ms |
| whole iteration | 316 ms | 401 ms |
| per token: `common_sampler_sample` | 0.60 ms | 3.6 to 4.6 ms |
| per token: `common_token_to_piece` | 0.002 ms | 0.002 ms |
| per token: `process_token` (stop strings, streaming) | 0.065 ms | 0.18 ms |
| per token: `queue_results.send` | 0.061 ms | 0.18 ms |

Sampling one row builds a candidate array over a 248320-token vocabulary, about 4 MB of memory
traffic. With one context that pass runs in the gap where both GPUs are idle and gets the full
memory bandwidth of the node. With two groups it runs against the other group's GPU work on the
same LPDDR5X and costs six to seven times more per row, while sitting on each group's critical
path between the synchronize and the next submit. Every other candidate was measured and
falsified: the results queue and the task queue are three orders of magnitude too small, and the
engine lock was never contended (0.00 ms in every window; forcing the old single shared host lock
back on with an A/B switch gave 74.7 against 73.5 to 75.3 tok/s).

## Changes

- `--pipeline-groups N`, parsed in `tools/server` because it only means anything for the server.
  Slots are partitioned contiguously; each context gets `n_ctx / N` and `n_seq_max = P / N`, so
  the per-slot context and the total KV over all groups are what the user asked for. Slot
  selection still runs over all slots, so prompt-cache similarity and the slot save / restore
  endpoints behave exactly as before. `N > 1` is refused together with speculative decoding,
  multimodal, control vectors and `--sleep-idle`.
- Each group samples its rows over a small worker pool. The rows are independent (own sampler,
  own row of the logits), so the tokens are the ones the serial pass would have produced. The
  thread budget is divided by the number of groups, so a pipeline-groups run is not simply given
  more CPU than the single-context run. `LLAMA_SERVER_SAMPLE_THREADS=1` turns it off.
- The engine lock is per group, so the host path of one group does not exclude the other's. This
  is worth nothing on its own on this hardware and is reported as such, but it is what the
  feature is supposed to guarantee.
- Task processing pauses only the group that owns the slot the task touches, instead of every
  group. This is what fixed TTFT (29 s to 7 s at 32 concurrent).
- `get_available_slot()` called `prompt_save` / `prompt_load`, which read and write the slot's
  sequence KV, before the guard waited for the owning group's decode to finish. With
  `--cache-ram 0` the cache is null so it never fired; with the cache on it is a live race
  against a running decode and it matches the 29 s TTFT and the abort seen while developing this.
  The cache update now happens after the wait.
- `server_metrics` is no longer written from several group threads at once, and each group counts
  its own slots instead of every slot of the server (which double counted `n_busy_slots`).
- ggml-rpc: a whole message is now atomic on the wire. The socket is cached per endpoint and
  shared by every backend of that endpoint, and a message was three unlocked writes, so two
  contexts interleaved their command streams and `--pipeline-groups 2` aborted with "Remote RPC
  server crashed or returned malformed response" within seconds. Responses are handed out in
  request order by a ticket, so a waiter does not hold the send lock. `last_graph_uid` moved to
  the connection and is checked under that lock, which closes a hazard where GRAPH_RECOMPUTE
  could re-run the other context's graph.

## Correctness

Per-group speculative decoding (the section below), on top of the proofs already listed here:

- Single GPU, five prompts, 48 tokens, temperature 0: greedy output byte identical between the PR
  base, `--pipeline-groups 1` and `--pipeline-groups 2` on this branch, md5
  `e154ffeace8e6d57298e1963f16529b5` for all three.
- Qwen3.5-4B-MTP on one GPU, `--parallel 8`: groups 1 and groups 2 give the same sequential greedy
  md5 with MTP (`4dae418e8227bddb0fc0e93ab11a9e67`) and the same without it
  (`43e68a9c6ffafce623dd8089192cdfc3`); all eight slots of both groups serve requests and
  `/metrics` reports drafted and accepted tokens in both MTP arms.
- `tools/server/tests/unit/test_speculative.py` (`--model-draft` sidecar, context shift,
  context-not-exceeded, parallel requests): 6 passed with one group, 6 passed with two.
  `test_basic.py`, `test_completion.py`, `test_ctx_shift.py`, `test_slot_save.py`: 59 passed,
  1 skipped, 1 failed in both arms, the failure being a preset whose model is not in the offline
  cache. Slot save / restore and context shift therefore also run over two groups.
- Greedy output byte-identical at `N = 1`, `N = 2` and `N = 4` over a CPU-only two-RPC split,
  five prompts, md5 `177dc61e0703eba3bdaf7bf1131f0458`, same as the unmodified binary.
- `tools/server/tests` run serially against this build and against the unmodified branch head on
  the same machine: 325 passed, 233 failed, 6 skipped, 9 errors on both, with byte-identical
  failure name sets. The failures are pre-existing in that environment (the cached test models do
  not match), not introduced here.
- `--pipeline-groups 2` with the sampling pool on and off gives the same test results.

## Speculative decoding per group

`--pipeline-groups N` now combines with speculative decoding (`--spec-type draft-mtp` with the MTP
head inside the GGUF, and `--model-draft` with a sidecar draft model). Each group owns its own
speculative state:

- one draft or MTP `llama_context`, created by `common_speculative_init_from_params` against the
  group's target context, so `ctx_other` and the next-token embedding hooks point at that context;
- one `common_speculative`, sized for the group's `P/N` sequences and addressed by the slot's
  sequence id inside the group (`slot.seq_id`, which is `slot.id` with one group);
- the draft batches go through the group's draft context on the group's decode thread, like
  `llama_decode` already does; the two task-queue yields around the drafter are only taken on the
  single-group main-thread path.

Slot save / restore, context checkpoints (the drafter state is stored and restored with the
checkpoint) and the prompt cache behave as before, per slot. With `N = 1` the code path is the same
as before, spelled through `groups[0]`. With `--model-draft` the sidecar model is loaded once per
group. `validate_pipeline_groups` no longer refuses drafters; `--mmproj`, `--control-vector` and
`--sleep-idle-seconds` are still refused with `N > 1`.

Two DGX Sparks, Qwen3.8-27B-UD-Q4_K_XL, layer split over one `ggml-rpc-server` on the peer
(`--rpc peer:50055 --device RPC0,CUDA0 -sm layer`), `-c 16384 --parallel 32 --cache-ram 0 -fa on
-ngl 99 -t 6`, real-text prompts, npp 128 / ntg 256, 2 requests per client. MTP is
`--spec-type draft-mtp --spec-draft-n-max 3` off the head inside the GGUF. Two passes with the arm
order reversed, because the SM clock decays through a window; the cells below all ran with both
GPUs at 2390 to 2400 MHz and no cap marker (the three cells that were capped or straddled a cap
stage are listed after the table, and each of them has a clean repeat).

| groups | MTP | 8 users tok/s | TPOT ms | 32 users tok/s | TPOT ms | accepted/drafted 8 / 32 |
|---|---|---|---|---|---|---|
| 1 | no | 55.3 | 136 | 96.9 | 311 | - |
| 1 | yes | 95.5 / 93.6 | 74 / 75 | 112.9 / 114.2 | 233 / 232 | 0.80 / 0.64 |
| 2 | no | 54.0 | 139 | 115.7 | 219 | - |
| **2** | **yes** | **77.1** | **84** | **133.8** | **200** | 0.72 / 0.68 |

At 32 users the combination is the best cell measured: 1.38x over one context without speculation,
1.17x over one context with MTP and 1.16x over two groups without it. At 8 users it is not: one
context with MTP is faster (95.5 against 77.1), because two groups halve the rows per group and the
draft head is at its most valuable when the batch is small and the step is memory bound. The
crossover is between 8 and 32 rows, which is the same crossover the `--pipeline-groups` result
itself has.

Cells with a clock caveat, each superseded by the clean repeat in the table: one group without MTP
in the first pass ran at 1828 MHz (53.6 / 95.5), two groups without MTP in the reversed pass at
1690 MHz (51.5 / 108.7), two groups with MTP in the reversed pass straddled a cap stage
(92.0 / 128.3). Every 32-user cell in every arm, including the two without speculation, had one
request of 64 return no tokens; it is present in the arms this PR does not touch, so it is not a
property of per-group speculation.

## Known limits

- **Use `--cache-ram 0` with a layer split.** The RAM prompt cache moves a whole slot state on
  every slot handover, and on a split most of that state lives on the remote node, so it crosses
  the wire. At 32 concurrent clients on the pair, with the cache at its default: one group 75.9
  tok/s and 33 s median TTFT (against 99.7 and 7.5 with `--cache-ram 0`); two groups 6.9 tok/s
  with 14 of 64 requests timing out, because the handover runs on the single task thread and the
  other group starves while it does. This is a property of the cache on a split, and one group is
  already badly hurt by it, but two groups make it much worse and it is not fixed here.
- At 256 slots the two-group cell finished 386 of 512 requests, the rest ending with a truncated
  HTTP response; the server log records no error, so the truncation is on the HTTP path at 256
  concurrent streams, and the node crossed 80 C during that cell. That row is reported with its
  error count and is not a clean measurement. 32, 64 and 128 slots are clean.
- The gain is specific to a layer split. On a single node there is nothing to pipeline.




## Update 2026-09-07: the flag is worth a good deal more than the figures above

The best number in this description is 1.38x at 32 users with two groups and MTP. That was measured before three launch settings were understood, and with all three the same mechanism reaches **1.77x**: 209.5 tok/s against 118.6 for one context on the same split. Qwen3.8-27B UD-Q4_K_XL, two nodes, `--device RPC0,CUDA0 -sm layer`, both GPUs pinned at 1690 MHz.

| rows per group | tok/s | vs one context |
|---|---|---|
| 32 | 143.3 | 1.20x |
| 64 | 182.7 | 1.54x |
| 128 | 209.47 mean (197.2 to 215.8) | **1.77x** mean, 1.81x best |
| 192 | 204.3 | 1.72x |
| 256 | 206.4 | 1.73x |

What the earlier cells were missing:

* **Rows per group.** 32 was never swept. The curve is not linear and it peaks at 128, then turns over. This is the whole difference between 1.20x and 1.814x and it is a property of how much work each group has to amortise its half of the step against, not of the flag.
* **`--kv-unified`.** Worth 23 to 30 percent at 32 rows on a two group arm and nothing at all on one context, so it never showed up in a single context comparison.
* **`--tensor-split 0.5,0.5`.** Without it llama.cpp splits by free memory at load time, so the layer boundary moves between runs and two cells are not comparable. Five boundaries were measured and the even one wins.

Two other things worth recording for anyone reading the numbers above. Speculation does not compose with this at high concurrency: `--spec-draft-n-max 3` is the worst of the three depths at every row count on a split, and above 64 rows speculation of any depth loses (212.72 tok/s off against 164.06 at n=1 and 132.24 at n=3 at 128 rows). Acceptance is a property of the depth rather than the rows, 0.87 / 0.78 / 0.69 at depths 1 / 2 / 3, so a deeper draft accepts strictly more tokens per step and still loses throughput. And more groups is not better: four groups is 10.3 percent slower than two and three groups 11.0 percent slower, because the bottleneck GPU is already 91.55 percent busy on CUDA event accounting at two groups and what is left is scheduling inside prompt batches, not idle waiting for a neighbour.

Cost, stated honestly: at 128 rows the TTFT of a saturating burst is 18.1 s median and 27.2 s p99, against 4.6 and 5.6 at 32 rows. `--parallel` should be sized to the expected load. A server built for 128 rows and driven at 32 gives 110.3 tok/s against 143.3, so oversizing loses 23 percent of throughput and 38 percent of median TTFT at the same time.


### Correction 2026-09-08: quote the mean, not the best leg

The 1.814x above was the **best of three legs**. Re-measured with the original harness on the same binaries, two further legs read 1.789x and 1.665x, with server-side token counters agreeing with the client to 0.01 percent and resident memory matching to the megabyte, so the layer boundary was identical. Pooling all five legs gives a two-group arm of 197.2 to 215.8 tok/s, mean **209.47**, against a one-context arm of 118.42 to 118.96, mean **118.63**.

So the honest headline for this flag is **1.77x, range 1.67 to 1.81 over five legs**, on a saturating 128-row burst whose leg-to-leg spread is 9 percent. The mechanism and the magnitude are unchanged; only the statistic was too flattering.

Two things confirmed while settling this. The comment-reduction pass on this branch is inert: stripping comments with `gcc -fpreprocessed -dD -E`, all five touched files are token-identical between `a1dd7c5e8` and `d98d90dd8`, and the current head measures 1.759x in the same clock state, inside the leg scatter. And generation length is a real axis worth stating: the same leg reads 1.789x at ntg 256 and 1.714x at ntg 128, because the aggregate ratio is diluted by prefill. The decode-only TPOT ratio is 1.947x.

## Scope, relative to the base branch

This PR targets `master`, and against that base it changes **7 files, 1197 insertions and 231 deletions**.
Stated explicitly because a reviewer diffs against the base, not against the point in a stack a
branch was cut from, and a scope claim measured from the wrong reference is exactly the sentence a
reviewer trusts instead of checking.