### PR TITLE
server: reuse checkpoint state buffers from a bounded pool

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -2251,6 +2251,133 @@ bool common_prompt_batch_decode(
     return true;
 }
 
+common_state_buffer_pool & common_state_buffer_pool::instance() {
+    static common_state_buffer_pool pool;
+    return pool;
+}
+
+// derived once, from host memory as the CPU backend device reports it. an unknown host memory
+// size means no pooling at all, which is the safe direction.
+static size_t common_state_buffer_pool_cap() {
+    size_t mem_free  = 0;
+    size_t mem_total = 0;
+
+    ggml_backend_dev_t cpu_dev = ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU);
+    if (cpu_dev != nullptr) {
+        ggml_backend_dev_memory(cpu_dev, &mem_free, &mem_total);
+    }
+
+    if (mem_total == 0) {
+        return 0;
+    }
+
+    return std::min(mem_total / 16, mem_free / 4);
+}
+
+void common_state_buffer_pool::get(std::vector<uint8_t> & dst, size_t size) {
+    {
+        std::lock_guard<std::mutex> lock(mtx);
+
+        st.n_get++;
+
+        t_last_us = ggml_time_us();
+
+        // an allocation that is already big enough is already resident - nothing to do
+        if (dst.capacity() < size) {
+            // best fit, so a large pooled buffer is not spent on a small request
+            size_t best = free_bufs.size();
+            for (size_t i = 0; i < free_bufs.size(); ++i) {
+                if (free_bufs[i].capacity() >= size &&
+                        (best == free_bufs.size() || free_bufs[i].capacity() < free_bufs[best].capacity())) {
+                    best = i;
+                }
+            }
+
+            if (best < free_bufs.size()) {
+                held_bytes -= free_bufs[best].capacity();
+
+                // the pooled buffer goes to the caller and the caller's undersized one is
+                // dropped: it belongs to a different size class and is of no use here
+                std::swap(dst, free_bufs[best]);
+                free_bufs.erase(free_bufs.begin() + best);
+
+                st.n_hit++;
+            }
+        }
+    }
+
+    // on a hit the pooled buffer normally already has exactly this size, so this is a no-op and
+    // the stale bytes are left in place. that is safe because every caller overwrites the whole
+    // buffer and aborts if the state does not fill it. when the sizes differ, the fill only
+    // touches pages that are already resident.
+    dst.resize(size);
+}
+
+void common_state_buffer_pool::put(std::vector<uint8_t> && src) {
+    const size_t cap = src.capacity();
+
+    if (cap < MIN_BUFFER_BYTES) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(mtx);
+
+    st.n_put++;
+
+    t_last_us = ggml_time_us();
+
+    if (!cap_known) {
+        cap_bytes = common_state_buffer_pool_cap();
+        cap_known = true;
+    }
+
+    if (free_bufs.size() >= MAX_BUFFERS || held_bytes + cap > cap_bytes) {
+        return; // declined: src is freed by its own destructor, as it would be without the pool
+    }
+
+    // the logical size is kept, not cleared: a later get() of the same size is then a no-op
+    // resize rather than a full zero fill of the buffer
+    free_bufs.push_back(std::move(src));
+
+    held_bytes += cap;
+
+    n_hwm = std::max(n_hwm, free_bufs.size());
+
+    st.n_keep++;
+}
+
+void common_state_buffer_pool::trim(int64_t idle_us) {
+    std::lock_guard<std::mutex> lock(mtx);
+
+    if (free_bufs.empty() || ggml_time_us() - t_last_us < idle_us) {
+        return;
+    }
+
+    free_bufs.clear();
+    free_bufs.shrink_to_fit();
+
+    held_bytes = 0;
+}
+
+common_state_buffer_pool::stats common_state_buffer_pool::get_stats() const {
+    std::lock_guard<std::mutex> lock(mtx);
+
+    stats res = st;
+
+    res.held_bytes = held_bytes;
+    res.cap_bytes  = cap_bytes;
+    res.n_hwm      = n_hwm;
+
+    return res;
+}
+
+common_prompt_checkpoint::~common_prompt_checkpoint() {
+    auto & pool = common_state_buffer_pool::instance();
+
+    pool.put(std::move(data_tgt));
+    pool.put(std::move(data_dft));
+}
+
 size_t common_prompt_checkpoint::size() const {
     return data_tgt.size() + data_dft.size() + data_spec.size();
 }
@@ -2289,7 +2416,7 @@ void common_prompt_checkpoint::update_tgt(
 
     const size_t ckpt_size = llama_state_seq_get_size_ext(ctx, seq_id, flags);
 
-    data_tgt.resize(ckpt_size);
+    common_state_buffer_pool::instance().get(data_tgt, ckpt_size);
 
     const size_t n = llama_state_seq_get_data_ext(ctx, data_tgt.data(), ckpt_size, seq_id, flags);
     if (n != ckpt_size) {
@@ -2307,7 +2434,7 @@ void common_prompt_checkpoint::update_dft(
 
     const size_t ckpt_size = llama_state_seq_get_size_ext(ctx, seq_id, flags);
 
-    data_dft.resize(ckpt_size);
+    common_state_buffer_pool::instance().get(data_dft, ckpt_size);
 
     const size_t n = llama_state_seq_get_data_ext(ctx, data_dft.data(), ckpt_size, seq_id, flags);
     if (n != ckpt_size) {

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -2256,8 +2256,8 @@ common_state_buffer_pool & common_state_buffer_pool::instance() {
     return pool;
 }
 
-// derived once, from host memory as the CPU backend device reports it. an unknown host memory
-// size means no pooling at all, which is the safe direction.
+// derived once, from host memory as the CPU backend device reports it. a host memory size that
+// cannot be trusted means no pooling at all, which is the safe direction.
 static size_t common_state_buffer_pool_cap() {
     size_t mem_free  = 0;
     size_t mem_total = 0;
@@ -2267,14 +2267,25 @@ static size_t common_state_buffer_pool_cap() {
         ggml_backend_dev_memory(cpu_dev, &mem_free, &mem_total);
     }
 
-    if (mem_total == 0) {
+    GGML_UNUSED(mem_free);
+
+    // zero means the CPU device could not report a size. an absurd size means the query itself
+    // failed without saying so: ggml_backend_cpu_device_get_memory() multiplies out
+    // sysconf(_SC_PHYS_PAGES) with no error check, so a -1 from a restricted container arrives
+    // here as ~1.8e19. treat both as unknown and keep nothing.
+    if (mem_total == 0 || mem_total > (1ull << 50)) {
         return 0;
     }
 
-    return std::min(mem_total / 16, mem_free / 4);
+    // a fraction of TOTAL host memory, deliberately not of free: every non-Windows host reports
+    // free == total for the CPU device ("free system memory is ill-defined, assume all of it is
+    // free"), so a free-based cap would be the same number with a false claim attached to it.
+    return mem_total / 16;
 }
 
 void common_state_buffer_pool::get(std::vector<uint8_t> & dst, size_t size) {
+    std::vector<uint8_t> prev; // the caller's previous storage, offered back below
+
     {
         std::lock_guard<std::mutex> lock(mtx);
 
@@ -2282,8 +2293,11 @@ void common_state_buffer_pool::get(std::vector<uint8_t> & dst, size_t size) {
 
         t_last_us = ggml_time_us();
 
-        // an allocation that is already big enough is already resident - nothing to do
-        if (dst.capacity() < size) {
+        if (dst.capacity() >= size) {
+            // the caller's own allocation is already big enough, so it is already resident.
+            // that is a reuse too, and the cheapest kind.
+            st.n_hit++;
+        } else {
             // best fit, so a large pooled buffer is not spent on a small request
             size_t best = free_bufs.size();
             for (size_t i = 0; i < free_bufs.size(); ++i) {
@@ -2296,15 +2310,20 @@ void common_state_buffer_pool::get(std::vector<uint8_t> & dst, size_t size) {
             if (best < free_bufs.size()) {
                 held_bytes -= free_bufs[best].capacity();
 
-                // the pooled buffer goes to the caller and the caller's undersized one is
-                // dropped: it belongs to a different size class and is of no use here
-                std::swap(dst, free_bufs[best]);
+                prev = std::move(free_bufs[best]);
                 free_bufs.erase(free_bufs.begin() + best);
+
+                // dst takes the pooled buffer and prev takes the caller's old one
+                std::swap(dst, prev);
 
                 st.n_hit++;
             }
         }
     }
+
+    // the caller's old buffer was too small for this request but may still serve a smaller
+    // checkpoint later, so offer it back rather than dropping it on the floor
+    put(std::move(prev));
 
     // on a hit the pooled buffer normally already has exactly this size, so this is a no-op and
     // the stale bytes are left in place. that is safe because every caller overwrites the whole
@@ -2317,7 +2336,7 @@ void common_state_buffer_pool::put(std::vector<uint8_t> && src) {
     const size_t cap = src.capacity();
 
     if (cap < MIN_BUFFER_BYTES) {
-        return;
+        return; // below the allocator's mmap threshold: holding it would save nothing
     }
 
     std::lock_guard<std::mutex> lock(mtx);
@@ -2331,8 +2350,31 @@ void common_state_buffer_pool::put(std::vector<uint8_t> && src) {
         cap_known = true;
     }
 
-    if (free_bufs.size() >= MAX_BUFFERS || held_bytes + cap > cap_bytes) {
-        return; // declined: src is freed by its own destructor, as it would be without the pool
+    if (cap > cap_bytes) {
+        return; // one buffer of this size would spend the whole budget
+    }
+
+    // eviction. make room by dropping the smallest pooled buffers, but only ones smaller than
+    // the buffer coming in. a pool already full of buffers at least this large has nothing to
+    // gain from the swap, so decline instead. that rule is what keeps a workload whose
+    // checkpoints grow through a prompt from wedging the pool full of small buffers that no
+    // later and larger request can use.
+    while (free_bufs.size() >= MAX_BUFFERS || held_bytes + cap > cap_bytes) {
+        size_t worst = 0;
+        for (size_t i = 1; i < free_bufs.size(); ++i) {
+            if (free_bufs[i].capacity() < free_bufs[worst].capacity()) {
+                worst = i;
+            }
+        }
+
+        if (free_bufs.empty() || free_bufs[worst].capacity() >= cap) {
+            return; // declined: src is freed by its own destructor, as it would be without the pool
+        }
+
+        held_bytes -= free_bufs[worst].capacity();
+        free_bufs.erase(free_bufs.begin() + worst);
+
+        st.n_evict++;
     }
 
     // the logical size is kept, not cleared: a later get() of the same size is then a no-op
@@ -2357,6 +2399,7 @@ void common_state_buffer_pool::trim(int64_t idle_us) {
     free_bufs.shrink_to_fit();
 
     held_bytes = 0;
+    n_hwm      = 0;
 }
 
 common_state_buffer_pool::stats common_state_buffer_pool::get_stats() const {
@@ -2372,10 +2415,18 @@ common_state_buffer_pool::stats common_state_buffer_pool::get_stats() const {
 }
 
 common_prompt_checkpoint::~common_prompt_checkpoint() {
-    auto & pool = common_state_buffer_pool::instance();
+    // a destructor is noexcept and put() can throw: it locks a mutex and pushes to a vector.
+    // that matters on exactly the path this has to survive, because server_prompt_cache::alloc()
+    // recovers from a std::bad_alloc by destroying cached prompts, and a throw from here would
+    // turn a graceful cache shrink into a terminate().
+    try {
+        auto & pool = common_state_buffer_pool::instance();
 
-    pool.put(std::move(data_tgt));
-    pool.put(std::move(data_dft));
+        pool.put(std::move(data_tgt));
+        pool.put(std::move(data_dft));
+    } catch (...) {
+        // the buffers are freed by their own destructors instead
+    }
 }
 
 size_t common_prompt_checkpoint::size() const {

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -2252,8 +2252,15 @@ bool common_prompt_batch_decode(
 }
 
 common_state_buffer_pool & common_state_buffer_pool::instance() {
-    static common_state_buffer_pool pool;
-    return pool;
+    // Deliberately leaked. A function-local static is destroyed in reverse order of completion of
+    // construction, so a common_prompt_checkpoint with static storage duration constructed before
+    // this one would be destroyed after it and its destructor would call put() on a destroyed
+    // object. [basic.start.term]/5 makes that undefined, and the try/catch in the destructor
+    // cannot help, because it is not an exception. No such holder exists today; this keeps it from
+    // becoming a silent use-after-free the day one does. The pool is process-wide and one
+    // allocation, so leaking it at exit costs nothing.
+    static common_state_buffer_pool * pool = new common_state_buffer_pool();
+    return *pool;
 }
 
 static size_t common_state_buffer_pool_cap() {

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -2256,8 +2256,6 @@ common_state_buffer_pool & common_state_buffer_pool::instance() {
     return pool;
 }
 
-// derived once, from host memory as the CPU backend device reports it. a host memory size that
-// cannot be trusted means no pooling at all, which is the safe direction.
 static size_t common_state_buffer_pool_cap() {
     size_t mem_free  = 0;
     size_t mem_total = 0;
@@ -2269,17 +2267,13 @@ static size_t common_state_buffer_pool_cap() {
 
     GGML_UNUSED(mem_free);
 
-    // zero means the CPU device could not report a size. an absurd size means the query itself
-    // failed without saying so: ggml_backend_cpu_device_get_memory() multiplies out
-    // sysconf(_SC_PHYS_PAGES) with no error check, so a -1 from a restricted container arrives
-    // here as ~1.8e19. treat both as unknown and keep nothing.
+    // ggml_backend_cpu_device_get_memory() multiplies out sysconf(_SC_PHYS_PAGES) unchecked, so a
+    // -1 from a restricted container arrives as ~1.8e19: absurd means unknown, not huge.
     if (mem_total == 0 || mem_total > (1ull << 50)) {
         return 0;
     }
 
-    // a fraction of TOTAL host memory, deliberately not of free: every non-Windows host reports
-    // free == total for the CPU device ("free system memory is ill-defined, assume all of it is
-    // free"), so a free-based cap would be the same number with a false claim attached to it.
+    // of total, not free: every non-Windows host reports free == total for the CPU device
     return mem_total / 16;
 }
 
@@ -2294,8 +2288,6 @@ void common_state_buffer_pool::get(std::vector<uint8_t> & dst, size_t size) {
         t_last_us = ggml_time_us();
 
         if (dst.capacity() >= size) {
-            // the caller's own allocation is already big enough, so it is already resident.
-            // that is a reuse too, and the cheapest kind.
             st.n_hit++;
         } else {
             // best fit, so a large pooled buffer is not spent on a small request
@@ -2313,7 +2305,6 @@ void common_state_buffer_pool::get(std::vector<uint8_t> & dst, size_t size) {
                 prev = std::move(free_bufs[best]);
                 free_bufs.erase(free_bufs.begin() + best);
 
-                // dst takes the pooled buffer and prev takes the caller's old one
                 std::swap(dst, prev);
 
                 st.n_hit++;
@@ -2321,14 +2312,11 @@ void common_state_buffer_pool::get(std::vector<uint8_t> & dst, size_t size) {
         }
     }
 
-    // the caller's old buffer was too small for this request but may still serve a smaller
-    // checkpoint later, so offer it back rather than dropping it on the floor
+    // too small here, but may still serve a smaller checkpoint later
     put(std::move(prev));
 
-    // on a hit the pooled buffer normally already has exactly this size, so this is a no-op and
-    // the stale bytes are left in place. that is safe because every caller overwrites the whole
-    // buffer and aborts if the state does not fill it. when the sizes differ, the fill only
-    // touches pages that are already resident.
+    // usually a no-op leaving stale bytes: callers overwrite the whole buffer and abort if the
+    // state does not fill it
     dst.resize(size);
 }
 
@@ -2354,11 +2342,6 @@ void common_state_buffer_pool::put(std::vector<uint8_t> && src) {
         return; // one buffer of this size would spend the whole budget
     }
 
-    // eviction. make room by dropping the smallest pooled buffers, but only ones smaller than
-    // the buffer coming in. a pool already full of buffers at least this large has nothing to
-    // gain from the swap, so decline instead. that rule is what keeps a workload whose
-    // checkpoints grow through a prompt from wedging the pool full of small buffers that no
-    // later and larger request can use.
     while (free_bufs.size() >= MAX_BUFFERS || held_bytes + cap > cap_bytes) {
         size_t worst = 0;
         for (size_t i = 1; i < free_bufs.size(); ++i) {
@@ -2377,8 +2360,7 @@ void common_state_buffer_pool::put(std::vector<uint8_t> && src) {
         st.n_evict++;
     }
 
-    // the logical size is kept, not cleared: a later get() of the same size is then a no-op
-    // resize rather than a full zero fill of the buffer
+    // size kept, not cleared: a later get() of the same size is then a no-op resize
     free_bufs.push_back(std::move(src));
 
     held_bytes += cap;
@@ -2415,17 +2397,15 @@ common_state_buffer_pool::stats common_state_buffer_pool::get_stats() const {
 }
 
 common_prompt_checkpoint::~common_prompt_checkpoint() {
-    // a destructor is noexcept and put() can throw: it locks a mutex and pushes to a vector.
-    // that matters on exactly the path this has to survive, because server_prompt_cache::alloc()
-    // recovers from a std::bad_alloc by destroying cached prompts, and a throw from here would
-    // turn a graceful cache shrink into a terminate().
+    // put() locks and pushes, so it can throw, and a destructor is noexcept. that is fatal on the
+    // one path this must survive: server_prompt_cache::alloc() destroys cached prompts to recover
+    // from std::bad_alloc, and a throw here would make that graceful shrink a terminate().
     try {
         auto & pool = common_state_buffer_pool::instance();
 
         pool.put(std::move(data_tgt));
         pool.put(std::move(data_dft));
     } catch (...) {
-        // the buffers are freed by their own destructors instead
     }
 }
 

--- a/common/common.h
+++ b/common/common.h
@@ -14,6 +14,7 @@
 #include <string_view>
 #include <vector>
 #include <map>
+#include <mutex>
 #include <algorithm>
 #include <fstream>
 
@@ -1134,6 +1135,93 @@ enum ggml_opt_optimizer_type common_opt_get_optimizer(const char *);
 // prompt utils
 //
 
+// A bounded, process-wide pool of reusable byte buffers for sequence-state checkpoints.
+//
+// Checkpoint buffers are large - for a hybrid/recurrent model the non-rollbackable state of a
+// single sequence runs to hundreds of MiB - and one is allocated and freed per prompt. Any
+// allocation that size comes straight from mmap() and goes straight back on free, so the first
+// write to a fresh buffer faults in every one of its pages. In llama-server that shows up as a
+// ~44 ms zero fill inside `update_tgt()` before the state copy can even start, repeated for
+// every checkpoint of every prompt.
+//
+// Handing the buffer to this pool instead of to the allocator keeps the pages mapped, resident
+// and dirty, so the next checkpoint of the same size reuses them and pays neither the faults
+// nor the fill.
+//
+// Note that the zero fill itself is load bearing and must not simply be removed: with a CUDA
+// target context, `llama_state_seq_get_data_ext()` copying into pageable host memory that is
+// not yet resident runs about 140x slower than into memory that is. The pool removes the fill
+// by making it unnecessary, not by skipping it.
+//
+// Memory policy.
+//
+//  - Byte cap. At most `cap_bytes` is retained, derived once from host memory as
+//    min(1/16 of total, 1/4 of free). A machine with little memory therefore keeps little or
+//    nothing, and when host memory cannot be determined at all the pool keeps nothing.
+//  - Count cap. At most `MAX_BUFFERS` buffers, a sanity bound; the byte cap is the real one.
+//  - Size floor. Buffers below `MIN_BUFFER_BYTES` are never retained. Below the allocator's
+//    mmap threshold there is no fault storm to avoid, so pooling them would only hold memory.
+//  - Release. `trim()` drops buffers the pool has not touched for a while, so an idle server
+//    gives the memory back instead of holding it for the life of the process.
+//
+// When any cap is reached the buffer is simply freed, which is exactly the behaviour without
+// the pool: a machine that cannot afford the pool degrades to today's behaviour, never to
+// something worse.
+//
+// On the peak. The pool only ever receives buffers that the process had just freed, and hands
+// them straight back out, so for a steady workload the sum of live plus pooled buffers is the
+// count the process already peaked at without the pool. The byte cap and `trim()` bound the
+// one case where that is not true: a server whose live checkpoint count structurally shrinks.
+struct common_state_buffer_pool {
+    // sanity bound on the buffer count; the byte cap is the limit that actually binds
+    static constexpr size_t MAX_BUFFERS = 64;
+
+    // buffers below this size are left to the allocator: they do not come from mmap(), so
+    // reusing them saves nothing
+    static constexpr size_t MIN_BUFFER_BYTES = 32ull*1024*1024;
+
+    struct stats {
+        uint64_t n_get  = 0; // buffers requested
+        uint64_t n_hit  = 0; // ... served from the pool
+        uint64_t n_put  = 0; // buffers offered back
+        uint64_t n_keep = 0; // ... retained
+        size_t held_bytes = 0;
+        size_t cap_bytes  = 0;
+        size_t n_hwm      = 0; // high water mark of retained buffers
+    };
+
+    // resize `dst` to `size`, reusing a pooled allocation when one fits.
+    // the previous contents of `dst` are not preserved; every caller overwrites the whole
+    // buffer immediately, and preserving them would defeat the point of the reuse.
+    void get(std::vector<uint8_t> & dst, size_t size);
+
+    // offer `src` to the pool. if the policy declines it, `src` is left alone and freed by its
+    // own destructor, exactly as it would be without the pool.
+    void put(std::vector<uint8_t> && src);
+
+    // free every pooled buffer if the pool has not been used for `idle_us`. cheap and safe to
+    // call often; the server calls it whenever all of its slots are idle.
+    void trim(int64_t idle_us);
+
+    stats get_stats() const;
+
+    static common_state_buffer_pool & instance();
+
+private:
+    mutable std::mutex mtx;
+
+    std::vector<std::vector<uint8_t>> free_bufs;
+
+    size_t held_bytes = 0;
+    size_t cap_bytes  = 0;
+    size_t n_hwm      = 0;
+    bool   cap_known  = false;
+
+    int64_t t_last_us = 0;
+
+    stats st;
+};
+
 struct common_prompt_checkpoint {
     int64_t n_tokens;
 
@@ -1149,6 +1237,20 @@ struct common_prompt_checkpoint {
     // (optional) speculative-decoding implementation state stashed with the checkpoint
     // (e.g. eagle3's deferred-boundary g_embd row)
     std::vector<uint8_t> data_spec;
+
+    common_prompt_checkpoint() = default;
+
+    // returns the state buffers to common_state_buffer_pool instead of to the allocator.
+    // the copy and move members are defaulted explicitly: declaring a destructor would
+    // otherwise suppress the implicit moves and turn every list splice into a deep copy of a
+    // multi-hundred-MiB buffer.
+    ~common_prompt_checkpoint();
+
+    common_prompt_checkpoint(const common_prompt_checkpoint &) = default;
+    common_prompt_checkpoint(common_prompt_checkpoint &&) noexcept = default;
+
+    common_prompt_checkpoint & operator=(const common_prompt_checkpoint &) = default;
+    common_prompt_checkpoint & operator=(common_prompt_checkpoint &&) noexcept = default;
 
     size_t size() const;
 

--- a/common/common.h
+++ b/common/common.h
@@ -1155,14 +1155,23 @@ enum ggml_opt_optimizer_type common_opt_get_optimizer(const char *);
 //
 // Memory policy.
 //
-//  - Byte cap. At most `cap_bytes` is retained, derived once from host memory as
-//    min(1/16 of total, 1/4 of free). A machine with little memory therefore keeps little or
-//    nothing, and when host memory cannot be determined at all the pool keeps nothing.
-//  - Count cap. At most `MAX_BUFFERS` buffers, a sanity bound; the byte cap is the real one.
+//  - Byte cap. At most `cap_bytes` is retained, derived once as 1/16 of total host memory, so
+//    the pool is proportionate to the machine it runs on. When host memory cannot be
+//    determined the pool keeps nothing.
+//  - Count cap. At most `MAX_BUFFERS` buffers. With `n_ctx_checkpoints` defaulting to 32 per
+//    slot a busy server can release far more than that at once, so this cap does bind, and
+//    the eviction rule below decides which buffers survive it.
+//  - Eviction. A buffer offered to a full pool displaces the smallest pooled buffer, but only
+//    one smaller than itself; otherwise it is declined. Without that rule a workload whose
+//    checkpoints grow through a prompt would fill the pool with small buffers that no later
+//    request can use, and the hit rate would fall to zero while the memory stayed held.
 //  - Size floor. Buffers below `MIN_BUFFER_BYTES` are never retained. Below the allocator's
 //    mmap threshold there is no fault storm to avoid, so pooling them would only hold memory.
-//  - Release. `trim()` drops buffers the pool has not touched for a while, so an idle server
-//    gives the memory back instead of holding it for the life of the process.
+//  - Release. `trim()` drops buffers the pool has not touched for a while. The server calls it
+//    from the task queue's idle wait, so a server that goes quiet gives the memory back, and
+//    with a zero timeout from the prompt cache's out-of-memory recovery, so pooled bytes are
+//    always reclaimable under allocation pressure even though they are not counted against
+//    `--cache-ram`.
 //
 // When any cap is reached the buffer is simply freed, which is exactly the behaviour without
 // the pool: a machine that cannot afford the pool degrades to today's behaviour, never to
@@ -1173,7 +1182,7 @@ enum ggml_opt_optimizer_type common_opt_get_optimizer(const char *);
 // count the process already peaked at without the pool. The byte cap and `trim()` bound the
 // one case where that is not true: a server whose live checkpoint count structurally shrinks.
 struct common_state_buffer_pool {
-    // sanity bound on the buffer count; the byte cap is the limit that actually binds
+    // bound on the buffer count. this does bind in practice, see the eviction rule above
     static constexpr size_t MAX_BUFFERS = 64;
 
     // buffers below this size are left to the allocator: they do not come from mmap(), so
@@ -1184,7 +1193,8 @@ struct common_state_buffer_pool {
         uint64_t n_get  = 0; // buffers requested
         uint64_t n_hit  = 0; // ... served from the pool
         uint64_t n_put  = 0; // buffers offered back
-        uint64_t n_keep = 0; // ... retained
+        uint64_t n_keep  = 0; // ... retained
+        uint64_t n_evict = 0; // pooled buffers displaced to make room
         size_t held_bytes = 0;
         size_t cap_bytes  = 0;
         size_t n_hwm      = 0; // high water mark of retained buffers

--- a/common/common.h
+++ b/common/common.h
@@ -1135,58 +1135,19 @@ enum ggml_opt_optimizer_type common_opt_get_optimizer(const char *);
 // prompt utils
 //
 
-// A bounded, process-wide pool of reusable byte buffers for sequence-state checkpoints.
+// Bounded process-wide pool of reusable checkpoint state buffers. At hundreds of MiB each these
+// come from mmap() and go back on free, so every fresh buffer faults in all of its pages.
 //
-// Checkpoint buffers are large - for a hybrid/recurrent model the non-rollbackable state of a
-// single sequence runs to hundreds of MiB - and one is allocated and freed per prompt. Any
-// allocation that size comes straight from mmap() and goes straight back on free, so the first
-// write to a fresh buffer faults in every one of its pages. In llama-server that shows up as a
-// ~44 ms zero fill inside `update_tgt()` before the state copy can even start, repeated for
-// every checkpoint of every prompt.
+// Do NOT instead delete the zero fill this avoids: with a CUDA target context,
+// llama_state_seq_get_data_ext() into non-resident pageable host memory runs about 140x slower.
 //
-// Handing the buffer to this pool instead of to the allocator keeps the pages mapped, resident
-// and dirty, so the next checkpoint of the same size reuses them and pays neither the faults
-// nor the fill.
-//
-// Note that the zero fill itself is load bearing and must not simply be removed: with a CUDA
-// target context, `llama_state_seq_get_data_ext()` copying into pageable host memory that is
-// not yet resident runs about 140x slower than into memory that is. The pool removes the fill
-// by making it unnecessary, not by skipping it.
-//
-// Memory policy.
-//
-//  - Byte cap. At most `cap_bytes` is retained, derived once as 1/16 of total host memory, so
-//    the pool is proportionate to the machine it runs on. When host memory cannot be
-//    determined the pool keeps nothing.
-//  - Count cap. At most `MAX_BUFFERS` buffers. With `n_ctx_checkpoints` defaulting to 32 per
-//    slot a busy server can release far more than that at once, so this cap does bind, and
-//    the eviction rule below decides which buffers survive it.
-//  - Eviction. A buffer offered to a full pool displaces the smallest pooled buffer, but only
-//    one smaller than itself; otherwise it is declined. Without that rule a workload whose
-//    checkpoints grow through a prompt would fill the pool with small buffers that no later
-//    request can use, and the hit rate would fall to zero while the memory stayed held.
-//  - Size floor. Buffers below `MIN_BUFFER_BYTES` are never retained. Below the allocator's
-//    mmap threshold there is no fault storm to avoid, so pooling them would only hold memory.
-//  - Release. `trim()` drops buffers the pool has not touched for a while. The server calls it
-//    from the task queue's idle wait, so a server that goes quiet gives the memory back, and
-//    with a zero timeout from the prompt cache's out-of-memory recovery, so pooled bytes are
-//    always reclaimable under allocation pressure even though they are not counted against
-//    `--cache-ram`.
-//
-// When any cap is reached the buffer is simply freed, which is exactly the behaviour without
-// the pool: a machine that cannot afford the pool degrades to today's behaviour, never to
-// something worse.
-//
-// On the peak. The pool only ever receives buffers that the process had just freed, and hands
-// them straight back out, so for a steady workload the sum of live plus pooled buffers is the
-// count the process already peaked at without the pool. The byte cap and `trim()` bound the
-// one case where that is not true: a server whose live checkpoint count structurally shrinks.
+// A full pool only accepts a buffer by displacing a SMALLER one, else checkpoints growing through
+// a prompt wedge it full of small buffers no later request can use. trim() keeps pooled bytes
+// reclaimable, since they do not count against `--cache-ram`.
 struct common_state_buffer_pool {
-    // bound on the buffer count. this does bind in practice, see the eviction rule above
     static constexpr size_t MAX_BUFFERS = 64;
 
-    // buffers below this size are left to the allocator: they do not come from mmap(), so
-    // reusing them saves nothing
+    // below the allocator's mmap threshold there is no fault storm to avoid
     static constexpr size_t MIN_BUFFER_BYTES = 32ull*1024*1024;
 
     struct stats {
@@ -1200,17 +1161,11 @@ struct common_state_buffer_pool {
         size_t n_hwm      = 0; // high water mark of retained buffers
     };
 
-    // resize `dst` to `size`, reusing a pooled allocation when one fits.
-    // the previous contents of `dst` are not preserved; every caller overwrites the whole
-    // buffer immediately, and preserving them would defeat the point of the reuse.
+    // contents of `dst` are NOT preserved; every caller overwrites the whole buffer
     void get(std::vector<uint8_t> & dst, size_t size);
 
-    // offer `src` to the pool. if the policy declines it, `src` is left alone and freed by its
-    // own destructor, exactly as it would be without the pool.
     void put(std::vector<uint8_t> && src);
 
-    // free every pooled buffer if the pool has not been used for `idle_us`. cheap and safe to
-    // call often; the server calls it whenever all of its slots are idle.
     void trim(int64_t idle_us);
 
     stats get_stats() const;
@@ -1250,10 +1205,8 @@ struct common_prompt_checkpoint {
 
     common_prompt_checkpoint() = default;
 
-    // returns the state buffers to common_state_buffer_pool instead of to the allocator.
-    // the copy and move members are defaulted explicitly: declaring a destructor would
-    // otherwise suppress the implicit moves and turn every list splice into a deep copy of a
-    // multi-hundred-MiB buffer.
+    // the copy/move members below are defaulted explicitly: declaring this destructor suppresses
+    // the implicit moves, turning every list splice into a deep copy of a multi-hundred-MiB buffer.
     ~common_prompt_checkpoint();
 
     common_prompt_checkpoint(const common_prompt_checkpoint &) = default;

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2252,10 +2252,10 @@ private:
         const auto pool = common_state_buffer_pool::instance().get_stats();
 
         SLT_TRC(slot,
-                "created context checkpoint %d of %d (pos_min = %d, pos_max = %d, n_tokens = %" PRId64 ", size = %.3f MiB, buffer pool: %" PRIu64 "/%" PRIu64 " reused, %.3f of %.3f MiB held, hwm %zu)\n",
+                "created context checkpoint %d of %d (pos_min = %d, pos_max = %d, n_tokens = %" PRId64 ", size = %.3f MiB, buffer pool: %" PRIu64 "/%" PRIu64 " reused, %" PRIu64 " evicted, %.3f of %.3f MiB held, hwm %zu)\n",
                 (int) slot.prompt.checkpoints.size(), params_base.n_ctx_checkpoints, cur.pos_min,
                 cur.pos_max, cur.n_tokens, (float) cur.size() / 1024 / 1024,
-                pool.n_hit, pool.n_get, pool.held_bytes / (1024.0 * 1024.0), pool.cap_bytes / (1024.0 * 1024.0), pool.n_hwm);
+                pool.n_hit, pool.n_get, pool.n_evict, pool.held_bytes / (1024.0 * 1024.0), pool.cap_bytes / (1024.0 * 1024.0), pool.n_hwm);
     }
 
     // returns false to decline the task, it is offered again after the decode is done
@@ -2704,11 +2704,6 @@ private:
 
             if (all_idle) {
                 SRV_TRC("%s", "all slots are idle\n");
-
-                // give the checkpoint buffers back once the server has been quiet for a while.
-                // the delay matters: back-to-back request waves go briefly all-idle between
-                // waves, and dropping the pool there would throw away every reuse.
-                common_state_buffer_pool::instance().trim(30ll*1000*1000);
 
                 metrics_flush_idle();
 

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2249,10 +2249,13 @@ private:
         // stash the draft's speculative state with the checkpoint
         common_speculative_get_state(spec.get(), slot.id, cur.data_spec);
 
+        const auto pool = common_state_buffer_pool::instance().get_stats();
+
         SLT_TRC(slot,
-                "created context checkpoint %d of %d (pos_min = %d, pos_max = %d, n_tokens = %" PRId64 ", size = %.3f MiB)\n",
+                "created context checkpoint %d of %d (pos_min = %d, pos_max = %d, n_tokens = %" PRId64 ", size = %.3f MiB, buffer pool: %" PRIu64 "/%" PRIu64 " reused, %.3f of %.3f MiB held, hwm %zu)\n",
                 (int) slot.prompt.checkpoints.size(), params_base.n_ctx_checkpoints, cur.pos_min,
-                cur.pos_max, cur.n_tokens, (float) cur.size() / 1024 / 1024);
+                cur.pos_max, cur.n_tokens, (float) cur.size() / 1024 / 1024,
+                pool.n_hit, pool.n_get, pool.held_bytes / (1024.0 * 1024.0), pool.cap_bytes / (1024.0 * 1024.0), pool.n_hwm);
     }
 
     // returns false to decline the task, it is offered again after the decode is done
@@ -2701,6 +2704,11 @@ private:
 
             if (all_idle) {
                 SRV_TRC("%s", "all slots are idle\n");
+
+                // give the checkpoint buffers back once the server has been quiet for a while.
+                // the delay matters: back-to-back request waves go briefly all-idle between
+                // waves, and dropping the pool there would throw away every reuse.
+                common_state_buffer_pool::instance().trim(30ll*1000*1000);
 
                 metrics_flush_idle();
 

--- a/tools/server/server-queue.cpp
+++ b/tools/server/server-queue.cpp
@@ -1,3 +1,4 @@
+#include "common.h"
 #include "server-task.h"
 #include "server-queue.h"
 
@@ -357,6 +358,15 @@ void server_queue::start_loop(int64_t idle_sleep_ms) {
                 if (res) {
                     break; // new task arrived or terminate
                 }
+
+                // nothing to do. hand back any checkpoint state buffers the pool is still
+                // holding, so a server that has gone quiet does not keep them for the life of
+                // the process. this is the only loop that runs while the queue is empty, so it
+                // is the only place the release can happen. done without the lock: trim()
+                // unmaps hundreds of MiB and must not delay an arriving task.
+                lock.unlock();
+                common_state_buffer_pool::instance().trim(30ll*1000*1000);
+
                 // otherwise, loop again to check sleeping condition
             }
         }

--- a/tools/server/server-queue.cpp
+++ b/tools/server/server-queue.cpp
@@ -359,11 +359,8 @@ void server_queue::start_loop(int64_t idle_sleep_ms) {
                     break; // new task arrived or terminate
                 }
 
-                // nothing to do. hand back any checkpoint state buffers the pool is still
-                // holding, so a server that has gone quiet does not keep them for the life of
-                // the process. this is the only loop that runs while the queue is empty, so it
-                // is the only place the release can happen. done without the lock: trim()
-                // unmaps hundreds of MiB and must not delay an arriving task.
+                // the only loop running while the queue is empty, so the only place a quiet server
+                // gives pooled buffers back. unlocked: trim() unmaps hundreds of MiB.
                 lock.unlock();
                 common_state_buffer_pool::instance().trim(30ll*1000*1000);
 

--- a/tools/server/server-queue.cpp
+++ b/tools/server/server-queue.cpp
@@ -333,6 +333,11 @@ void server_queue::start_loop(int64_t idle_sleep_ms) {
                     cb(true);
                 }
                 req_stop_sleeping = false;
+                // Sleep is when the server claims the memory is gone, and it preempts the timed
+                // trim below whenever the sleep threshold is inside that idle window, so release
+                // unconditionally here. Held under the lock deliberately: dropping it around the
+                // unmap would open a wakeup window between the callbacks and the wait.
+                common_state_buffer_pool::instance().trim(0);
                 // wait until we are requested to exit sleeping state
                 condition_tasks.wait(lock, [&]{
                     return (!running || req_stop_sleeping);

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -1767,6 +1767,12 @@ server_prompt_cache_state * server_prompt_cache::alloc(const server_prompt & pro
     } catch (const std::bad_alloc & e) {
         SRV_ERR("failed to allocate memory for prompt cache state: %s\n", e.what());
 
+        // the checkpoint buffer pool holds host memory that is reusable but not currently in
+        // use, and it is not counted against limit_size. release all of it before shrinking the
+        // cache: without this the retry reclaims nothing, because the cached prompts destroyed
+        // by update() below hand their buffers to the pool instead of to the allocator.
+        common_state_buffer_pool::instance().trim(0);
+
         limit_size = std::max<size_t>(1, 0.4*size());
 
         SRV_WRN(" - cache size limit reduced to %.3f MiB\n", limit_size / (1024.0 * 1024.0));

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -1767,10 +1767,8 @@ server_prompt_cache_state * server_prompt_cache::alloc(const server_prompt & pro
     } catch (const std::bad_alloc & e) {
         SRV_ERR("failed to allocate memory for prompt cache state: %s\n", e.what());
 
-        // the checkpoint buffer pool holds host memory that is reusable but not currently in
-        // use, and it is not counted against limit_size. release all of it before shrinking the
-        // cache: without this the retry reclaims nothing, because the cached prompts destroyed
-        // by update() below hand their buffers to the pool instead of to the allocator.
+        // release first or the retry reclaims nothing: update() below hands the destroyed prompts'
+        // buffers to the pool, which limit_size does not count, rather than to the allocator
         common_state_buffer_pool::instance().trim(0);
 
         limit_size = std::max<size_t>(1, 0.4*size());

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -1767,8 +1767,9 @@ server_prompt_cache_state * server_prompt_cache::alloc(const server_prompt & pro
     } catch (const std::bad_alloc & e) {
         SRV_ERR("failed to allocate memory for prompt cache state: %s\n", e.what());
 
-        // release first or the retry reclaims nothing: update() below hands the destroyed prompts'
-        // buffers to the pool, which limit_size does not count, rather than to the allocator
+        // limit_size does not count pooled bytes, so both trims are needed: the first releases
+        // what was already pooled, the second the buffers update() just evicted, which the
+        // checkpoint destructors hand to the pool rather than to the allocator.
         common_state_buffer_pool::instance().trim(0);
 
         limit_size = std::max<size_t>(1, 0.4*size());
@@ -1776,6 +1777,8 @@ server_prompt_cache_state * server_prompt_cache::alloc(const server_prompt & pro
         SRV_WRN(" - cache size limit reduced to %.3f MiB\n", limit_size / (1024.0 * 1024.0));
 
         update();
+
+        common_state_buffer_pool::instance().trim(0);
 
         return nullptr;
     }


### PR DESCRIPTION
**A 19% cut in p90 time to first token on a hybrid model at 32 slots, with throughput unchanged
to slightly up.** The cost removed is in prefill, on the critical path for TTFT; the decode path
never touches it. Host work per prefill iteration falls from 556.7 ms to 129.7 ms.

---

A context checkpoint of a hybrid or recurrent model holds the whole non-rollbackable sequence
state. For a 27B `qwen35` at 16k context that is **149 MiB**, and llama-server allocates and
frees one per prompt. Any allocation that size comes straight from `mmap()` and goes straight
back on `free()`, so the first write to a fresh buffer faults in every one of its pages.

That first write is `data_tgt.resize()` in `common_prompt_checkpoint::update_tgt()`, and on a
DGX Spark serving 32 slots it is **43.2 ms of the 54.9 ms a checkpoint costs**, which is
**454.8 of the 556.7 ms of a prefill iteration**. `create_checkpoint` is 82% of the prefill batch
build, and the prefill batch build is the single longest host stall in the server. It is a time
to first token cost: the decode path never touches it.

This hands the buffer to a bounded pool instead of to the allocator. The pages stay mapped and
resident, so the next checkpoint reuses them.

### The fill is load bearing, and is not removed here

The obvious change is to stop zero filling a buffer that `llama_state_seq_get_data_ext()`
overwrites immediately. It was tried, and it is wrong. With a CUDA target context the copy into
pageable host memory that is not yet resident runs about **140x slower**, 6.5 ms against 917 ms
for 149 MiB, for a 24% throughput regression and triple the TTFT. On the CPU backend the same
change is neutral, so a CPU-only measurement would have shipped it.

This PR does not remove the fill. It makes it disappear by making it unnecessary: on a pool hit
the buffer already has the right size, so `resize()` is a no-op over memory that is already
mapped, resident and dirty, which is the state the fill existed to produce.

### Per-phase table

`Qwen3.8-27B-UD-Q4_K_XL`, one DGX Spark, no RPC, `--parallel 32`, 32 concurrent, npp 128 ntg 256,
`--cache-ram 0`. Four traced cells, every one of them inside a single thermal-cap window at
1690 MHz, cross-checked against the thermal guard's own log. Prefill iterations:

| | resize, us/call | state copy, us/call | per checkpoint, us | batch build, ms/iter |
|---|---|---|---|---|
| master | 42342 | 12943 | 55293 | 568.3 |
| master | 44155 | 10250 | 54414 | 545.1 |
| **this PR** | **13636** | **6840** | **20481** | **127.1** |
| **this PR** | **14605** | **5600** | **20210** | **132.4** |

**54.85 ms to 20.35 ms per checkpoint, and 556.7 ms to 129.7 ms of host work per prefill
iteration, minus 77%.** `create_checkpoint` alone goes from 454.8 to 129.4 ms per iteration.
The residual 14 ms of resize is the cold first wave: a miss still pays the full 43 ms, a hit
pays nothing, and about a third of the checkpoints in a cell are misses.

Decode iterations are untouched: `post_decode` 6.86 and 6.96 ms/iter on master against
6.89 with the pool, decode batch build about 10 us/call either way.

### Time to first token

This is where the change is visible to a user. Two independent brackets, base / new / base with
one server load per arm, every arm inside one capped window at 1690 MHz:

| 27B, 32 slots | base | new | base |
|---|---|---|---|
| TTFT p90, ms | 9624.9 | **7943.9** | 9537.9 |
| TTFT p90, ms | 9856.2 | **7687.1** | 9589.5 |
| TTFT p99, ms | 9636.1 | **7954.1** | 9548.4 |
| TTFT p99, ms | 9866.0 | **7699.1** | 9599.8 |
| TTFT median, ms | 5629.1 | **4308.0** | 8379.9 |
| TTFT median, ms | 8615.5 | **5901.7** | 5821.1 |
| tok/s | 97.50 | 101.17 | 97.70 |
| tok/s | 97.56 | 100.87 | 94.11 |

**TTFT p90 and p99 both fall 19%.** Throughput at 32 slots is +3%, and at 8 and 1 slots it is
inside the bracket, which is what one checkpoint per prompt predicts: those cells are not prefill
bound.

A third bracket on the same branch: 99.01 / 100.80 / -- tok/s, TTFT p90 9730.7 to 7966.6 ms,
minus 18.1%. Three brackets, base p90 9538 to 9856 ms and new p90 7687 to 7967 ms.

A second hybrid, `Qwen3.5-4B`, A/B/A with the GPU clocks pinned by the harness for the whole run:

| 4B, 32 slots | base | new | base |
|---|---|---|---|
| tok/s | 366.00 | 369.50 | 375.53 |
| TTFT median, ms | 1403.2 | **1122.6** | 1241.4 |
| TTFT p90, ms | 2393.3 | **1544.1** | 2303.2 |
| TTFT p99, ms | 2422.1 | **1719.5** | 2321.9 |
| at 8 slots, TTFT median, ms | 570.2 | **426.8** | 556.3 |
| at 8 slots, TTFT p90, ms | 616.8 | **520.8** | 576.1 |

TTFT p90 falls 34% at 32 slots and 13% at 8, with throughput inside the bracket. The smaller
model has a smaller checkpoint, so the whole of the win shows up as latency.

### Neutrality where checkpoints are not created

Two bracketed controls, all arms in one capped state.

- 27B with `-ctxcp 0`, same model, checkpoints off: 101.10 / 100.78 / 101.21 tok/s, TTFT p90
  7157 / 7163 / 7176 ms.
- `qwen2` arch, no recurrent state and no SWA, so checkpoints are never created: 1197.6 /
  1274.5 / 1217.7 tok/s at 32 slots, 555.9 / 593.6 / 561.7 at 8, 115.6 / 113.8 / 114.2 at 1.

Nothing below `MIN_BUFFER_BYTES` (32 MiB, the allocator's mmap threshold) is ever pooled, so for
a model whose checkpoints are small the pool is never entered at all: an SWA `tinygemma3` makes
0.356 MiB checkpoints and the pool declines every one of them.

### Memory policy

Documented on `common_state_buffer_pool`. A byte cap of 1/16 of total host memory, a count cap of
64 buffers, a 32 MiB size floor, an eviction rule that displaces the smallest pooled buffer and
only one smaller than the buffer coming in, and `trim()` from the task queue's idle wait and from
the prompt cache's out-of-memory recovery. Every cap declines the buffer and lets it be freed,
which is exactly master's behaviour, so a machine that cannot afford the pool degrades to today
rather than to something worse.

Worst case extra resident memory is the byte cap, 7.59 GiB on a 121 GiB machine. The measured
case is far below it, because the pool only ever receives buffers the process had just freed and
hands them straight back out: high water mark 17 buffers, 2.5 GiB, and **the server's VmHWM is
6.4738 GB with the pool against 6.4677 GB without it**, a rise of about 6 MB.

### A negative result, measured and dropped

A fourth commit wrote the recycled buffer once before the state copy, on the theory that the
device-to-host copy is fastest into host pages the CPU wrote last. It was dropped. Measured
A/B/A with all three cells inside one capped window, microseconds per `create_checkpoint`:

| | resize | state copy | total |
|---|---|---|---|
| pool, buffer handed over untouched | 13636 | 6840 | 20481 |
| pool, buffer written once first | 16279 | 5550 | 21835 |
| pool, buffer handed over untouched | 14605 | 5600 | 20210 |

The pass costs 2.2 ms and saves 0.7. The effect is real but does not pay for itself, and whole
cell throughput at 32 slots was 100.32 / 102.27 / 102.96 tok/s, inside the bracket.

The numbers that originally justified it came from two cells that were not in the same clock
state. The useful lesson is not "check the clock": it is that a two-cell A against B has nothing
in it that can disagree with itself, so any difference it shows is indistinguishable from drift.
Every comparison above is A/B/A, and every cell in it is cross-referenced against the machine's
thermal guard log to confirm all three arms were in one clock state.

### Correctness

Greedy, temperature 0, top_k 1, seed 42, `cache_prompt` false, one slot and one request in
flight so the batch composition is fixed, md5 of the concatenated output:

```
27B hybrid on CUDA, base / base control / new   e2515bd5d500bc6aa47a695daa843b0c   identical
4B  hybrid on CUDA, base / new                  4b557d7ef96866230689ecde84326274   identical
4B  hybrid on CPU,  base / base control / new   323b77244db12566f2bef5b9a4ef5016   identical
SWA (tinygemma3) on CPU, base / base ctl / new  0ad209cedd9d41ef94c39ca7ccf8d5dd   identical
```

`tests/test-recurrent-state-rollback` on the 4B hybrid produces output byte identical to master,
including the same pre-existing dirty-ctx mismatch.

The single-slot harness is used deliberately. With several requests decoded in one batch these
models are not run to run reproducible: base against base produced three different md5s from one
binary, so a concurrent harness is not usable as a correctness control.
