### PR TITLE
convert: support compressed-tensors mixed-precision NVFP4 checkpoints

### DIFF
--- a/conversion/base.py
+++ b/conversion/base.py
@@ -489,7 +489,7 @@ class ModelBase:
                     quant_format == "nvfp4-pack-quantized"
                     or quant_format == "mixed-precision"
                     and bool(groups)
-                    and all(g.get("format") == "nvfp4-pack-quantized" for g in groups.values() if isinstance(g, dict))
+                    and any(g.get("format") == "nvfp4-pack-quantized" for g in groups.values() if isinstance(g, dict))
                 )
 
                 if len(groups) > 1 and not nvfp4_compressed_tensors:
@@ -538,8 +538,27 @@ class ModelBase:
                             if (base_name + "_zero_point") in self.model_tensors:
                                 tensors_to_remove.append(base_name + "_zero_point")
                 elif nvfp4_compressed_tensors:
-                    # Don't error from compressed-tensors, we'll handle them in _generate_nvfp4_tensors
-                    pass
+                    # NVFP4 tensors were already repacked by _generate_nvfp4_tensors and removed
+                    # from model_tensors. For a "mixed-precision" checkpoint whatever weight_scale
+                    # entries are left belong to the non-NVFP4 config group (FP8 per-channel);
+                    # dequantize them exactly like the float-quantized branch above.
+                    for name in self.model_tensors.keys():
+                        if name.endswith(".weight_scale"):
+                            weight_name = name.removesuffix("_scale")
+                            if weight_name not in self.model_tensors:
+                                tensors_to_remove.append(name)
+                                continue
+                            w = self.model_tensors[weight_name]
+                            s = self.model_tensors[name]
+                            is_fp8 = False
+                            if self._fp8_as_q8:
+                                is_fp8 = w().dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
+                            self.model_tensors[weight_name] = lambda w=w, s=s: dequant_simple(w(), s(), None)
+                            tensors_to_remove.append(name)
+                            if is_fp8:
+                                self._fp8_dequantized.add(weight_name)
+                        elif name.endswith((".input_scale", ".k_scale", ".v_scale", ".weight_scale_2")):
+                            tensors_to_remove.append(name)
                 else:
                     raise NotImplementedError(f"Quant format {quant_format!r} for method {quant_method!r} is not yet supported")
             elif quant_method == "modelopt":
@@ -751,8 +770,15 @@ class ModelBase:
             weight = LazyTorchTensor.to_eager(self.model_tensors[name]())
             scale = LazyTorchTensor.to_eager(self.model_tensors[scale_name]())
 
-            # Skip non-NVFP4 tensors (e.g. FP8 with per-channel 1D scales)
+            # Skip non-NVFP4 tensors (e.g. FP8 with per-channel 1D scales).
+            # In a compressed-tensors "mixed-precision" checkpoint the FP8 group also has a
+            # 2D weight_scale of shape [out, 1], so shape alone is not enough: an NVFP4
+            # tensor is nibble-packed uint8 with an E4M3 scale, one per 16 values.
             if scale.ndim < 2:
+                continue
+            if weight.dtype != torch.uint8 or scale.dtype != torch.float8_e4m3fn:
+                continue
+            if scale.shape[-1] * 16 != weight.shape[-1] * 2:
                 continue
 
             scale2 = LazyTorchTensor.to_eager(self.model_tensors.get(scale2_name, lambda: torch.tensor(1.0))())
@@ -858,7 +884,7 @@ class ModelBase:
             quant_format == "nvfp4-pack-quantized"
             or quant_format == "mixed-precision"
             and bool(quant_groups)
-            and all(g.get("format") == "nvfp4-pack-quantized" for g in quant_groups.values() if isinstance(g, dict))
+            and any(g.get("format") == "nvfp4-pack-quantized" for g in quant_groups.values() if isinstance(g, dict))
         )
         if quant_algo != "NVFP4":
             if nvfp4_compressed_tensors:

--- a/conversion/base.py
+++ b/conversion/base.py
@@ -538,9 +538,8 @@ class ModelBase:
                             if (base_name + "_zero_point") in self.model_tensors:
                                 tensors_to_remove.append(base_name + "_zero_point")
                 elif nvfp4_compressed_tensors:
-                    # NVFP4 tensors are gone by here, so a leftover weight_scale is the FP8 group.
-                    # Per-channel residuals only: a block group's scales are a grid needing
-                    # block_structure expansion, which dequant_simple would misapply.
+                    # NVFP4 is gone by here, so a leftover weight_scale is the FP8 group. Per-channel
+                    # only: block scales are a grid dequant_simple would misapply.
                     for group in groups.values():
                         if not isinstance(group, dict) or group.get("format") == "nvfp4-pack-quantized":
                             continue

--- a/conversion/base.py
+++ b/conversion/base.py
@@ -494,9 +494,9 @@ class ModelBase:
 
                 if len(groups) > 1 and not nvfp4_compressed_tensors:
                     raise NotImplementedError("Can't handle multiple config groups for compressed-tensors yet")
-                weight_config = tuple(groups.values())[0]["weights"]
 
                 if quant_format == "float-quantized" or quant_format == "int-quantized" or quant_format == "naive-quantized":
+                    weight_config = tuple(groups.values())[0]["weights"]
                     block_size = weight_config.get("block_structure", None)
                     strategy = weight_config.get("strategy")
                     assert strategy == "channel" or strategy == "block"
@@ -516,6 +516,7 @@ class ModelBase:
                             if self._fp8_as_q8 and is_fp8:
                                 self._fp8_dequantized.add(weight_name)
                 elif quant_format == "pack-quantized":
+                    weight_config = tuple(groups.values())[0]["weights"]
                     assert weight_config.get("strategy") == "group"
                     assert weight_config.get("type", "int") == "int"
                     num_bits = weight_config.get("num_bits")
@@ -544,10 +545,27 @@ class ModelBase:
                         if not isinstance(group, dict) or group.get("format") == "nvfp4-pack-quantized":
                             continue
                         residual = group.get("weights") or {}
-                        if residual.get("strategy") != "channel" or residual.get("block_structure") is not None:
+                        # dequant_simple is the only dequantizer reachable from here, so the
+                        # residual group has to be one that dequant_simple is correct for:
+                        # an unpacked weight with one scale per row. "pack-quantized" is not,
+                        # its weights are nibble-packed ints needing dequant_packed, and
+                        # prepare_tensors has already renamed its weight_packed to weight, so
+                        # nothing downstream can tell. Refusing beats a silently wrong file.
+                        group_format = group.get("format")
+                        if group_format not in (None, "float-quantized", "int-quantized", "naive-quantized"):
                             raise NotImplementedError(
                                 f"compressed-tensors mixed-precision with NVFP4 plus a "
-                                f"{residual.get('strategy')!r} group is not yet supported"
+                                f"{group_format!r} group is not yet supported"
+                            )
+                        if residual.get("block_structure") is not None:
+                            raise NotImplementedError(
+                                f"compressed-tensors mixed-precision with NVFP4 plus a group with "
+                                f"block_structure {residual.get('block_structure')!r} is not yet supported"
+                            )
+                        if residual.get("strategy") != "channel":
+                            raise NotImplementedError(
+                                f"compressed-tensors mixed-precision with NVFP4 plus a "
+                                f"{residual.get('strategy')!r} strategy group is not yet supported"
                             )
                     for name in self.model_tensors.keys():
                         if name.endswith(".weight_scale"):
@@ -557,9 +575,21 @@ class ModelBase:
                                 continue
                             w = self.model_tensors[weight_name]
                             s = self.model_tensors[name]
-                            is_fp8 = False
-                            if self._fp8_as_q8:
-                                is_fp8 = w().dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
+                            # _generate_nvfp4_tensors consumed every tensor it recognised as
+                            # NVFP4, so a uint8 weight still here is one its dtype or geometry
+                            # guard skipped. dequant_simple would multiply packed nibbles by a
+                            # scale and write the result out as if it were real weights, which
+                            # for some shapes broadcasts cleanly and produces no error at all.
+                            # .dtype and .shape come off a device="meta" tensor, so this does
+                            # not materialize anything.
+                            w_meta = w()
+                            if w_meta.dtype == torch.uint8:
+                                raise NotImplementedError(
+                                    f"{weight_name!r} is still packed uint8 after NVFP4 repacking, so its "
+                                    f"block geometry is not one this converter understands "
+                                    f"(weight {tuple(w_meta.shape)}, scale {tuple(s().shape)})"
+                                )
+                            is_fp8 = self._fp8_as_q8 and w_meta.dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
                             self.model_tensors[weight_name] = lambda w=w, s=s: dequant_simple(w(), s(), None)
                             tensors_to_remove.append(name)
                             if is_fp8:

--- a/conversion/base.py
+++ b/conversion/base.py
@@ -539,6 +539,17 @@ class ModelBase:
                                 tensors_to_remove.append(base_name + "_zero_point")
                 elif nvfp4_compressed_tensors:
                     # _generate_nvfp4_tensors already removed the NVFP4 tensors, so a leftover weight_scale is the FP8 group.
+                    # Only per-channel residual groups are handled: a "block" group's scales are a grid needing
+                    # block_structure expansion, and passing them straight to dequant_simple misapplies them.
+                    for group in groups.values():
+                        if not isinstance(group, dict) or group.get("format") == "nvfp4-pack-quantized":
+                            continue
+                        residual = group.get("weights") or {}
+                        if residual.get("strategy") != "channel" or residual.get("block_structure") is not None:
+                            raise NotImplementedError(
+                                f"compressed-tensors mixed-precision with NVFP4 plus a "
+                                f"{residual.get('strategy')!r} group is not yet supported"
+                            )
                     for name in self.model_tensors.keys():
                         if name.endswith(".weight_scale"):
                             weight_name = name.removesuffix("_scale")

--- a/conversion/base.py
+++ b/conversion/base.py
@@ -538,10 +538,7 @@ class ModelBase:
                             if (base_name + "_zero_point") in self.model_tensors:
                                 tensors_to_remove.append(base_name + "_zero_point")
                 elif nvfp4_compressed_tensors:
-                    # NVFP4 tensors were already repacked by _generate_nvfp4_tensors and removed
-                    # from model_tensors. For a "mixed-precision" checkpoint whatever weight_scale
-                    # entries are left belong to the non-NVFP4 config group (FP8 per-channel);
-                    # dequantize them exactly like the float-quantized branch above.
+                    # _generate_nvfp4_tensors already removed the NVFP4 tensors, so a leftover weight_scale is the FP8 group.
                     for name in self.model_tensors.keys():
                         if name.endswith(".weight_scale"):
                             weight_name = name.removesuffix("_scale")
@@ -770,10 +767,7 @@ class ModelBase:
             weight = LazyTorchTensor.to_eager(self.model_tensors[name]())
             scale = LazyTorchTensor.to_eager(self.model_tensors[scale_name]())
 
-            # Skip non-NVFP4 tensors (e.g. FP8 with per-channel 1D scales).
-            # In a compressed-tensors "mixed-precision" checkpoint the FP8 group also has a
-            # 2D weight_scale of shape [out, 1], so shape alone is not enough: an NVFP4
-            # tensor is nibble-packed uint8 with an E4M3 scale, one per 16 values.
+            # ndim alone is not enough: the FP8 group also has a 2D [out, 1] weight_scale. NVFP4 is nibble-packed uint8, E4M3 scale, one per 16.
             if scale.ndim < 2:
                 continue
             if weight.dtype != torch.uint8 or scale.dtype != torch.float8_e4m3fn:

--- a/conversion/base.py
+++ b/conversion/base.py
@@ -538,9 +538,9 @@ class ModelBase:
                             if (base_name + "_zero_point") in self.model_tensors:
                                 tensors_to_remove.append(base_name + "_zero_point")
                 elif nvfp4_compressed_tensors:
-                    # _generate_nvfp4_tensors already removed the NVFP4 tensors, so a leftover weight_scale is the FP8 group.
-                    # Only per-channel residual groups are handled: a "block" group's scales are a grid needing
-                    # block_structure expansion, and passing them straight to dequant_simple misapplies them.
+                    # NVFP4 tensors are gone by here, so a leftover weight_scale is the FP8 group.
+                    # Per-channel residuals only: a block group's scales are a grid needing
+                    # block_structure expansion, which dequant_simple would misapply.
                     for group in groups.values():
                         if not isinstance(group, dict) or group.get("format") == "nvfp4-pack-quantized":
                             continue
@@ -778,7 +778,7 @@ class ModelBase:
             weight = LazyTorchTensor.to_eager(self.model_tensors[name]())
             scale = LazyTorchTensor.to_eager(self.model_tensors[scale_name]())
 
-            # ndim alone is not enough: the FP8 group also has a 2D [out, 1] weight_scale. NVFP4 is nibble-packed uint8, E4M3 scale, one per 16.
+            # ndim is not enough: FP8 also has a 2D [out,1] scale. NVFP4 is packed uint8, E4M3 per 16.
             if scale.ndim < 2:
                 continue
             if weight.dtype != torch.uint8 or scale.dtype != torch.float8_e4m3fn:

--- a/scripts/unsloth/test_convert_nvfp4_mixed.py
+++ b/scripts/unsloth/test_convert_nvfp4_mixed.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+"""Tests for the compressed-tensors mixed-precision NVFP4 path in conversion/base.py.
+Run: python3 scripts/unsloth/test_convert_nvfp4_mixed.py
+
+Recognising a mixed-precision checkpoint means the NVFP4 branch of dequant_model now
+runs on real inputs instead of being a bare `pass`. Everything the NVFP4 group does not
+consume lands in that branch, and the only dequantizer it has is dequant_simple, which
+is correct for exactly one shape of input: an unpacked weight with one scale per row.
+
+So the thing worth testing is not that a supported checkpoint converts. It is that an
+UNSUPPORTED residual group is refused rather than quietly multiplied by a scale and
+written out, because a converter's output is a file someone keeps and uses for months
+and a wrong number in it never announces itself.
+
+Two ways the branch could be handed something dequant_simple cannot dequantize:
+
+  1. A "pack-quantized" residual group. Its weights are nibble-packed ints needing
+     dequant_packed. It passes a strategy-only guard because its strategy really is
+     "channel". And prepare_tensors renames every `.weight_packed` to `.weight` BEFORE
+     dequant_model runs, so by the time the branch sees it, the `weight_name not in
+     model_tensors` guard is testing a name that now exists. The guard looks correct and
+     is inert. That is `test_pack_quantized_residual_is_refused`, and the config it uses
+     is copied verbatim from unsloth/gemma-4-E2B-it-NVFP4 and -E4B-it-NVFP4, which ship
+     exactly this group_2 over embed_tokens_per_layer.
+
+  2. An NVFP4 tensor whose block geometry _generate_nvfp4_tensors skipped. It stays uint8
+     and packed. For most widths the shapes then fail to broadcast and you get a loud
+     error, but when the scale is [out, 1] it broadcasts cleanly and dequant_simple
+     happily returns packed nibbles scaled as if they were weights. That is
+     `test_surviving_packed_uint8_is_refused`.
+
+dequant_model only reads self._is_nvfp4, self.model_tensors, self.hparams,
+self._fp8_as_q8 and self._fp8_dequantized, so these drive it through a shim rather than
+running a full conversion. No tokenizer, no network, no model download.
+"""
+import sys
+import traceback
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+
+FAILS: list[str] = []
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    if cond:
+        print(f"ok   {name}")
+    else:
+        print(f"FAIL {name}{': ' + detail if detail else ''}")
+        FAILS.append(name)
+
+
+try:
+    import torch
+    from conversion.base import ModelBase
+except ImportError as e:  # pragma: no cover
+    print(f"SKIP: {e}. Install requirements/requirements-convert_hf_to_gguf.txt to run this.")
+    sys.exit(0)
+
+
+class Shim:
+    """The four attributes dequant_model actually reads."""
+
+    def __init__(self, tensors, quant_config, is_nvfp4=True, fp8_as_q8=False):
+        self.model_tensors = {k: (lambda v=v: v) for k, v in tensors.items()}
+        self.hparams = {"quantization_config": quant_config}
+        self._is_nvfp4 = is_nvfp4
+        self._fp8_as_q8 = fp8_as_q8
+        self._fp8_dequantized = set()
+
+    def run(self):
+        ModelBase.dequant_model(self)
+
+    def get(self, name):
+        return self.model_tensors[name]()
+
+
+def nvfp4_group(targets):
+    return {
+        "format": "nvfp4-pack-quantized",
+        "targets": targets,
+        "weights": {
+            "num_bits": 4, "type": "float", "strategy": "tensor_group",
+            "group_size": 16, "block_structure": None, "symmetric": True,
+            "scale_dtype": "torch.float8_e4m3fn",
+        },
+    }
+
+
+def fp8_channel_group(targets):
+    return {
+        "format": "float-quantized",
+        "targets": targets,
+        "weights": {
+            "num_bits": 8, "type": "float", "strategy": "channel",
+            "group_size": None, "block_structure": None, "symmetric": True,
+        },
+    }
+
+
+# Copied verbatim from unsloth/gemma-4-E2B-it-NVFP4 and unsloth/gemma-4-E4B-it-NVFP4
+# config.json, quantization_config.config_groups.group_2. Both ship this identically.
+GEMMA4_PACK_QUANTIZED_GROUP = {
+    "format": "pack-quantized",
+    "input_activations": None,
+    "output_activations": None,
+    "targets": ["re:.*embed_tokens_per_layer$"],
+    "weights": {
+        "actorder": None, "block_structure": None, "dynamic": False,
+        "group_size": None, "num_bits": 8, "observer": "memoryless_minmax",
+        "observer_kwargs": {}, "scale_dtype": None, "strategy": "channel",
+        "symmetric": True, "type": "int", "zp_dtype": None,
+    },
+}
+
+
+def residual_tensors(prefix="model.layers.0.self_attn.q_proj"):
+    """The state dequant_model actually sees. _generate_nvfp4_tensors has already run and
+    consumed every NVFP4 weight/scale pair, so what is left is the residual group only."""
+    return {
+        f"{prefix}.weight": torch.zeros(4, 8, dtype=torch.float8_e4m3fn),
+        f"{prefix}.weight_scale": torch.ones(4, 1),
+    }
+
+
+def raises(shim):
+    try:
+        shim.run()
+    except BaseException as e:  # noqa: BLE001 - the type is part of what we assert
+        return e
+    return None
+
+
+# --------------------------------------------------------------------------------------
+# 1. The defect: a pack-quantized residual group must be refused, not dequant_simple'd.
+#    Before the fix this returned cleanly and left embed_tokens_per_layer.weight as a
+#    dequant_simple lambda over nibble-packed int32. Exit code 0, wrong file.
+# --------------------------------------------------------------------------------------
+def test_pack_quantized_residual_is_refused():
+    tensors = residual_tensors()
+    tensors.update({
+        # prepare_tensors has already renamed .weight_packed -> .weight, which is exactly
+        # why the `weight_name not in model_tensors` guard does not catch this.
+        "model.embed_tokens_per_layer.weight": torch.zeros(8, 16, dtype=torch.int32),
+        "model.embed_tokens_per_layer.weight_scale": torch.ones(8, 1, dtype=torch.bfloat16),
+        "model.embed_tokens_per_layer.weight_shape": torch.tensor([8, 64]),
+    })
+    shim = Shim(tensors, {
+        "quant_method": "compressed-tensors",
+        "format": "mixed-precision",
+        "config_groups": {
+            "group_0": fp8_channel_group(["re:.*self_attn\\.(q|k|v|o)_proj$"]),
+            "group_1": nvfp4_group(["re:.*mlp\\.(gate|up|down)_proj$"]),
+            "group_2": GEMMA4_PACK_QUANTIZED_GROUP,
+        },
+    })
+    err = raises(shim)
+    check("pack-quantized residual raises", isinstance(err, NotImplementedError),
+          f"got {err!r}")
+    check("pack-quantized message names the format",
+          err is not None and "pack-quantized" in str(err), f"got {err!r}")
+    check("pack-quantized weight was not silently dequantized",
+          err is not None,
+          "dequant_model returned cleanly, embed_tokens_per_layer is now wrong numbers")
+
+
+# --------------------------------------------------------------------------------------
+# 2. Control: the shape this PR exists to support must still convert. A guard that
+#    refuses everything would pass test 1 and be useless.
+# --------------------------------------------------------------------------------------
+def test_nvfp4_plus_fp8_channel_still_works():
+    w = (torch.arange(32, dtype=torch.float32).reshape(4, 8) / 8.0).to(torch.float8_e4m3fn)
+    s = torch.tensor([[2.0], [3.0], [4.0], [5.0]])
+    tensors = residual_tensors()
+    tensors.update({
+        "model.layers.0.self_attn.q_proj.weight": w,
+        "model.layers.0.self_attn.q_proj.weight_scale": s,
+        "model.layers.0.self_attn.q_proj.input_scale": torch.tensor(1.0),
+        "model.layers.0.self_attn.k_scale": torch.tensor(1.0),
+        "model.layers.0.self_attn.v_scale": torch.tensor(1.0),
+    })
+    shim = Shim(tensors, {
+        "quant_method": "compressed-tensors",
+        "format": "mixed-precision",
+        "config_groups": {
+            "group_0": fp8_channel_group(["re:.*self_attn\\.(q|k|v|o)_proj$"]),
+            "group_1": nvfp4_group(["re:.*mlp\\.(gate|up|down)_proj$"]),
+        },
+    }, fp8_as_q8=True)
+    err = raises(shim)
+    check("nvfp4 + fp8-channel does not raise", err is None, f"got {err!r}")
+    if err is not None:
+        return
+    got = shim.get("model.layers.0.self_attn.q_proj.weight")
+    check("fp8 residual dequantized to the right numbers",
+          torch.allclose(got, w.float() * s), f"got {got}")
+    for sidecar in ("weight_scale", "input_scale"):
+        check(f"{sidecar} sidecar dropped",
+              f"model.layers.0.self_attn.q_proj.{sidecar}" not in shim.model_tensors)
+    for sidecar in ("k_scale", "v_scale"):
+        check(f"{sidecar} sidecar dropped",
+              f"model.layers.0.self_attn.{sidecar}" not in shim.model_tensors)
+    check("fp8 weight recorded for --fp8-as-q8",
+          "model.layers.0.self_attn.q_proj.weight" in shim._fp8_dequantized)
+
+
+# --------------------------------------------------------------------------------------
+# 3. A residual group with a block_structure is refused, and says so. dequant_simple
+#    would apply a 2-D grid of scales as if it were per-row.
+# --------------------------------------------------------------------------------------
+def test_block_structure_residual_is_refused():
+    group = fp8_channel_group(["re:.*self_attn\\.(q|k|v|o)_proj$"])
+    group["weights"]["block_structure"] = [128, 128]
+    shim = Shim(residual_tensors(), {
+        "quant_method": "compressed-tensors",
+        "format": "mixed-precision",
+        "config_groups": {"group_0": group, "group_1": nvfp4_group(["re:.*mlp.*$"])},
+    })
+    err = raises(shim)
+    check("block_structure residual raises", isinstance(err, NotImplementedError),
+          f"got {err!r}")
+    # The message used to say "a 'channel' group is not supported", naming the field
+    # that was fine and hiding the field that was not.
+    check("block_structure message names block_structure",
+          err is not None and "block_structure" in str(err), f"got {err!r}")
+
+
+def test_non_channel_strategy_residual_is_refused():
+    for strategy in ("tensor", "group", "token", None):
+        group = fp8_channel_group(["re:.*self_attn.*$"])
+        group["weights"]["strategy"] = strategy
+        shim = Shim(residual_tensors(), {
+            "quant_method": "compressed-tensors",
+            "format": "mixed-precision",
+            "config_groups": {"group_0": group, "group_1": nvfp4_group(["re:.*mlp.*$"])},
+        })
+        err = raises(shim)
+        check(f"strategy={strategy!r} residual raises",
+              isinstance(err, NotImplementedError), f"got {err!r}")
+
+
+# --------------------------------------------------------------------------------------
+# 4. Malformed and older exports must fail as NotImplementedError, never as a KeyError
+#    or AttributeError from an unguarded dict access.
+# --------------------------------------------------------------------------------------
+def test_missing_weights_key_is_not_a_keyerror():
+    for weights in (None, {}):
+        group = {"format": "float-quantized", "targets": ["re:.*self_attn.*$"], "weights": weights}
+        shim = Shim(residual_tensors(), {
+            "quant_method": "compressed-tensors",
+            "format": "mixed-precision",
+            "config_groups": {"group_0": group, "group_1": nvfp4_group(["re:.*mlp.*$"])},
+        })
+        err = raises(shim)
+        check(f"weights={weights!r} raises NotImplementedError",
+              isinstance(err, NotImplementedError), f"got {type(err).__name__}: {err}")
+
+    # weights absent entirely. `weight_config = tuple(groups.values())[0]["weights"]` used
+    # to run unconditionally just after the gate and KeyError here, even though the NVFP4
+    # branch never uses weight_config.
+    group = {"format": "float-quantized", "targets": ["re:.*self_attn.*$"]}
+    shim = Shim(residual_tensors(), {
+        "quant_method": "compressed-tensors",
+        "format": "mixed-precision",
+        "config_groups": {"group_0": group, "group_1": nvfp4_group(["re:.*mlp.*$"])},
+    })
+    err = raises(shim)
+    check("absent weights key raises NotImplementedError not KeyError",
+          isinstance(err, NotImplementedError), f"got {type(err).__name__}: {err}")
+
+
+# --------------------------------------------------------------------------------------
+# 5. An NVFP4 tensor _generate_nvfp4_tensors skipped stays packed uint8. With a [out, 1]
+#    scale it broadcasts cleanly, so this is the one shape where the old code produced a
+#    file with no error at all.
+# --------------------------------------------------------------------------------------
+def test_surviving_packed_uint8_is_refused():
+    shim = Shim({
+        "model.layers.0.mlp.down_proj.weight": torch.full((4, 8), 0x42, dtype=torch.uint8),
+        "model.layers.0.mlp.down_proj.weight_scale": torch.ones(4, 1).to(torch.float8_e4m3fn),
+    }, {
+        "quant_method": "compressed-tensors",
+        "format": "mixed-precision",
+        "config_groups": {
+            "group_0": fp8_channel_group(["re:.*self_attn.*$"]),
+            "group_1": nvfp4_group(["re:.*mlp.*$"]),
+        },
+    })
+    err = raises(shim)
+    check("surviving packed uint8 raises", isinstance(err, NotImplementedError),
+          f"got {err!r}")
+    check("packed uint8 message names the dtype",
+          err is not None and "uint8" in str(err), f"got {err!r}")
+
+
+# --------------------------------------------------------------------------------------
+# 6. The gate itself. any() must not pull a mixed-precision checkpoint with no NVFP4
+#    group into the NVFP4 path.
+# --------------------------------------------------------------------------------------
+def test_mixed_precision_without_nvfp4_still_refused():
+    shim = Shim({
+        "model.layers.0.self_attn.q_proj.weight": torch.zeros(4, 8, dtype=torch.float8_e4m3fn),
+        "model.layers.0.self_attn.q_proj.weight_scale": torch.ones(4, 1),
+    }, {
+        "quant_method": "compressed-tensors",
+        "format": "mixed-precision",
+        "config_groups": {
+            "group_0": fp8_channel_group(["re:.*self_attn.*$"]),
+            "group_1": fp8_channel_group(["re:.*mlp.*$"]),
+        },
+    }, is_nvfp4=False)
+    err = raises(shim)
+    check("mixed-precision with no NVFP4 group is refused",
+          isinstance(err, NotImplementedError) and "multiple config groups" in str(err),
+          f"got {err!r}")
+
+
+# --------------------------------------------------------------------------------------
+# 7. Single-group formats must be untouched by all of the above.
+# --------------------------------------------------------------------------------------
+def test_single_group_float_quantized_unaffected():
+    w = torch.zeros(4, 8, dtype=torch.float8_e4m3fn)
+    s = torch.full((4, 1), 2.0)
+    shim = Shim({
+        "model.layers.0.self_attn.q_proj.weight": w,
+        "model.layers.0.self_attn.q_proj.weight_scale": s,
+    }, {
+        "quant_method": "compressed-tensors",
+        "format": "float-quantized",
+        "config_groups": {"group_0": fp8_channel_group(["re:.*self_attn.*$"])},
+    }, is_nvfp4=False, fp8_as_q8=True)
+    err = raises(shim)
+    check("single-group float-quantized does not raise", err is None, f"got {err!r}")
+    if err is None:
+        check("single-group float-quantized dequantizes correctly",
+              torch.allclose(shim.get("model.layers.0.self_attn.q_proj.weight"), w.float() * s))
+
+
+if __name__ == "__main__":
+    for fn in (
+        test_pack_quantized_residual_is_refused,
+        test_nvfp4_plus_fp8_channel_still_works,
+        test_block_structure_residual_is_refused,
+        test_non_channel_strategy_residual_is_refused,
+        test_missing_weights_key_is_not_a_keyerror,
+        test_surviving_packed_uint8_is_refused,
+        test_mixed_precision_without_nvfp4_still_refused,
+        test_single_group_float_quantized_unaffected,
+    ):
+        print(f"-- {fn.__name__}")
+        try:
+            fn()
+        except Exception:
+            traceback.print_exc()
+            FAILS.append(fn.__name__)
+
+    print()
+    if FAILS:
+        print(f"{len(FAILS)} failure(s): {', '.join(FAILS)}")
+        sys.exit(1)
+    print("all passed")


### PR DESCRIPTION
## Problem

Every NVFP4 checkpoint Unsloth publishes is refused by `convert_hf_to_gguf.py`:

```
Traceback (most recent call last):
  File "convert_hf_to_gguf.py", line 311, in main
    model_instance.write()
  File "conversion/base.py", line 1100, in write
    self.prepare_tensors()
  File "conversion/qwen.py", line 150, in prepare_tensors
    super().prepare_tensors()
  File "conversion/base.py", line 924, in prepare_tensors
    self.dequant_model()
  File "conversion/base.py", line 506, in dequant_model
    raise NotImplementedError("Can't handle multiple config groups for compressed-tensors yet")
NotImplementedError: Can't handle multiple config groups for compressed-tensors yet
```

This reproduces on `unsloth/Qwen3.6-35B-A3B-NVFP4`, `unsloth/Qwen3.6-35B-A3B-NVFP4-Fast`
and `unsloth/Qwen3.6-27B-NVFP4`. `ggml-org/llama.cpp` master has the same two `all(...)`
gates (`conversion/base.py:492` and `:861`) and the same `raise` at `:496`, so it is
refused there too.

## Why

These are compressed-tensors `"format": "mixed-precision"` checkpoints with two config
groups, not one:

| group | format | weights | targets |
|---|---|---|---|
| `group_0` | `float-quantized` | 8 bit, `strategy: channel` | `self_attn.(q\|k\|v\|o)_proj`, `linear_attn.(in_proj_qkv\|in_proj_z\|out_proj)`, `lm_head` (and on the non-Fast 35B also the layer 32 to 39 experts) |
| `group_1` | `nvfp4-pack-quantized` | 4 bit, `group_size: 16`, `scale_dtype: torch.float8_e4m3fn` | `mlp.experts.*.(gate\|up\|down)_proj`, `shared_expert.(gate\|up\|down)_proj` |

The `nvfp4_compressed_tensors` gate demands that **all** groups be
`nvfp4-pack-quantized`, so a checkpoint that is NVFP4 for the experts and FP8 for the
attention is classified as neither, and falls into the multi-group `raise`.

## Fix

Four hunks in `conversion/base.py`:

1. and 2. `all(...)` becomes `any(...)` in both copies of the gate (`dequant_model` and
   `prepare_tensors`), so a mixed-precision checkpoint with an NVFP4 group is recognised
   as NVFP4.
3. `_generate_nvfp4_tensors` identifies NVFP4 tensors by dtype and block geometry
   (`weight` uint8, `scale` float8_e4m3fn, one scale per 16 values) rather than by
   `scale.ndim >= 2` alone. This matters because the FP8 group's per-channel
   `weight_scale` is shape `[out, 1]`, which is also rank 2, so without the extra test
   the FP8 tensors were fed to `_nvfp4_pack`.
4. The `nvfp4_compressed_tensors` branch of `dequant_model` was a bare `pass`. It now
   dequantizes whatever `weight_scale` entries survive `_generate_nvfp4_tensors` (which
   in a mixed-precision checkpoint are exactly the non-NVFP4 group) using the same
   `dequant_simple` call the `float-quantized` branch uses, and drops the unused
   `input_scale`, `k_scale` and `v_scale` sidecars.

## Verification

```
convert_hf_to_gguf.py \
  ~/.cache/huggingface/hub/models--unsloth--Qwen3.6-35B-A3B-NVFP4-Fast/snapshots/1c3f884b.../ \
  --outfile Qwen3.6-35B-A3B-NVFP4-Fast.gguf --outtype auto --fp8-as-q8
```

Converts in about six minutes on a DGX Spark and writes `general.file_type = 39`
(`MOSTLY_NVFP4`), 1233 tensors, 21.32 GiB:

| ggml type | tensors | GiB | share | example |
|---|---|---|---|---|
| NVFP4 | 240 | 16.941 | 79.5 % | `blk.0.ffn_down_exps.weight [512, 2048, 256]` |
| BF16 | 72 | 2.527 | 11.9 % | `token_embd.weight [2048, 248320]` |
| Q8_0 | 131 | 1.769 | 8.3 % | `output.weight [2048, 248320]` |
| F32 | 790 | 0.085 | 0.4 % | `blk.0.ffn_down_exps.scale [256]` |

480 of the F32 tensors are the `weight_scale_2` and `input_scale` sidecars written as
`.scale` and `.input_scale`.

Measured on a DGX Spark (GB10, sm_121a), `nvidia-smi -lgc 300,2100`, observed
`clocks.sm` 2093 MHz on every cell, against the same model as `MXFP4_MOE` and as
`unsloth/Qwen3.6-35B-A3B-GGUF` `UD-Q4_K_XL`:

| cell | Q4_K_XL (20.82 GiB) | MXFP4_MOE (18.42 GiB) | NVFP4 (21.32 GiB) |
|---|---|---|---|
| prefill npp 2048 npl 8, S_PP t/s | 2145.1 / 2174.4 | 2466.3 / 2459.0 | 2345.8 / 2360.8 |
| decode npp 128 ntg 128 npl 1, S_TG t/s | 65.74 | 68.03 | 67.28 |
| decode npl 8, S_TG t/s | 207.57 | 226.99 | 224.90 |
| decode npl 32, S_TG t/s | 325.40 | 341.48 | 340.22 |
| wikitext-2 test PPL, c 2048, 8 chunks | 4.8213 +/- 0.1228 | 4.9970 +/- 0.1289 | 4.9348 +/- 0.1269 |

`nsys` on the NVFP4 prefill cell confirms the Blackwell FP4 path is what runs:
42.3 % of GPU time in `mul_mat_q<(ggml_type)40, 128, false>` plus 2.5 % in
`quantize_mmq_nvfp4<...>`, the FP4 activation quantiser, so it is genuine W4A4.

KL divergence over 4 chunks with the NVFP4 GGUF as the base (no BF16 checkpoint was
available for an absolute reference):

| test | mean KLD | 99 % KLD | RMS delta p | same top-1 |
|---|---|---|---|---|
| Q4_K_XL | 0.0561 +/- 0.0023 | 0.634 | 7.28 % | 90.32 % |
| MXFP4_MOE | 0.0980 +/- 0.0038 | 1.031 | 9.66 % | 86.88 % |
| NVFP4 with `-ctk q8_0 -ctv q8_0` | 0.0381 +/- 0.0021 | 0.430 | 6.19 % | 91.59 % |

## Two things this does not do

- **The KV cache scales are dropped.** All three checkpoints carry
  `quantization_config.kv_cache_scheme` = 8 bit float, per-tensor, `static_minmax`, and
  ship `self_attn.k_scale` / `self_attn.v_scale` for the full-attention layers. There is
  no GGUF representation for them, so they are discarded and llama.cpp's KV cache stays
  F16 unless the user passes `-ctk` / `-ctv`. The FP8 KV the checkpoint was calibrated
  for is not reproduced.
- **The `input_scale` sidecars are written but unused.** `llama-model.cpp` loads them as
  `TENSOR_NOT_REQUIRED`, but the MMQ activation quantiser `quantize_mmq_nvfp4` computes
  its own dynamic per-row global scale (`row_amax / (6 * 448)`) at runtime and then does
  a five candidate local search over neighbouring UE4M3 codes per 16 element sub-block.
  The checkpoint's statically calibrated activation scale is therefore ignored, which is
  a deliberate difference from the vLLM CUTLASS path but worth being explicit about.

Draft because the size result deserves a follow-up: the convert-only path cannot touch
what the HF checkpoint left unquantized, so `token_embd` and the ignore-listed
`linear_attn.in_proj_a` / `in_proj_b` stay BF16 and the NVFP4 GGUF ends up larger than
Q4_K_XL. An `--outtype` style override for the unquantized remainder would fix that.


## Follow-up measured after this PR was opened

**Use `--outtype q8_0`, not `--outtype auto`.** A convert-only path cannot touch what the HF
checkpoint never quantized, so with `--outtype auto` the ignore-listed `token_embd` and
`linear_attn.in_proj_a` / `in_proj_b` stay BF16 (2.53 GiB) and the file lands at 21.32 GiB, larger
than Q4_K_XL. With `--outtype q8_0 --fp8-as-q8` it is 20.14 GiB:

| ggml type | tensors | GiB | share |
|---|---|---|---|
| NVFP4 | 240 | 16.941 | 84.1 % |
| Q8_0 | 203 | 3.111 | 15.5 % |
| F32 | 790 | 0.085 | 0.4 % |

The 240 NVFP4 tensors and all 480 `.scale` / `.input_scale` sidecars are byte-identical between the
two builds (sha256 over the concatenated NVFP4 tensor bytes matches). `llama-quantize` cannot do
this shrink instead: `--tensor-type` is only consulted inside `llama_tensor_get_type`, which is
only reached when `tensor_allows_quantization` returns true, and that function begins with
`if (params->only_copy) return false;` (`src/llama-quant.cpp:289`), while without `COPY` the NVFP4
expert tensors are eligible for requantization and there is no way to exempt them.

The q8_0 build also measures slightly better: PPL 4.9027 +/- 0.1260 against 4.9348 +/- 0.1269, and
prefill 2405.0 t/s against 2344.9 t/s, decode at npl 32 338.1 t/s against 339.7 t/s.

**The GGUF reproduces the source checkpoint.** Feeding vLLM the exact token ids that
`llama-perplexity --kl-divergence-base` scored (read out of the `.dat` header, so there is no
tokenizer mismatch) and scoring the same second-half positions with `prompt_logprobs=20`, over 4092
positions:

| | PPL |
|---|---|
| vLLM 0.28.0, `FlashInferCutlassNvFp4LinearKernel` + `FLASHINFER_CUTLASS` MoE | 6.3145 |
| llama.cpp, this NVFP4 GGUF | 6.3371 (+0.36 %) |

Top-20 KL(vLLM \|\| GGUF), renormalised over vLLM's top-20 support: 0.042921 nats, top-1 agreement
90.69 %. The weights are bit-identical between the two, so that residual is the KV cache and the
activation quantiser described above.
