### PR TITLE
rpc: direct server-to-server tensor transfer for a layer split

### DIFF
--- a/ggml/include/ggml-rpc.h
+++ b/ggml/include/ggml-rpc.h
@@ -7,7 +7,7 @@ extern "C" {
 #endif
 
 #define RPC_PROTO_MAJOR_VERSION    5
-#define RPC_PROTO_MINOR_VERSION    2
+#define RPC_PROTO_MINOR_VERSION    3
 #define RPC_PROTO_PATCH_VERSION    0
 
 #ifdef  __cplusplus

--- a/ggml/include/ggml-rpc.h
+++ b/ggml/include/ggml-rpc.h
@@ -7,7 +7,7 @@ extern "C" {
 #endif
 
 #define RPC_PROTO_MAJOR_VERSION    5
-#define RPC_PROTO_MINOR_VERSION    3
+#define RPC_PROTO_MINOR_VERSION    2
 #define RPC_PROTO_PATCH_VERSION    0
 
 #ifdef  __cplusplus

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <thread>
 
 static const char * RPC_DEBUG = std::getenv("GGML_RPC_DEBUG");
 
@@ -75,6 +76,8 @@ enum rpc_cmd {
     RPC_CMD_GRAPH_RECOMPUTE,
     RPC_CMD_MEMSET_TENSOR,
     RPC_CMD_GET_TENSORS,
+    RPC_CMD_COPY_TENSOR_TO,
+    RPC_CMD_PEER_BARRIER,
     RPC_CMD_COUNT,
 };
 
@@ -194,6 +197,29 @@ struct rpc_msg_copy_tensor_req {
 };
 
 struct rpc_msg_copy_tensor_rsp {
+    uint8_t result;
+};
+
+// RPC_CMD_COPY_TENSOR_TO tells the server that holds `src` to write it into `dst` on another
+// server, without the data passing through the client. The request is
+// | rpc_msg_copy_tensor_to_hdr | endpoint_len bytes of the destination endpoint |, and the
+// response arrives once the destination has acknowledged the write.
+struct rpc_msg_copy_tensor_to_hdr {
+    rpc_tensor src;
+    rpc_tensor dst;
+    uint64_t   size;
+    uint32_t   endpoint_len;
+};
+
+struct rpc_msg_copy_tensor_to_rsp {
+    uint8_t result;
+};
+
+// RPC_CMD_PEER_BARRIER has an empty request and a one byte response. A connection is served
+// strictly in order, so receiving its response proves that every command sent earlier on the
+// same connection has finished. It is what a source server waits on after pushing a
+// RPC_CMD_SET_TENSOR to a destination server.
+struct rpc_msg_peer_barrier_rsp {
     uint8_t result;
 };
 
@@ -337,6 +363,8 @@ static const char * rpc_cmd_name(int cmd) {
         case RPC_CMD_GRAPH_RECOMPUTE:   return "GRAPH_RECOMPUTE";
         case RPC_CMD_MEMSET_TENSOR:     return "MEMSET_TENSOR";
         case RPC_CMD_GET_TENSORS:       return "GET_TENSORS";
+        case RPC_CMD_COPY_TENSOR_TO:    return "COPY_TENSOR_TO";
+        case RPC_CMD_PEER_BARRIER:      return "PEER_BARRIER";
         default:                        return "?";
     }
 }
@@ -1025,6 +1053,67 @@ static bool rpc_supports_batched_get(const socket_ptr & sock) {
     return !disabled && sock->conn.server_minor >= 2;
 }
 
+// true when the server understands RPC_CMD_COPY_TENSOR_TO and RPC_CMD_PEER_BARRIER.
+// GGML_RPC_P2P=0 forces the old path, for A/B measurements.
+static bool rpc_supports_p2p(const socket_ptr & sock) {
+    static const char * env      = std::getenv("GGML_RPC_P2P");
+    static const bool   disabled = env != nullptr && std::strcmp(env, "0") == 0;
+    return !disabled && sock != nullptr && sock->conn.server_minor >= 3;
+}
+
+// Server to server movement of a tensor that crosses a stage boundary of a layer split. The
+// client tells the server that holds the source to write it into the destination tensor on
+// another server; only the command and its acknowledgement cross the client's host, not the
+// data. Two servers of one endpoint keep using the server local RPC_CMD_COPY_TENSOR.
+static bool ggml_backend_rpc_cpy_tensor_p2p(ggml_backend_t backend_src, ggml_backend_t backend_dst,
+                                            const ggml_tensor * src, ggml_tensor * dst) {
+    ggml_backend_rpc_context * src_ctx = (ggml_backend_rpc_context *) backend_src->context;
+    ggml_backend_rpc_context * dst_ctx = (ggml_backend_rpc_context *) backend_dst->context;
+
+    if (src_ctx->endpoint == dst_ctx->endpoint) {
+        // same server: ggml_backend_rpc_buffer_cpy_tensor does it without leaving the server
+        return false;
+    }
+    if (src->buffer == nullptr || dst->buffer == nullptr ||
+        !ggml_backend_buffer_is_rpc(src->buffer) || !ggml_backend_buffer_is_rpc(dst->buffer)) {
+        return false;
+    }
+    const uint64_t size = (uint64_t) ggml_nbytes(src);
+    if (size != (uint64_t) ggml_nbytes(dst)) {
+        return false;
+    }
+
+    auto src_sock = get_socket(src_ctx->endpoint);
+    auto dst_sock = get_socket(dst_ctx->endpoint);
+    if (!rpc_supports_p2p(src_sock) || !rpc_supports_p2p(dst_sock)) {
+        return false;
+    }
+
+    // anything queued for the destination has to be on the wire before the peer write lands
+    rpc_flush_deferred_guarded(dst_sock);
+
+    const std::string & endpoint = dst_ctx->endpoint;
+    rpc_msg_copy_tensor_to_hdr hdr;
+    hdr.src          = serialize_tensor(src);
+    hdr.dst          = serialize_tensor(dst);
+    hdr.size         = size;
+    hdr.endpoint_len = (uint32_t) endpoint.size();
+
+    std::vector<uint8_t> input(sizeof(hdr) + endpoint.size());
+    memcpy(input.data(), &hdr, sizeof(hdr));
+    memcpy(input.data() + sizeof(hdr), endpoint.data(), endpoint.size());
+
+    // The reply arrives once the destination server has acknowledged the write, so the
+    // destination cannot compute before the hidden state has landed: the next thing the
+    // scheduler does on that backend is RPC_CMD_GRAPH_COMPUTE, which is sent after this
+    // returns.
+    rpc_msg_copy_tensor_to_rsp response;
+    bool status = send_rpc_cmd(src_sock, RPC_CMD_COPY_TENSOR_TO, input.data(), input.size(),
+                               &response, sizeof(response));
+    RPC_STATUS_ASSERT(status);
+    return response.result != 0;
+}
+
 static void ggml_backend_rpc_get_tensor_async(ggml_backend_t backend, const ggml_tensor * tensor, void * data, size_t offset, size_t size) {
     ggml_backend_rpc_context * rpc_ctx = (ggml_backend_rpc_context *)backend->context;
     auto sock = get_socket(rpc_ctx->endpoint);
@@ -1059,8 +1148,10 @@ static bool ggml_backend_rpc_cpy_tensor_async(ggml_backend_t backend_src, ggml_b
     const bool src_is_rpc = ggml_backend_is_rpc(backend_src);
     const bool dst_is_rpc = ggml_backend_is_rpc(backend_dst);
 
-    // RPC to RPC on the same server is handled by the buffer level copy
-    if (src_is_rpc == dst_is_rpc) {
+    if (src_is_rpc && dst_is_rpc) {
+        return ggml_backend_rpc_cpy_tensor_p2p(backend_src, backend_dst, src, dst);
+    }
+    if (!src_is_rpc && !dst_is_rpc) {
         return false;
     }
 
@@ -1360,10 +1451,22 @@ void ggml_backend_rpc_get_device_memory(const char * endpoint, uint32_t device, 
 
 // RPC server-side implementation
 
+// State that every connection of one server process shares.
+//
+// Before peer to peer copies a server served one client at a time, so a session could own its
+// buffers privately. A source server now opens a second connection to the destination server
+// and writes into a buffer that the coordinator allocated over its own connection, so the live
+// buffers have to be visible to every connection, and command execution has to be serialised
+// across connections (two connections must never drive the same backend at the same time).
+struct rpc_server_shared {
+    std::mutex                               mtx;      // serialises command execution
+    std::unordered_set<ggml_backend_buffer_t> buffers; // every live buffer of this process
+};
+
 class rpc_server {
 public:
-    rpc_server(std::vector<ggml_backend_t> all_backends, const char * cache_dir)
-        : backends(std::move(all_backends)), cache_dir(cache_dir) {
+    rpc_server(std::vector<ggml_backend_t> all_backends, const char * cache_dir, rpc_server_shared & shared)
+        : backends(std::move(all_backends)), cache_dir(cache_dir), shared(shared) {
         stored_graphs.resize(backends.size());
     }
     ~rpc_server();
@@ -1381,6 +1484,7 @@ public:
     bool get_tensor(const rpc_msg_get_tensor_req & request, std::vector<uint8_t> & response);
     bool get_tensors(const std::vector<uint8_t> & input, std::vector<uint8_t> & response);
     bool copy_tensor(const rpc_msg_copy_tensor_req & request, rpc_msg_copy_tensor_rsp & response);
+    bool copy_tensor_to(const std::vector<uint8_t> & input, rpc_msg_copy_tensor_to_rsp & response);
     bool graph_compute(const std::vector<uint8_t> & input);
     bool graph_recompute(const rpc_msg_graph_recompute_req & request);
     bool init_tensor(const rpc_msg_init_tensor_req & request);
@@ -1401,9 +1505,17 @@ private:
                               std::unordered_map<uint64_t, struct ggml_tensor*> & tensor_map);
 
 
+    socket_ptr get_peer_socket(const std::string & endpoint);
+
     std::vector<ggml_backend_t> backends;
     const char * cache_dir;
-    std::unordered_set<ggml_backend_buffer_t> buffers;
+    rpc_server_shared & shared;
+    // buffers allocated over this connection; freed when it closes
+    std::unordered_set<ggml_backend_buffer_t> owned_buffers;
+    // connections to other servers, one per destination endpoint, closed with this connection
+    std::unordered_map<std::string, socket_ptr> peer_socks;
+    // reused staging for RPC_CMD_COPY_TENSOR_TO
+    std::vector<uint8_t> p2p_buf;
     // store the last computed graph for each backend
     std::vector<stored_graph> stored_graphs;
 };
@@ -1416,6 +1528,8 @@ void rpc_server::hello(rpc_msg_hello_rsp & response) {
 }
 
 bool rpc_server::get_alloc_size(const rpc_msg_get_alloc_size_req & request, rpc_msg_get_alloc_size_rsp & response) {
+    std::lock_guard<std::mutex> lock(shared.mtx);
+
     uint32_t dev_id = request.device;
     if (dev_id >= backends.size()) {
         return false;
@@ -1456,6 +1570,8 @@ bool rpc_server::get_alloc_size(const rpc_msg_get_alloc_size_req & request, rpc_
 }
 
 bool rpc_server::alloc_buffer(const rpc_msg_alloc_buffer_req & request, rpc_msg_alloc_buffer_rsp & response) {
+    std::lock_guard<std::mutex> lock(shared.mtx);
+
     uint32_t dev_id = request.device;
     if (dev_id >= backends.size()) {
         return false;
@@ -1469,7 +1585,8 @@ bool rpc_server::alloc_buffer(const rpc_msg_alloc_buffer_req & request, rpc_msg_
         response.remote_size = buffer->size;
         LOG_DBG("[%s] device: %d, size: %" PRIu64 " -> remote_ptr: %" PRIx64 ", remote_size: %" PRIu64 "\n",
             __func__, dev_id, request.size, response.remote_ptr, response.remote_size);
-        buffers.insert(buffer);
+        shared.buffers.insert(buffer);
+        owned_buffers.insert(buffer);
     } else {
         LOG_DBG("[%s] device: %d, size: %" PRIu64 " -> failed\n", __func__, dev_id, request.size);
     }
@@ -1477,6 +1594,8 @@ bool rpc_server::alloc_buffer(const rpc_msg_alloc_buffer_req & request, rpc_msg_
 }
 
 bool rpc_server::get_alignment(const rpc_msg_get_alignment_req & request, rpc_msg_get_alignment_rsp & response) {
+    std::lock_guard<std::mutex> lock(shared.mtx);
+
     uint32_t dev_id = request.device;
     if (dev_id >= backends.size()) {
         return false;
@@ -1489,6 +1608,8 @@ bool rpc_server::get_alignment(const rpc_msg_get_alignment_req & request, rpc_ms
 }
 
 bool rpc_server::get_max_size(const rpc_msg_get_max_size_req & request, rpc_msg_get_max_size_rsp & response) {
+    std::lock_guard<std::mutex> lock(shared.mtx);
+
     uint32_t dev_id = request.device;
     if (dev_id >= backends.size()) {
         return false;
@@ -1501,9 +1622,11 @@ bool rpc_server::get_max_size(const rpc_msg_get_max_size_req & request, rpc_msg_
 }
 
 bool rpc_server::buffer_get_base(const rpc_msg_buffer_get_base_req & request, rpc_msg_buffer_get_base_rsp & response) {
+    std::lock_guard<std::mutex> lock(shared.mtx);
+
     LOG_DBG("[%s] remote_ptr: %" PRIx64 "\n", __func__, request.remote_ptr);
     ggml_backend_buffer_t buffer = reinterpret_cast<ggml_backend_buffer_t>(request.remote_ptr);
-    if (buffers.find(buffer) == buffers.end()) {
+    if (shared.buffers.find(buffer) == shared.buffers.end()) {
         GGML_LOG_ERROR("[%s] buffer not found\n", __func__);
         return false;
     }
@@ -1513,21 +1636,26 @@ bool rpc_server::buffer_get_base(const rpc_msg_buffer_get_base_req & request, rp
 }
 
 bool rpc_server::free_buffer(const rpc_msg_free_buffer_req & request) {
+    std::lock_guard<std::mutex> lock(shared.mtx);
+
     LOG_DBG("[%s] remote_ptr: %" PRIx64 "\n", __func__, request.remote_ptr);
     ggml_backend_buffer_t buffer = reinterpret_cast<ggml_backend_buffer_t>(request.remote_ptr);
-    if (buffers.find(buffer) == buffers.end()) {
+    if (owned_buffers.find(buffer) == owned_buffers.end()) {
         GGML_LOG_ERROR("[%s] buffer not found\n", __func__);
         return false;
     }
     ggml_backend_buffer_free(buffer);
-    buffers.erase(buffer);
+    owned_buffers.erase(buffer);
+    shared.buffers.erase(buffer);
     return true;
 }
 
 bool rpc_server::buffer_clear(const rpc_msg_buffer_clear_req & request) {
+    std::lock_guard<std::mutex> lock(shared.mtx);
+
     LOG_DBG("[%s] remote_ptr: %" PRIx64 ", value: %u\n", __func__, request.remote_ptr, request.value);
     ggml_backend_buffer_t buffer = reinterpret_cast<ggml_backend_buffer_t>(request.remote_ptr);
-    if (buffers.find(buffer) == buffers.end()) {
+    if (shared.buffers.find(buffer) == shared.buffers.end()) {
         GGML_LOG_ERROR("[%s] buffer not found\n", __func__);
         return false;
     }
@@ -1536,6 +1664,8 @@ bool rpc_server::buffer_clear(const rpc_msg_buffer_clear_req & request) {
 }
 
 bool rpc_server::memset_tensor(const rpc_msg_memset_tensor_req & request) {
+    std::lock_guard<std::mutex> lock(shared.mtx);
+
     struct ggml_init_params params {
         /*.mem_size   =*/ ggml_tensor_overhead(),
         /*.mem_buffer =*/ NULL,
@@ -1607,7 +1737,7 @@ ggml_tensor * rpc_server::deserialize_tensor(struct ggml_context * ctx, const rp
         result->nb[i] = tensor->nb[i];
     }
     result->buffer = reinterpret_cast<ggml_backend_buffer_t>(tensor->buffer);
-    if (result->buffer && buffers.find(result->buffer) == buffers.end()) {
+    if (result->buffer && shared.buffers.find(result->buffer) == shared.buffers.end()) {
         result->buffer = nullptr;
     }
 
@@ -1632,6 +1762,8 @@ ggml_tensor * rpc_server::deserialize_tensor(struct ggml_context * ctx, const rp
 
 
 bool rpc_server::set_tensor(const std::vector<uint8_t> & input) {
+    std::lock_guard<std::mutex> lock(shared.mtx);
+
     // serialization format: | rpc_tensor | offset (8 bytes) | data (size bytes) |
     if (input.size() < sizeof(rpc_tensor) + sizeof(uint64_t)) {
         return false;
@@ -1705,6 +1837,8 @@ bool rpc_server::get_cached_file(uint64_t hash, std::vector<uint8_t> & data) {
 
 bool rpc_server::set_tensor_hash(const rpc_msg_set_tensor_hash_req & request, rpc_msg_set_tensor_hash_rsp & response)
 {
+    std::lock_guard<std::mutex> lock(shared.mtx);
+
     std::vector<uint8_t> cached_file;
     if (!get_cached_file(request.hash, cached_file)) {
         response.result = 0;
@@ -1746,6 +1880,8 @@ bool rpc_server::set_tensor_hash(const rpc_msg_set_tensor_hash_req & request, rp
 }
 
 bool rpc_server::init_tensor(const rpc_msg_init_tensor_req & request) {
+    std::lock_guard<std::mutex> lock(shared.mtx);
+
     struct ggml_init_params params {
         /*.mem_size   =*/ ggml_tensor_overhead(),
         /*.mem_buffer =*/ NULL,
@@ -1781,6 +1917,8 @@ bool rpc_server::init_tensor(const rpc_msg_init_tensor_req & request) {
 }
 
 bool rpc_server::get_tensor(const rpc_msg_get_tensor_req & request, std::vector<uint8_t> & response) {
+    std::lock_guard<std::mutex> lock(shared.mtx);
+
     struct ggml_init_params params {
         /*.mem_size   =*/ ggml_tensor_overhead(),
         /*.mem_buffer =*/ NULL,
@@ -1820,6 +1958,8 @@ bool rpc_server::get_tensor(const rpc_msg_get_tensor_req & request, std::vector<
 // request order, so one decode step of a backend sampled batch is one round trip instead of one
 // per sequence and per sampler output.
 bool rpc_server::get_tensors(const std::vector<uint8_t> & input, std::vector<uint8_t> & response) {
+    std::lock_guard<std::mutex> lock(shared.mtx);
+
     if (input.size() < sizeof(uint32_t)) {
         return false;
     }
@@ -1871,6 +2011,8 @@ bool rpc_server::get_tensors(const std::vector<uint8_t> & input, std::vector<uin
 }
 
 bool rpc_server::copy_tensor(const rpc_msg_copy_tensor_req & request, rpc_msg_copy_tensor_rsp & response) {
+    std::lock_guard<std::mutex> lock(shared.mtx);
+
     struct ggml_init_params params {
         /*.mem_size   =*/ 2*ggml_tensor_overhead(),
         /*.mem_buffer =*/ NULL,
@@ -1908,6 +2050,111 @@ bool rpc_server::copy_tensor(const rpc_msg_copy_tensor_req & request, rpc_msg_co
             __func__, (void*) src->buffer, (void*) dst->buffer);
 
     response.result = ggml_backend_buffer_copy_tensor(src, dst);
+    return true;
+}
+
+socket_ptr rpc_server::get_peer_socket(const std::string & endpoint) {
+    auto it = peer_socks.find(endpoint);
+    if (it != peer_socks.end()) {
+        return it->second;
+    }
+    // the same connect and HELLO negotiation a client does, so a server to server link uses
+    // RDMA whenever both rails allow it and TCP otherwise
+    auto sock = get_socket(endpoint);
+    if (sock == nullptr) {
+        GGML_LOG_ERROR("[%s] failed to connect to %s\n", __func__, endpoint.c_str());
+        return nullptr;
+    }
+    if (sock->conn.server_minor < 3) {
+        GGML_LOG_ERROR("[%s] %s does not support peer to peer copies\n", __func__, endpoint.c_str());
+        return nullptr;
+    }
+    peer_socks[endpoint] = sock;
+    return sock;
+}
+
+// Writes a tensor of this server into a tensor of another server. The data never reaches the
+// client that issued the command. The source region is validated exactly like RPC_CMD_GET_TENSOR
+// and is pushed to the destination as an ordinary RPC_CMD_SET_TENSOR, so the destination applies
+// its own deserialize_tensor and buffer range checks and nothing about the destination pointer is
+// trusted here. RPC_CMD_PEER_BARRIER then tells us that the write has landed.
+//
+// Recoverable problems (the destination is unreachable or too old, the write was rejected) are
+// reported as result = 0, which puts the client back on its previous path; only a malformed
+// request or an out of bounds source is a protocol error.
+bool rpc_server::copy_tensor_to(const std::vector<uint8_t> & input, rpc_msg_copy_tensor_to_rsp & response) {
+    response.result = 0;
+    if (input.size() < sizeof(rpc_msg_copy_tensor_to_hdr)) {
+        return false;
+    }
+    rpc_msg_copy_tensor_to_hdr hdr;
+    memcpy(&hdr, input.data(), sizeof(hdr));
+    if (input.size() != sizeof(hdr) + (size_t) hdr.endpoint_len) {
+        return false;
+    }
+    const std::string endpoint((const char *) input.data() + sizeof(hdr), hdr.endpoint_len);
+
+    const size_t msg_size = sizeof(rpc_tensor) + sizeof(uint64_t) + (size_t) hdr.size;
+    if (p2p_buf.size() < msg_size) {
+        p2p_buf.resize(msg_size);
+    }
+    const uint64_t dst_offset = 0;
+    memcpy(p2p_buf.data(), &hdr.dst, sizeof(rpc_tensor));
+    memcpy(p2p_buf.data() + sizeof(rpc_tensor), &dst_offset, sizeof(dst_offset));
+
+    // read the source out of this server's device; the peer connection is used without this
+    // lock, so a ring of servers cannot deadlock on each other's execution mutex
+    {
+        std::lock_guard<std::mutex> lock(shared.mtx);
+
+        struct ggml_init_params params {
+            /*.mem_size   =*/ ggml_tensor_overhead(),
+            /*.mem_buffer =*/ NULL,
+            /*.no_alloc   =*/ true,
+        };
+        ggml_context_ptr ctx_ptr { ggml_init(params) };
+        GGML_ASSERT(ctx_ptr != nullptr);
+        ggml_tensor * tensor = deserialize_tensor(ctx_ptr.get(), &hdr.src);
+        if (tensor == nullptr || tensor->buffer == nullptr) {
+            GGML_LOG_ERROR("[%s] error deserializing tensor\n", __func__);
+            return false;
+        }
+
+        // sanitize tensor->data
+        const size_t p0 = (size_t) ggml_backend_buffer_get_base(tensor->buffer);
+        const size_t p1 = p0 + ggml_backend_buffer_get_size(tensor->buffer);
+        if (hdr.src.data < p0 || hdr.src.data >= p1 || hdr.size > (p1 - hdr.src.data)) {
+            GGML_LOG_ERROR("[%s] source region (data=0x%" PRIx64 ", size=%" PRIu64 ") out of buffer bounds [0x%zx, 0x%zx)\n",
+                           __func__, hdr.src.data, hdr.size, p0, p1);
+            return false;
+        }
+        if (hdr.size > (uint64_t) ggml_nbytes(tensor)) {
+            GGML_LOG_ERROR("[%s] source region larger than the tensor\n", __func__);
+            return false;
+        }
+
+        ggml_backend_tensor_get(tensor, p2p_buf.data() + sizeof(rpc_tensor) + sizeof(dst_offset), 0, hdr.size);
+    }
+
+    socket_ptr peer = get_peer_socket(endpoint);
+    if (peer == nullptr) {
+        return true;
+    }
+
+    LOG_DBG("[%s] %" PRIu64 " bytes to %s\n", __func__, hdr.size, endpoint.c_str());
+
+    if (!send_rpc_cmd(peer, RPC_CMD_SET_TENSOR, p2p_buf.data(), msg_size)) {
+        GGML_LOG_ERROR("[%s] failed to send to %s\n", __func__, endpoint.c_str());
+        peer_socks.erase(endpoint);
+        return true;
+    }
+    rpc_msg_peer_barrier_rsp barrier;
+    if (!send_rpc_cmd(peer, RPC_CMD_PEER_BARRIER, nullptr, 0, &barrier, sizeof(barrier))) {
+        GGML_LOG_ERROR("[%s] %s did not acknowledge the write\n", __func__, endpoint.c_str());
+        peer_socks.erase(endpoint);
+        return true;
+    }
+    response.result = barrier.result;
     return true;
 }
 
@@ -1968,6 +2215,8 @@ ggml_tensor * rpc_server::create_node(uint64_t id,
 }
 
 bool rpc_server::graph_compute(const std::vector<uint8_t> & input) {
+    std::lock_guard<std::mutex> lock(shared.mtx);
+
     // serialization format:
     // | device (4 bytes) | n_nodes (4 bytes) | nodes (n_nodes * sizeof(uint64_t) | n_tensors (4 bytes) | tensors (n_tensors * sizeof(rpc_tensor)) |
     if (input.size() < 2*sizeof(uint32_t)) {
@@ -2042,6 +2291,8 @@ bool rpc_server::graph_compute(const std::vector<uint8_t> & input) {
 }
 
 bool rpc_server::graph_recompute(const rpc_msg_graph_recompute_req & request) {
+    std::lock_guard<std::mutex> lock(shared.mtx);
+
     uint32_t device = request.device;
     if (device >= backends.size()) {
         return false;
@@ -2057,6 +2308,8 @@ bool rpc_server::graph_recompute(const rpc_msg_graph_recompute_req & request) {
 }
 
 bool rpc_server::get_device_memory(const rpc_msg_get_device_memory_req & request, rpc_msg_get_device_memory_rsp & response) {
+    std::lock_guard<std::mutex> lock(shared.mtx);
+
     uint32_t dev_id = request.device;
     if (dev_id >= backends.size()) {
         return false;
@@ -2071,14 +2324,18 @@ bool rpc_server::get_device_memory(const rpc_msg_get_device_memory_req & request
 }
 
 rpc_server::~rpc_server() {
-    for (auto buffer : buffers) {
+    // the connections this server opened to other servers go away with this connection
+    peer_socks.clear();
+    std::lock_guard<std::mutex> lock(shared.mtx);
+    for (auto buffer : owned_buffers) {
+        shared.buffers.erase(buffer);
         ggml_backend_buffer_free(buffer);
     }
 }
 
 static void rpc_serve_client(const std::vector<ggml_backend_t> & backends, const char * cache_dir,
-                             socket_ptr sock) {
-    rpc_server server(backends, cache_dir);
+                             socket_ptr sock, rpc_server_shared & shared) {
+    rpc_server server(backends, cache_dir, shared);
     uint8_t cmd;
     if (!sock->recv_data(&cmd, 1)) {
         return;
@@ -2314,6 +2571,32 @@ static void rpc_serve_client(const std::vector<ggml_backend_t> & backends, const
                 }
                 break;
             }
+            case RPC_CMD_COPY_TENSOR_TO: {
+                std::vector<uint8_t> input;
+                if (!recv_msg(sock, input)) {
+                    return;
+                }
+                rpc_msg_copy_tensor_to_rsp response;
+                if (!server.copy_tensor_to(input, response)) {
+                    return;
+                }
+                if (!send_msg(sock, &response, sizeof(response))) {
+                    return;
+                }
+                break;
+            }
+            case RPC_CMD_PEER_BARRIER: {
+                if (!recv_msg(sock, nullptr, 0)) {
+                    return;
+                }
+                // every command received earlier on this connection has already been served
+                rpc_msg_peer_barrier_rsp response;
+                response.result = 1;
+                if (!send_msg(sock, &response, sizeof(response))) {
+                    return;
+                }
+                break;
+            }
             case RPC_CMD_COPY_TENSOR: {
                 rpc_msg_copy_tensor_req request;
                 if (!recv_msg(sock, &request, sizeof(request))) {
@@ -2425,6 +2708,10 @@ void ggml_backend_rpc_start_server(const char * endpoint, const char * cache_dir
         fprintf(stderr, "Failed to create server socket\n");
         return;
     }
+    // One thread per connection: besides the client that drives this server, other servers
+    // connect to it to deliver the tensors of a layer split directly (RPC_CMD_COPY_TENSOR_TO).
+    // The connections share one buffer registry and one execution mutex, see rpc_server_shared.
+    auto shared = std::make_shared<rpc_server_shared>();
     while (true) {
         auto client_socket = server_socket->accept();
         if (client_socket == nullptr) {
@@ -2433,9 +2720,13 @@ void ggml_backend_rpc_start_server(const char * endpoint, const char * cache_dir
         }
         printf("Accepted client connection\n");
         fflush(stdout);
-        rpc_serve_client(backends, cache_dir, client_socket);
-        printf("Client connection closed\n");
-        fflush(stdout);
+        // the state the threads share outlives this function, so a failed accept cannot pull
+        // it out from under a connection that is still being served
+        std::thread([backends, cache_dir, client_socket, shared]() {
+            rpc_serve_client(backends, cache_dir, client_socket, *shared);
+            printf("Client connection closed\n");
+            fflush(stdout);
+        }).detach();
     }
     rpc_transport_shutdown();
     for (auto backend : backends) {

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -2076,13 +2076,8 @@ bool rpc_server::copy_tensor_to(const std::vector<uint8_t> & input, rpc_msg_copy
     }
     const std::string endpoint((const char *) input.data() + sizeof(hdr), hdr.endpoint_len);
 
-    const size_t msg_size = sizeof(rpc_tensor) + sizeof(uint64_t) + (size_t) hdr.size;
-    if (p2p_buf.size() < msg_size) {
-        p2p_buf.resize(msg_size);
-    }
-    const uint64_t dst_offset = 0;
-    memcpy(p2p_buf.data(), &hdr.dst, sizeof(rpc_tensor));
-    memcpy(p2p_buf.data() + sizeof(rpc_tensor), &dst_offset, sizeof(dst_offset));
+    // sized below, once hdr.size has been checked against the source tensor
+    size_t msg_size = 0;
 
     // read the source out of this server's device; the peer connection is used without this
     // lock, so a ring of servers cannot deadlock on each other's execution mutex
@@ -2114,6 +2109,18 @@ bool rpc_server::copy_tensor_to(const std::vector<uint8_t> & input, rpc_msg_copy
             GGML_LOG_ERROR("[%s] source region larger than the tensor\n", __func__);
             return false;
         }
+
+        // only now is hdr.size known to fit both the buffer and the tensor. Sizing the staging
+        // buffer before these checks let a client pick any 64 bit length: a large one aborts the
+        // server on an uncaught bad_alloc, and one near SIZE_MAX wraps msg_size so that the two
+        // header copies below run past the end of an undersized vector.
+        const uint64_t dst_offset = 0;
+        msg_size = sizeof(rpc_tensor) + sizeof(dst_offset) + (size_t) hdr.size;
+        if (p2p_buf.size() < msg_size) {
+            p2p_buf.resize(msg_size);
+        }
+        memcpy(p2p_buf.data(), &hdr.dst, sizeof(rpc_tensor));
+        memcpy(p2p_buf.data() + sizeof(rpc_tensor), &dst_offset, sizeof(dst_offset));
 
         ggml_backend_tensor_get(tensor, p2p_buf.data() + sizeof(rpc_tensor) + sizeof(dst_offset), 0, hdr.size);
     }

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -502,13 +502,19 @@ static bool send_rpc_cmd(socket_ptr sock, enum rpc_cmd cmd, const void * input, 
 // Performs HELLO handshake with transport auto-negotiation.
 // Advertises local capabilities via conn_caps; if the server responds with
 // matching capabilities, the socket is upgraded transparently.
-static bool negotiate_hello(const std::shared_ptr<socket_t> & sock) {
+// may_fail is for connections opened from inside a server: a destination that disconnects or
+// truncates its HELLO must not abort the source server and every client it is serving, so the
+// caller gets false and copy_tensor_to reports result = 0. A client keeps aborting as before.
+static bool negotiate_hello(const std::shared_ptr<socket_t> & sock, bool may_fail = false) {
     rpc_msg_hello_req request = {};
     rpc_msg_hello_rsp response = {};
 
     sock->get_caps(request.conn_caps);
 
     bool status = send_rpc_cmd(sock, RPC_CMD_HELLO, &request, sizeof(request), &response, sizeof(response));
+    if (!status && may_fail) {
+        return false;
+    }
     RPC_STATUS_ASSERT(status);
 
     if (response.major != RPC_PROTO_MAJOR_VERSION || response.minor > RPC_PROTO_MINOR_VERSION) {
@@ -537,7 +543,7 @@ static std::shared_ptr<socket_t> find_socket(const std::string & endpoint) {
     return nullptr;
 }
 
-static std::shared_ptr<socket_t> get_socket(const std::string & endpoint) {
+static std::shared_ptr<socket_t> get_socket(const std::string & endpoint, bool may_fail = false) {
     std::lock_guard<std::mutex> lock(g_sockets_mutex);
 
     auto it = g_sockets.find(endpoint);
@@ -560,7 +566,7 @@ static std::shared_ptr<socket_t> get_socket(const std::string & endpoint) {
     if (sock == nullptr) {
         return nullptr;
     }
-    if (!negotiate_hello(sock)) {
+    if (!negotiate_hello(sock, may_fail)) {
         return nullptr;
     }
     LOG_DBG("[%s] connected to %s\n", __func__, endpoint.c_str());
@@ -2035,7 +2041,8 @@ socket_ptr rpc_server::get_peer_socket(const std::string & endpoint) {
     }
     // the same connect and HELLO negotiation a client does, so a server to server link uses
     // RDMA whenever both rails allow it and TCP otherwise
-    auto sock = get_socket(endpoint);
+    // may_fail: a destination that is down or restarting is a recoverable condition here
+    auto sock = get_socket(endpoint, /* may_fail */ true);
     if (sock == nullptr) {
         GGML_LOG_ERROR("[%s] failed to connect to %s\n", __func__, endpoint.c_str());
         return nullptr;

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -90,11 +90,20 @@ struct rpc_msg_hello_req {
     uint8_t conn_caps[RPC_CONN_CAPS_SIZE];
 };
 
+// Server feature flags, carried in the byte that used to be pure padding in the HELLO response.
+// Features are advertised here rather than by bumping the protocol minor because a client rejects
+// any server whose minor exceeds its own, so a bump locks out every already-deployed older client
+// even when the new commands are purely additive. This byte is fixed size, already on the wire,
+// and ignored by every existing client, which reads it as padding and sees zero.
+enum rpc_srv_flag {
+    RPC_SRV_FLAG_PEER_COPY = 1 << 0,  // supports RPC_CMD_COPY_TENSOR_TO and RPC_CMD_PEER_BARRIER
+};
+
 struct rpc_msg_hello_rsp {
     uint8_t major;
     uint8_t minor;
     uint8_t patch;
-    uint8_t padding;
+    uint8_t srv_flags;
     uint8_t conn_caps[RPC_CONN_CAPS_SIZE];
 };
 
@@ -524,6 +533,7 @@ static bool negotiate_hello(const std::shared_ptr<socket_t> & sock, bool may_fai
     }
 
     sock->conn.server_minor = response.minor;
+    sock->conn.server_flags = response.srv_flags;
 
     sock->update_caps(response.conn_caps);
     return true;
@@ -1047,7 +1057,7 @@ static bool rpc_supports_batched_get(const socket_ptr & sock) {
 static bool rpc_supports_p2p(const socket_ptr & sock) {
     static const char * env      = std::getenv("GGML_RPC_P2P");
     static const bool   disabled = env != nullptr && std::strcmp(env, "0") == 0;
-    return !disabled && sock != nullptr && sock->conn.server_minor >= 3;
+    return !disabled && sock != nullptr && (sock->conn.server_flags & RPC_SRV_FLAG_PEER_COPY);
 }
 
 // Server to server movement of a tensor that crosses a stage boundary of a layer split. The
@@ -1523,7 +1533,9 @@ void rpc_server::hello(rpc_msg_hello_rsp & response) {
     response.major = RPC_PROTO_MAJOR_VERSION;
     response.minor = RPC_PROTO_MINOR_VERSION;
     response.patch = RPC_PROTO_PATCH_VERSION;
-    LOG_DBG("[%s] version: %d.%d.%d\n", __func__, response.major, response.minor, response.patch);
+    response.srv_flags = RPC_SRV_FLAG_PEER_COPY;
+    LOG_DBG("[%s] version: %d.%d.%d flags: 0x%02x\n", __func__, response.major, response.minor,
+            response.patch, response.srv_flags);
 }
 
 bool rpc_server::get_alloc_size(const rpc_msg_get_alloc_size_req & request, rpc_msg_get_alloc_size_rsp & response) {
@@ -2062,7 +2074,7 @@ socket_ptr rpc_server::get_peer_socket(const std::string & endpoint) {
         GGML_LOG_ERROR("[%s] failed to connect to %s\n", __func__, endpoint.c_str());
         return nullptr;
     }
-    if (sock->conn.server_minor < 3) {
+    if (!(sock->conn.server_flags & RPC_SRV_FLAG_PEER_COPY)) {
         GGML_LOG_ERROR("[%s] %s does not support peer to peer copies\n", __func__, endpoint.c_str());
         return nullptr;
     }

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -1507,7 +1507,10 @@ public:
 
 private:
     bool get_cached_file(uint64_t hash, std::vector<uint8_t> & data);
-    ggml_tensor * deserialize_tensor(struct ggml_context * ctx, const rpc_tensor * tensor);
+    // allow_foreign widens buffer validation from this session's buffers to every live buffer
+    // in the process. Only the peer-copy write path sets it, see set_tensor().
+    ggml_tensor * deserialize_tensor(struct ggml_context * ctx, const rpc_tensor * tensor,
+                                     bool allow_foreign = false);
     ggml_tensor * create_node(uint64_t id,
                               struct ggml_context * ctx,
                               const std::unordered_map<uint64_t, const rpc_tensor*> & tensor_ptrs,
@@ -1637,7 +1640,7 @@ bool rpc_server::buffer_get_base(const rpc_msg_buffer_get_base_req & request, rp
 
     LOG_DBG("[%s] remote_ptr: %" PRIx64 "\n", __func__, request.remote_ptr);
     ggml_backend_buffer_t buffer = reinterpret_cast<ggml_backend_buffer_t>(request.remote_ptr);
-    if (shared.buffers.find(buffer) == shared.buffers.end()) {
+    if (owned_buffers.find(buffer) == owned_buffers.end()) {
         GGML_LOG_ERROR("[%s] buffer not found\n", __func__);
         return false;
     }
@@ -1666,7 +1669,7 @@ bool rpc_server::buffer_clear(const rpc_msg_buffer_clear_req & request) {
 
     LOG_DBG("[%s] remote_ptr: %" PRIx64 ", value: %u\n", __func__, request.remote_ptr, request.value);
     ggml_backend_buffer_t buffer = reinterpret_cast<ggml_backend_buffer_t>(request.remote_ptr);
-    if (shared.buffers.find(buffer) == shared.buffers.end()) {
+    if (owned_buffers.find(buffer) == owned_buffers.end()) {
         GGML_LOG_ERROR("[%s] buffer not found\n", __func__);
         return false;
     }
@@ -1722,7 +1725,8 @@ bool rpc_server::memset_tensor(const rpc_msg_memset_tensor_req & request) {
     return true;
 }
 
-ggml_tensor * rpc_server::deserialize_tensor(struct ggml_context * ctx, const rpc_tensor * tensor) {
+ggml_tensor * rpc_server::deserialize_tensor(struct ggml_context * ctx, const rpc_tensor * tensor,
+                                             bool allow_foreign) {
     // Validate tensor type before using it
     if (tensor->type >= GGML_TYPE_COUNT) {
         GGML_LOG_ERROR("[%s] invalid tensor type received: %u\n", __func__, tensor->type);
@@ -1748,7 +1752,12 @@ ggml_tensor * rpc_server::deserialize_tensor(struct ggml_context * ctx, const rp
         result->nb[i] = tensor->nb[i];
     }
     result->buffer = reinterpret_cast<ggml_backend_buffer_t>(tensor->buffer);
-    if (result->buffer && shared.buffers.find(result->buffer) == shared.buffers.end()) {
+    // Validate against this session's own buffers by default. Before peer copies existed the
+    // registry was per connection, so naming another connection's buffer simply did not resolve;
+    // moving the registry into rpc_server_shared made every live buffer in the process reachable
+    // from every connection, which is a wider grant than the peer-copy write actually needs.
+    const auto & allowed = allow_foreign ? shared.buffers : owned_buffers;
+    if (result->buffer && allowed.find(result->buffer) == allowed.end()) {
         result->buffer = nullptr;
     }
 
@@ -1792,7 +1801,11 @@ bool rpc_server::set_tensor(const std::vector<uint8_t> & input) {
     ggml_context_ptr ctx_ptr { ggml_init(params) };
     GGML_ASSERT(ctx_ptr != nullptr);
     ggml_context * ctx = ctx_ptr.get();
-    ggml_tensor * tensor = deserialize_tensor(ctx, in_tensor);
+    // The destination of a peer copy receives this command on the connection the source server
+    // opened, not on the connection of the client that allocated the buffer, so this is the one
+    // path that has to resolve a buffer belonging to another session. The write is still bounded
+    // by the buffer range checks in deserialize_tensor and below.
+    ggml_tensor * tensor = deserialize_tensor(ctx, in_tensor, /* allow_foreign */ true);
     if (tensor == nullptr || tensor->buffer == nullptr) {
         GGML_LOG_ERROR("[%s] error deserializing tensor\n", __func__);
         return false;

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -78,6 +78,10 @@ enum rpc_cmd {
     RPC_CMD_GET_TENSORS,
     RPC_CMD_COPY_TENSOR_TO,
     RPC_CMD_PEER_BARRIER,
+    // sent by a source server on the link it opened to a destination server, to mark that link as
+    // server to server. Only such a link may write a buffer it does not own. Appended last so the
+    // existing command numbers, and RPC_CMD_HELLO in particular, do not move.
+    RPC_CMD_PEER_LINK,
     RPC_CMD_COUNT,
 };
 
@@ -384,6 +388,7 @@ static const char * rpc_cmd_name(int cmd) {
         case RPC_CMD_GET_TENSORS:       return "GET_TENSORS";
         case RPC_CMD_COPY_TENSOR_TO:    return "COPY_TENSOR_TO";
         case RPC_CMD_PEER_BARRIER:      return "PEER_BARRIER";
+        case RPC_CMD_PEER_LINK:         return "PEER_LINK";
         default:                        return "?";
     }
 }
@@ -1545,6 +1550,8 @@ public:
         ggml_cgraph          * graph;
     };
 
+    void set_peer_link() { is_peer_link = true; }
+
 private:
     bool get_cached_file(uint64_t hash, std::vector<uint8_t> & data);
     // allow_foreign widens buffer validation from this session's buffers to every live buffer
@@ -1566,10 +1573,25 @@ private:
     std::unordered_set<ggml_backend_buffer_t> owned_buffers;
     // connections to other servers, one per destination endpoint, closed with this connection
     std::unordered_map<std::string, socket_ptr> peer_socks;
+    // endpoints this server could not reach, and until when not to try again. See get_peer_socket.
+    std::unordered_map<std::string, std::chrono::steady_clock::time_point> peer_failed_until;
+    std::unordered_map<std::string, std::chrono::seconds> peer_backoff;
     // reused staging for RPC_CMD_COPY_TENSOR_TO
     std::vector<uint8_t> p2p_buf;
     // store the last computed graph for each backend
     std::vector<stored_graph> stored_graphs;
+
+    // Set only by RPC_CMD_PEER_LINK, which a source server sends on the link it opened to push a
+    // peer copy. Ordinary coordinator connections never send it and so can never write a buffer
+    // belonging to another session, which they previously could: SET_TENSOR widened validation for
+    // every caller because the peer-copy destination is the one path that legitimately needs it.
+    //
+    // This is isolation, not authentication. The RPC protocol has no authentication of any kind and
+    // an untrusted client could send this command too, so it does not make the port safe to expose;
+    // what it does is stop an ordinary or buggy client from reaching another session's buffers at
+    // all, which is the difference between every connection holding the privilege and only the one
+    // that asked for it.
+    bool is_peer_link = false;
 };
 
 void rpc_server::hello(rpc_msg_hello_rsp & response) {
@@ -1846,7 +1868,11 @@ bool rpc_server::set_tensor(const std::vector<uint8_t> & input) {
     // opened, not on the connection of the client that allocated the buffer, so this is the one
     // path that has to resolve a buffer belonging to another session. The write is still bounded
     // by the buffer range checks in deserialize_tensor and below.
-    ggml_tensor * tensor = deserialize_tensor(ctx, in_tensor, /* allow_foreign */ true);
+    //
+    // Only a link that declared itself with RPC_CMD_PEER_LINK gets that widening. An ordinary
+    // client connection is held to its own buffers, so it can no longer overwrite another
+    // session's buffer by supplying that buffer's pointer.
+    ggml_tensor * tensor = deserialize_tensor(ctx, in_tensor, /* allow_foreign */ is_peer_link);
     if (tensor == nullptr || tensor->buffer == nullptr) {
         GGML_LOG_ERROR("[%s] error deserializing tensor\n", __func__);
         return false;
@@ -2152,18 +2178,55 @@ socket_ptr rpc_server::get_peer_socket(const std::string & endpoint) {
     if (it != peer_socks.end()) {
         return it->second;
     }
+
+    // A destination the coordinator can reach but this server cannot, which is what asymmetric
+    // firewall or NAT rules produce, fails here on every single cross-server copy. Nothing about
+    // that failure was remembered, so each split boundary paid another blocking connect, and when
+    // the packets are dropped rather than refused that is the full OS TCP timeout, tens of seconds
+    // each time. The fallback path is meant to be a mild slowdown, not a stall. Remember the
+    // failure and stop retrying it until the backoff expires.
+    const auto now = std::chrono::steady_clock::now();
+    {
+        auto bad = peer_failed_until.find(endpoint);
+        if (bad != peer_failed_until.end()) {
+            if (now < bad->second) {
+                return nullptr;
+            }
+            peer_failed_until.erase(bad);
+        }
+    }
+
+    auto fail = [&](const char * why) -> socket_ptr {
+        // grows 1s, 2s, 4s ... to a cap, so a destination that is down briefly is retried soon
+        // while one that is unreachable by routing stops costing anything measurable
+        auto & backoff = peer_backoff[endpoint];
+        backoff = backoff == std::chrono::seconds(0) ? std::chrono::seconds(1)
+                                                     : std::min(backoff * 2, std::chrono::seconds(60));
+        peer_failed_until[endpoint] = now + backoff;
+        GGML_LOG_ERROR("[%s] %s: %s, not retrying for %llds\n", __func__, endpoint.c_str(), why,
+                       (long long) backoff.count());
+        return nullptr;
+    };
+
     // the same connect and HELLO negotiation a client does, so a server to server link uses
     // RDMA whenever both rails allow it and TCP otherwise
     // may_fail: a destination that is down or restarting is a recoverable condition here
     auto sock = get_socket(endpoint, /* may_fail */ true);
     if (sock == nullptr) {
-        GGML_LOG_ERROR("[%s] failed to connect to %s\n", __func__, endpoint.c_str());
-        return nullptr;
+        return fail("failed to connect");
     }
     if (!(sock->conn.server_flags & RPC_SRV_FLAG_PEER_COPY)) {
-        GGML_LOG_ERROR("[%s] %s does not support peer to peer copies\n", __func__, endpoint.c_str());
-        return nullptr;
+        return fail("does not support peer to peer copies");
     }
+    // Declare this link server to server before any write goes over it. The destination only
+    // widens buffer validation for links that have said this, so without it the copy would be
+    // rejected as a write to a buffer this session does not own.
+    rpc_msg_peer_barrier_rsp linked;
+    if (!send_rpc_cmd(sock, RPC_CMD_PEER_LINK, nullptr, 0, &linked, sizeof(linked)) || linked.result == 0) {
+        return fail("peer link handshake failed");
+    }
+
+    peer_backoff.erase(endpoint);
     peer_socks[endpoint] = sock;
     return sock;
 }
@@ -2435,6 +2498,18 @@ rpc_server::~rpc_server() {
     }
 }
 
+// connections currently being served, and the ceiling on them. See the accept loop.
+static std::atomic<int> rpc_live_conns{0};
+
+static int rpc_max_conns() {
+    static const int n = [] {
+        const char * e = getenv("GGML_RPC_MAX_CONNECTIONS");
+        const int v = e != nullptr ? atoi(e) : 0;
+        return v > 0 ? v : 64;
+    }();
+    return n;
+}
+
 static void rpc_serve_client(const std::vector<ggml_backend_t> & backends, const char * cache_dir,
                              socket_ptr sock, rpc_server_shared & shared) {
     rpc_server server(backends, cache_dir, shared);
@@ -2699,6 +2774,18 @@ static void rpc_serve_client(const std::vector<ggml_backend_t> & backends, const
                 }
                 break;
             }
+            case RPC_CMD_PEER_LINK: {
+                if (!recv_msg(sock, nullptr, 0)) {
+                    return;
+                }
+                server.set_peer_link();
+                rpc_msg_peer_barrier_rsp response;
+                response.result = 1;
+                if (!send_msg(sock, &response, sizeof(response))) {
+                    return;
+                }
+                break;
+            }
             case RPC_CMD_COPY_TENSOR: {
                 rpc_msg_copy_tensor_req request;
                 if (!recv_msg(sock, &request, sizeof(request))) {
@@ -2820,12 +2907,29 @@ void ggml_backend_rpc_start_server(const char * endpoint, const char * cache_dir
             fprintf(stderr, "Failed to accept client connection\n");
             return;
         }
+        // Every accepted socket used to get a detached thread before HELLO was validated, and that
+        // thread can sit in recv_data() indefinitely because the transport sets no read timeout. A
+        // host that opens connections and then says nothing therefore consumed a thread, its stack
+        // and a descriptor each time, without ever completing a handshake, until the server ran out
+        // of one of them. Cap the number of connections served at once and refuse beyond it, which
+        // costs a well behaved deployment nothing: the coordinator and its peers are few.
+        if (rpc_live_conns.load(std::memory_order_relaxed) >= rpc_max_conns()) {
+            fprintf(stderr, "Refusing client connection: already serving %d, limit %d "
+                            "(raise with GGML_RPC_MAX_CONNECTIONS)\n",
+                    rpc_live_conns.load(std::memory_order_relaxed), rpc_max_conns());
+            fflush(stderr);
+            // dropping the last reference closes it, so the peer sees the connection go away
+            continue;
+        }
+        rpc_live_conns.fetch_add(1, std::memory_order_relaxed);
+
         printf("Accepted client connection\n");
         fflush(stdout);
         // the state the threads share outlives this function, so a failed accept cannot pull
         // it out from under a connection that is still being served
         std::thread([backends, cache_dir, client_socket, shared]() {
             rpc_serve_client(backends, cache_dir, client_socket, *shared);
+            rpc_live_conns.fetch_sub(1, std::memory_order_relaxed);
             printf("Client connection closed\n");
             fflush(stdout);
         }).detach();

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -1081,6 +1081,21 @@ static bool ggml_backend_rpc_cpy_tensor_p2p(ggml_backend_t backend_src, ggml_bac
     // anything queued for the destination has to be on the wire before the peer write lands
     rpc_flush_deferred_guarded(dst_sock);
 
+    // and it has to have been served, not merely sent. The peer write arrives on a different
+    // connection, so flushing this one orders the bytes but nothing else: an earlier
+    // GRAPH_COMPUTE or SET_TENSOR that has not yet taken the destination's execution mutex can
+    // still run after the peer's SET_TENSOR and read or overwrite a reused split input buffer.
+    // One connection is served in order, so a command with a reply is the barrier: when this
+    // returns, everything sent earlier on dst_sock is done. Failure is recoverable, the caller
+    // falls back to routing the tensor through the client.
+    {
+        rpc_msg_peer_barrier_rsp barrier;
+        if (!send_rpc_cmd(dst_sock, RPC_CMD_PEER_BARRIER, nullptr, 0, &barrier, sizeof(barrier))) {
+            GGML_LOG_ERROR("[%s] %s did not acknowledge the barrier\n", __func__, dst_ctx->endpoint.c_str());
+            return false;
+        }
+    }
+
     const std::string & endpoint = dst_ctx->endpoint;
     rpc_msg_copy_tensor_to_hdr hdr;
     hdr.src          = serialize_tensor(src);

--- a/ggml/src/ggml-rpc/transport.cpp
+++ b/ggml/src/ggml-rpc/transport.cpp
@@ -674,7 +674,7 @@ socket_ptr socket_t::create_server(const char * host, int port) {
     if (bind(sockfd, (struct sockaddr *) &serv_addr, sizeof(serv_addr)) < 0) {
         return nullptr;
     }
-    if (listen(sockfd, 1) < 0) {
+    if (listen(sockfd, 16) < 0) {
         return nullptr;
     }
     return socket_ptr(new socket_t(std::make_unique<impl>(sockfd)));

--- a/ggml/src/ggml-rpc/transport.cpp
+++ b/ggml/src/ggml-rpc/transport.cpp
@@ -41,6 +41,30 @@ using ssize_t = __int64;
 typedef int sockfd_t;
 #endif
 
+// Writing to a socket whose peer has gone away raises SIGPIPE on POSIX, and neither this library
+// nor the rpc-server executable installs a handler, so the default action terminates the whole
+// process. That was survivable while every send belonged to a client that aborts on a broken
+// connection anyway. It is not survivable now: a source server writes to a cached peer connection,
+// and a destination that was restarted is exactly the recoverable case that is supposed to end in
+// result = 0, not in the source server dying and taking every client it serves with it.
+//
+// Linux and most BSDs take MSG_NOSIGNAL per send. Apple has no MSG_NOSIGNAL and needs the
+// SO_NOSIGPIPE socket option instead, applied once per descriptor. Windows has no SIGPIPE at all.
+#if defined(MSG_NOSIGNAL)
+#  define RPC_SEND_FLAGS MSG_NOSIGNAL
+#else
+#  define RPC_SEND_FLAGS 0
+#endif
+
+static void set_no_sigpipe(sockfd_t sockfd) {
+#if !defined(MSG_NOSIGNAL) && defined(SO_NOSIGPIPE)
+    int flag = 1;
+    setsockopt(sockfd, SOL_SOCKET, SO_NOSIGPIPE, (char *) &flag, sizeof(flag));
+#else
+    (void) sockfd;
+#endif
+}
+
 static const char * RPC_DEBUG = std::getenv("GGML_RPC_DEBUG");
 
 #define LOG_DBG(...) \
@@ -490,7 +514,7 @@ bool socket_t::impl::send_data(const void * data, size_t size) {
     size_t bytes_sent = 0;
     while (bytes_sent < size) {
         size_t size_to_send = std::min(size - bytes_sent, MAX_CHUNK_SIZE);
-        ssize_t n = send(fd, (const char *)data + bytes_sent, size_to_send, 0);
+        ssize_t n = send(fd, (const char *)data + bytes_sent, size_to_send, RPC_SEND_FLAGS);
         if (n < 0) {
             GGML_LOG_ERROR("send failed (bytes_sent=%zu, size_to_send=%zu)\n",
                            bytes_sent, size_to_send);
@@ -646,11 +670,15 @@ socket_ptr socket_t::accept() {
     if (!is_valid_fd(client_socket_fd)) {
         return nullptr;
     }
+    set_no_sigpipe(client_socket_fd);
+    // Adopt first here too: a TCP_NODELAY failure used to leak the accepted descriptor, and this
+    // one is reached once per client connection rather than once per process.
+    socket_ptr sock(new socket_t(std::make_unique<impl>(client_socket_fd)));
     if (!set_no_delay(client_socket_fd)) {
         GGML_LOG_ERROR("Failed to set TCP_NODELAY\n");
         return nullptr;
     }
-    return socket_ptr(new socket_t(std::make_unique<impl>(client_socket_fd)));
+    return sock;
 }
 
 socket_ptr socket_t::create_server(const char * host, int port) {
@@ -658,6 +686,9 @@ socket_ptr socket_t::create_server(const char * host, int port) {
     if (!is_valid_fd(sockfd)) {
         return nullptr;
     }
+    set_no_sigpipe(sockfd);
+    // Same reason as socket_t::connect: adopt first, so the failure paths below cannot leak.
+    socket_ptr sock(new socket_t(std::make_unique<impl>(sockfd)));
     if (!set_reuse_addr(sockfd)) {
         GGML_LOG_ERROR("Failed to set SO_REUSEADDR\n");
         return nullptr;
@@ -677,7 +708,7 @@ socket_ptr socket_t::create_server(const char * host, int port) {
     if (listen(sockfd, 16) < 0) {
         return nullptr;
     }
-    return socket_ptr(new socket_t(std::make_unique<impl>(sockfd)));
+    return sock;
 }
 
 socket_ptr socket_t::connect(const char * host, int port) {
@@ -685,6 +716,15 @@ socket_ptr socket_t::connect(const char * host, int port) {
     if (!is_valid_fd(sockfd)) {
         return nullptr;
     }
+    set_no_sigpipe(sockfd);
+    // Adopt the descriptor before anything that can fail, so every early return below closes it.
+    // socket_t::impl's destructor already calls closesocket(); the leak was purely that the fd
+    // was carried raw until the last line. This used to cost at most one descriptor per process
+    // at startup, because a client that cannot connect aborts. A server calls this per peer copy
+    // through get_peer_socket(), failed peers are not cached, and a destination that refuses the
+    // connection is a recoverable condition that keeps being retried, so the same leak becomes one
+    // descriptor per tensor per boundary crossing and a long decode exhausts the limit.
+    socket_ptr sock(new socket_t(std::make_unique<impl>(sockfd)));
     if (!set_no_delay(sockfd)) {
         GGML_LOG_ERROR("Failed to set TCP_NODELAY\n");
         return nullptr;
@@ -701,7 +741,7 @@ socket_ptr socket_t::connect(const char * host, int port) {
     if (::connect(sockfd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
         return nullptr;
     }
-    return socket_ptr(new socket_t(std::make_unique<impl>(sockfd)));
+    return sock;
 }
 
 #ifdef _WIN32

--- a/ggml/src/ggml-rpc/transport.h
+++ b/ggml/src/ggml-rpc/transport.h
@@ -40,6 +40,9 @@ struct rpc_conn_state {
 
     std::unordered_map<uint32_t, uint64_t> last_graph_uid;
 
+    // server feature flags from the HELLO response
+    uint8_t server_flags = 0;
+
     uint32_t server_minor = 0;
 
     // lock order: mtx_defer before mtx_send, never the reverse


### PR DESCRIPTION
## What this does

A layer split over several RPC devices used to move every hidden state through the host that runs
the scheduler. `ggml_backend_sched_compute_splits` has no direct path between two RPC buffers on
different endpoints (`ggml_backend_rpc_buffer_cpy_tensor` returns false as soon as the sockets
differ), so each stage boundary fell back to `ggml_backend_tensor_copy`: a `GET_TENSOR` into a
host allocation on the coordinator, then a `SET_TENSOR` back out. Two transfers, a synchronize,
and the hidden state of every boundary crossing the coordinator's memory.

With this change the coordinator still issues every control command, but for a boundary between
two remote servers it issues one command instead of two and the data goes straight from one
server to the other. P stages form a ring: the coordinator sends the embeddings to stage 1,
stage 1 sends its output to stage 2, and so on back to the device that holds the output layer.

## Protocol

Minor version 2 -> 3. Every existing command byte and struct is unchanged, so old clients and
servers interoperate for everything else, and the new commands are only used after the HELLO
version check reports minor >= 3 on **both** endpoints.

* `RPC_CMD_COPY_TENSOR_TO` is sent to the server that holds the **source** tensor. Payload is
  `| src rpc_tensor | dst rpc_tensor | size | endpoint_len | destination endpoint |`. The source
  server validates the source region exactly as `RPC_CMD_GET_TENSOR` does (`deserialize_tensor`
  plus the buffer range check), reads it, opens or reuses a connection to the destination
  endpoint using the same connect and HELLO negotiation a client uses (so RDMA when both rails
  allow it and TCP otherwise), and pushes the data as an ordinary `RPC_CMD_SET_TENSOR`. Nothing
  about the destination pointer is trusted on the source side: the destination applies its own
  `deserialize_tensor` and buffer range checks, the same ones it applies to a client.
* `RPC_CMD_PEER_BARRIER` is an empty request with a one byte response. A connection is served
  strictly in order, so its response proves the `SET_TENSOR` that preceded it has completed.
  The source server waits for it before answering the client, which is the ordering guarantee:
  the destination cannot compute before the write has landed, because the scheduler only sends
  `RPC_CMD_GRAPH_COMPUTE` to the destination after `RPC_CMD_COPY_TENSOR_TO` has returned.

Connections to other servers are cached per destination endpoint and closed when the client that
asked for them disconnects. Recoverable failures (destination unreachable, destination too old,
write rejected) come back as `result = 0` and the client falls back to the previous path; only a
malformed request or an out of bounds source closes the connection.

Serving several connections at once is what this needs, so a server now runs one thread per
connection over a shared buffer registry and a shared execution mutex; a session still owns and
frees only the buffers it allocated. The execution mutex is released before the peer connection
is used, so a ring of servers cannot deadlock on each other.

Client side, the RPC backend's `cpy_tensor_async` takes the RPC to RPC case when the two
endpoints differ. Two devices of one server keep the server-local `RPC_CMD_COPY_TENSOR`, and
every other combination returns false so the previous path runs unchanged. `GGML_RPC_P2P=0`
forces the old path for A/B.

## Commands and bytes per decode step

Client side counters (`GGML_RPC_STATS=1`), decode window, Qwen3.8-27B UD-Q4_K_XL, 32 rows,
three stages (`--device RPC0,RPC1,CUDA0 -sm layer --tensor-split 1,1,1`), so one RPC to RPC
boundary per step. The hidden state is 32 x 5120 x 4 B = 655360 B.

| per decode step | hub path | direct path |
|---|---|---|
| GET_TENSOR | 2.00 | 1.00 |
| SET_TENSOR | 12.00 | 11.00 |
| COPY_TENSOR_TO | - | 1.00 |
| total commands | 16.00 | 15.00 |
| request bytes from the coordinator | 1 382 840 | 727 488 |
| response bytes to the coordinator | ~1 310 720 | ~655 360 |

One `GET_TENSOR` plus one `SET_TENSOR` become one `COPY_TENSOR_TO` per boundary, and 1.31 MB per
step stops crossing the coordinator: 2.69 MB of RPC traffic per step becomes 1.38 MB, a 49
percent reduction. For P stages the saving is (P - 2) boundaries per step, so it grows with the
number of nodes while the coordinator's work stays flat.

CPU-only harness (`tests/cpu/rpc_p2p.sh`, three local rpc-servers on the CPU backend,
`--device RPC0,RPC1,RPC2 -sm layer`, the process host doing the embedding lookup), single stream,
exact per-step counts over the decode window:

| per decode step, 3 RPC devices | hub | direct |
|---|---|---|
| GET_TENSOR | 2.01 | 0.00 |
| SET_TENSOR | 18.99 | 17.01 |
| COPY_TENSOR_TO | - | 1.99 |
| SET_TENSOR bytes | 33 375 | 16 240 |

Two RPC to RPC boundaries, two `COPY_TENSOR_TO`, and the SET_TENSOR payload halves.

## Correctness

Greedy output over five prompts, 48 tokens, temperature 0, top_k 1, on the CPU-only harness:
md5 `177dc61e0703eba3bdaf7bf1131f0458` for all four arms - three stage and two stage,
`GGML_RPC_P2P=0` and `GGML_RPC_P2P=1` - which is the same md5 the existing RPC harnesses record.
`tools/server/tests`: 368 passed, 6 skipped, 199 deselected.

## Numbers on two GB10 nodes

Qwen3.8-27B UD-Q4_K_XL, 32 concurrent closed loop clients, npp 128 / ntg 256, 64 requests,
`-c 16384` (16386 for the three group cells), `--cache-ram 0`, `-fa on`, `-t 6`. Local CUDA0 holds
the last third and the output layer; two `ggml-rpc-server` processes on the peer (ports 50052 and
50053, one GPU between them) hold the first two thirds, `--tensor-split 1,1,1`.

| cell | arm | position in round | tok/s | TPOT ms | TTFT med s | util local | util peer | clocks.sm local / peer | tmax local / peer |
|---|---|---|---|---|---|---|---|---|---|
| h1_a | hub, N=1 | 1 | 101.52 | 292.0 | 6.55 | 34.1 | 58.5 | 2401 / 2445 | 55 / 69 |
| d1_a | direct, N=1 | 2 | 99.06 | 298.4 | 5.98 | 32.9 | 59.6 | 2398 / 1804 | 58 / 68 |
| h3_a | hub, 3 groups | 3 | 87.92 | 342.7 | 5.45 | 46.4 | 92.4 | 2396 / 2466 | 60 / 74 |
| d3_a | direct, 3 groups | 4 | 75.54 | 344.7 | 6.31 | 42.7 | 89.0 | 2392 / 1856 | 63 / 75 |
| d3_b | direct, 3 groups | 1 | 83.38 | 359.4 | 6.47 | 43.8 | 91.8 | 2393 / 1856 | 65 / 65 |
| h3_b | hub, 3 groups | 2 | 77.31 | 355.3 | 7.22 | 45.4 | 90.3 | 2392 / 1690 | 67 / 58 |
| d1_b | direct, N=1 | 3 | 96.98 | 302.4 | 6.33 | 31.3 | 60.2 | 2392 / 1690 | 63 / 56 |
| h1_b | hub, N=1 | 4 | 98.18 | 300.7 | 6.33 | 30.6 | 59.6 | 2392 / 1690 | 61 / 54 |

Two stage reference on the same binaries, `--device RPC0,CUDA0`, one rpc-server on the peer:

| cell | tok/s | TPOT ms | TTFT med s | util local | util peer | clocks.sm local / peer |
|---|---|---|---|---|---|---|
| N=1 | 101.13 | 293.8 | 5.34 | 46.1 | 47.6 | 2389 / 2438 |
| N=2 | 143.22 | 208.1 | 4.92 | 85.0 | 84.4 | 2400 / 2268 |

Reading these honestly: throughput does not move. The peer's mean SM clock falls monotonically
through each round (2466, 1856, 1690 MHz), so the first cell of a round is always the fastest one,
and the ranking of the two arms flips when the order is reversed: hub is ahead by 16 percent when
it runs first (round a) and behind by 8 percent when the direct arm runs first (round b). Both
arms are inside that band, so this pair and this topology do not separate them on tok/s. That is
expected here, because the two remote stages share one GPU on one node: the boundary the change
removes from the coordinator becomes a loopback transfer on the peer, and nothing is freed on the
one link that matters. What is unambiguous is the protocol accounting above, which is what scales:
for P stages on P nodes the change removes (P - 2) hidden state round trips per step from the
coordinator's link and memory, so the coordinator stops being a per-boundary relay and the wire
cost of a stage boundary no longer depends on where the scheduler runs.

Also visible in the table: three stages over the same two GPUs is worse than two stages
(143.2 tok/s at two stages with two groups against 77 to 88 at three stages with three groups),
so a third stage should only be added with a third node.

Known limitation, not fixed here: `RPC_CMD_COPY_TENSOR_TO` blocks the source server's connection
thread for the whole transfer plus the barrier, so with several pipeline groups over one
connection the groups serialise behind it. Moving the transfer to a per-destination worker and
letting the destination enforce the ordering with a sequence number, instead of the client
waiting for the acknowledgement, would remove that; it needs a second command on the destination
and another measurement window.

## Non-RPC workloads

Every line of this change is in `ggml/src/ggml-rpc/`:

```
 ggml/include/ggml-rpc.h         |   2 +-
 ggml/src/ggml-rpc/ggml-rpc.cpp  | 325 +++++++++++++++++++++++++++++++-----
 ggml/src/ggml-rpc/transport.cpp |   2 +-
```

`ggml-backend.cpp`, the scheduler, and the CUDA, Metal, Vulkan, CPU and HIP backends are not
touched, so a build with `-DGGML_RPC=OFF` contains none of it and `libggml-base` and `libllama`
gain no new behaviour when the RPC backend is not loaded. Checks on one GB10:

* `-DGGML_RPC=OFF -DGGML_CUDA=ON` configures and builds clean.
* `test-backend-ops -b CUDA0`: 13572/13572 tests passed, OK, on this branch and on the base, same
  count.
* Greedy generation on one GPU with no `--rpc`, three prompts, 64 tokens, temperature 0, top_k 1:
  md5 `1f99f8da109f7a456073901232e1f014` on this branch and on the base, byte identical.
* `llama-batched-bench` on one GPU with no `--rpc`, npp 512, ntg 128, npl 1 / 8 / 32, run as a
  base / new / base bracket in one window (whole run tok/s):

  | npl | base a | new | base b |
  |---|---|---|---|
  | 1 | 55.32 | 53.72 | 53.75 |
  | 8 | 232.26 | 212.29 | 211.87 |
  | 32 | 347.84 | 339.19 | 338.14 |

  The first run of the bracket is the fastest in every row (a cold GPU at the start of the
  window); the new binary matches the second base run to within 0.2 percent at npl 1 and 8 and
  sits between the two base runs at npl 32.



## Scope: this does nothing on a two node pair

Worth stating plainly, because the byte table above is easy to read as a decode win and it is not one here. The saving is (P - 2) boundaries per step. On the two DGX Spark pair P = 2, so there is no RPC to RPC boundary at all and this change is inert: the one crossing goes to the device holding the output layer, which is the coordinator's own CUDA0. The three stage cells above were run with two rpc-servers sharing one GPU on the peer precisely because that is the only way to make a P = 3 boundary exist on two machines, and they show three stages over two GPUs is worse than two stages regardless of the arm.

There is also now a measurement that bounds what any interconnect change on the pair can be worth. A two node layer split moves 6.84 MB per decode step in total, which is 0.34 ms of a 220 ms step against the measured 20.31 GB/s NCCL bus bandwidth, under 0.005x of end to end speedup. Removing 1.31 MB of that would be worth under 0.001x even if the boundary existed. So this PR should be read as a three or more node capacity and scaling change, plus the per connection threaded rpc-server it introduces, and not as a throughput change for the pair. The honest reading of the tok/s table stands as written: the arms do not separate.