### PR TITLE
rpc: do not abort on shutdown when a teardown round trip fails

### DIFF
--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -393,8 +393,11 @@ static std::shared_ptr<socket_t> get_socket(const std::string & endpoint) {
 static void ggml_backend_rpc_buffer_free_buffer(ggml_backend_buffer_t buffer) {
     ggml_backend_rpc_buffer_context * ctx = (ggml_backend_rpc_buffer_context *)buffer->context;
     rpc_msg_free_buffer_req request = {ctx->remote_ptr};
-    bool status = send_rpc_cmd(ctx->sock, RPC_CMD_FREE_BUFFER, &request, sizeof(request), nullptr, 0);
-    RPC_STATUS_ASSERT(status);
+    // releasing a remote buffer must not abort: this runs during teardown, and if the peer is
+    // already gone then so is the buffer. The local context is freed either way.
+    if (!send_rpc_cmd(ctx->sock, RPC_CMD_FREE_BUFFER, &request, sizeof(request), nullptr, 0)) {
+        GGML_LOG_ERROR("%s: failed to free the remote buffer, the connection is gone\n", __func__);
+    }
     delete ctx;
 }
 
@@ -823,24 +826,34 @@ bool ggml_backend_is_rpc(ggml_backend_t backend) {
     return backend != NULL && ggml_guid_matches(backend->guid, ggml_backend_rpc_guid());
 }
 
-static void get_device_memory(const std::shared_ptr<socket_t> & sock, uint32_t device, size_t * free, size_t * total) {
+static bool get_device_memory(const std::shared_ptr<socket_t> & sock, uint32_t device, size_t * free, size_t * total) {
     rpc_msg_get_device_memory_req request;
     request.device = device;
     rpc_msg_get_device_memory_rsp response;
-    bool status = send_rpc_cmd(sock, RPC_CMD_GET_DEVICE_MEMORY, &request, sizeof(request), &response, sizeof(response));
-    RPC_STATUS_ASSERT(status);
+    if (!send_rpc_cmd(sock, RPC_CMD_GET_DEVICE_MEMORY, &request, sizeof(request), &response, sizeof(response))) {
+        return false;
+    }
     *free = response.free_mem;
     *total = response.total_mem;
+    return true;
 }
 
 void ggml_backend_rpc_get_device_memory(const char * endpoint, uint32_t device, size_t * free, size_t * total) {
+    *free = 0;
+    *total = 0;
     auto sock = get_socket(endpoint);
     if (sock == nullptr) {
-        *free = 0;
-        *total = 0;
         return;
     }
-    get_device_memory(sock, device, free, total);
+    // this is an informational device property, not part of the data path, and it is queried during
+    // teardown as well (the memory breakdown printed on exit), by which time the peer rpc-server may
+    // already be gone. A dead connection here must not abort the process: report the memory as
+    // unknown, which is what an endpoint we cannot connect to at all already reports.
+    if (!get_device_memory(sock, device, free, total)) {
+        GGML_LOG_ERROR("%s: failed to query device memory of %s, reporting 0\n", __func__, endpoint);
+        *free = 0;
+        *total = 0;
+    }
 }
 
 // RPC server-side implementation

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -393,8 +393,7 @@ static std::shared_ptr<socket_t> get_socket(const std::string & endpoint) {
 static void ggml_backend_rpc_buffer_free_buffer(ggml_backend_buffer_t buffer) {
     ggml_backend_rpc_buffer_context * ctx = (ggml_backend_rpc_buffer_context *)buffer->context;
     rpc_msg_free_buffer_req request = {ctx->remote_ptr};
-    // releasing a remote buffer must not abort: this runs during teardown, and if the peer is
-    // already gone then so is the buffer. The local context is freed either way.
+    // teardown: if the peer is gone, so is the buffer. Never abort here.
     if (!send_rpc_cmd(ctx->sock, RPC_CMD_FREE_BUFFER, &request, sizeof(request), nullptr, 0)) {
         GGML_LOG_ERROR("%s: failed to free the remote buffer, the connection is gone\n", __func__);
     }
@@ -845,10 +844,8 @@ void ggml_backend_rpc_get_device_memory(const char * endpoint, uint32_t device, 
     if (sock == nullptr) {
         return;
     }
-    // this is an informational device property, not part of the data path, and it is queried during
-    // teardown as well (the memory breakdown printed on exit), by which time the peer rpc-server may
-    // already be gone. A dead connection here must not abort the process: report the memory as
-    // unknown, which is what an endpoint we cannot connect to at all already reports.
+    // informational, not the data path, and queried at teardown when the peer may be gone: report 0,
+    // as an endpoint we cannot connect to already does.
     if (!get_device_memory(sock, device, free, total)) {
         GGML_LOG_ERROR("%s: failed to query device memory of %s, reporting 0\n", __func__, endpoint);
         *free = 0;

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -844,8 +844,7 @@ void ggml_backend_rpc_get_device_memory(const char * endpoint, uint32_t device, 
     if (sock == nullptr) {
         return;
     }
-    // informational, not the data path, and queried at teardown when the peer may be gone: report 0,
-    // as an endpoint we cannot connect to already does.
+    // informational, queried at teardown when the peer may be gone: report 0, as an unreachable endpoint does.
     if (!get_device_memory(sock, device, free, total)) {
         GGML_LOG_ERROR("%s: failed to query device memory of %s, reporting 0\n", __func__, endpoint);
         *free = 0;


### PR DESCRIPTION
## What happens

`llama-server` built with `GGML_RPC` aborts on exit, after it has already printed
`cleaning up before exit`:

```
ggml/src/ggml-rpc/ggml-rpc.cpp:891: Remote RPC server crashed or returned malformed response
#3  ggml_backend_rpc_get_device_memory ()
#4  common_memory_breakdown_print(llama_context const*) ()
#5  llama_server(common_params&, int, char**) ()
```

## Why

`common_memory_breakdown_print()` is called after `clean_up()`, which calls
`llama_backend_free()`. The RPC device answers `get_memory` with a round trip to the peer,
and by that point the round trip fails, so `RPC_STATUS_ASSERT` aborts the process.

This was first seen on a two node layer split where the peer `ggml-rpc-server` had been
stopped before the local server exited.

**Correction, 2026-09-08.** This paragraph previously claimed the abort reproduces with a
peer that is alive and healthy, and therefore fires on every shutdown of a server using
`--rpc`. Re-tested on the pair, that is wrong: with a healthy peer the master exits
cleanly. The trigger is an **unreachable** peer, which is the case the original report
came from. Three of the four cells below reproduce exactly as written, including the log
line counts, so the defect and the fix are unchanged; only this claim about how often it
fires was too broad.

That still makes it worth fixing rather than a corner case. A peer going away before the
coordinator exits is the normal shutdown order for a split: the orchestrator tears down
the remote servers first, and any crash, kill or network loss on the peer puts the
coordinator in exactly this state. An informational property should not abort a process
that has already finished its work.

## The fix

Device memory is an informational property, not part of the data path, and
`ggml_backend_rpc_get_device_memory()` already has a defined answer for an endpoint it
cannot reach at all: report 0 free and 0 total. Report the same when the query itself
fails, and log an error.

Freeing a remote buffer is released state and is also a teardown operation, so a failure
there is logged instead of aborting: if the peer is gone then so is the buffer, and the
local context is freed either way. Without this second hunk the process still aborts a few
microseconds later in `ggml_backend_rpc_buffer_free_buffer` from
`ggml_backend_sched_free`, on the way out of `~llama_context`.

Every other `RPC_STATUS_ASSERT`, including all of the data path ones, is unchanged. A
failure while setting or getting a tensor or running a graph still aborts.

The alternative, teaching `common_memory_breakdown_print()` to skip backends whose
connection has dropped, was rejected: that code is shared with every non-RPC build and has
no way to ask a backend whether it is still reachable, so it would need a new backend
interface entry for one caller. Caching the last known figure inside the RPC backend was
also rejected: it adds state to keep in sync in order to print a number that is meaningless
by the time it is printed.

## What was measured

CPU only, `stories15M-q4_0.gguf`, `--rpc HOST:PORT --device RPC0 -ngl 99`, one completion
served, then SIGINT. The verdict is the process exit status: 134 is SIGABRT, 0 is a clean exit.

A fixed delay after SIGINT does not test this. The teardown round trip is microseconds wide, so
a reset injected 20 or 50 ms after the signal always lands outside it and comes back clean on
both arms, saying nothing (rows c7 and c8 below, kept as a negative control). What does work is
a proxy that parses the client to server RPC framing (`cmd:1 | size:8 | payload`) and resets the
connection the instant a chosen command byte is issued, before forwarding it.
`RPC_CMD_GET_DEVICE_MEMORY` is 11 and `RPC_CMD_FREE_BUFFER` is 4.

Single node, `127.0.0.1`:

| case | fault | before | after |
|---|---|---|---|
| c1 | healthy peer, ordinary shutdown | **clean, rc 0** | clean, rc 0 |
| c2 | peer `SIGKILL`ed before shutdown | **abort, rc 134** | clean, 1 `reporting 0`, 3 `connection is gone` |
| c3 | peer `SIGTERM`ed before shutdown | **abort, rc 134** | clean, same log lines |
| c4 | RST injected by the proxy, peer process still alive | **abort, rc 134** | clean, rc 0 |
| c5 | orderly FIN from the peer side, peer process still alive | **abort, rc 134** | clean, rc 0 |
| c6 | peer accepts and never answers | hang | hang, unchanged, see follow ups |
| c7 | peer killed 50 ms after SIGINT | clean | clean (fault missed the window) |
| c8 x5 | RST 20 ms after SIGINT, five repetitions | clean x5 | clean x5 (fault missed the window) |
| c9a | RST the instant `RPC_CMD_GET_DEVICE_MEMORY` is issued | **abort at `ggml-rpc.cpp:831`** | clean, 1 `reporting 0`, 3 `connection is gone` |
| c9b | RST the instant `RPC_CMD_FREE_BUFFER` is issued | **abort at `ggml-rpc.cpp:397`** | clean, 3 `connection is gone` |

Two nodes, `ggml-rpc-server` on a second DGX Spark over the LAN, which is the topology the
original report came from:

| case | fault | before | after |
|---|---|---|---|
| n1 | healthy peer, ordinary shutdown | **clean, rc 0** | clean, rc 0 |
| n2 | remote peer `SIGKILL`ed before shutdown | **abort, rc 134, core dumped** | clean, 1 `reporting 0`, 3 `connection is gone` |
| n3 | remote peer `SIGTERM`ed before shutdown | **abort, rc 134, core dumped** | clean, same |

**8 of the 8 injections that actually reach the teardown round trip abort before and are clean
after**, across five fault shapes and two topologies. c9b is the row that shows the second hunk
is load bearing rather than defensive: with the reset landing on the free, the abort is in
`ggml_backend_rpc_buffer_free_buffer` at `ggml-rpc.cpp:397`, not in `get_device_memory`.

A healthy peer exits **cleanly** before the change, on both topologies (c1 and n1). An earlier
revision of this description claimed otherwise; that claim was wrong and is corrected here.

## Follow ups this does not fix

Neither is a regression and neither is introduced here, but both are in the same file and both
turned up while testing this change.

**1. There is no socket timeout anywhere in the RPC transport, so a peer that accepts a
connection and then never answers hangs the shutdown forever.** `ggml/src/ggml-rpc/transport.cpp`
sets `TCP_NODELAY` and `SO_REUSEADDR` and nothing else: no `SO_RCVTIMEO`, no `SO_SNDTIMEO`, no
connect timeout. `socket_t::impl::recv_data()` loops on `recv(fd, ..., 0)` until it has the
bytes, gets 0 (peer performed an orderly shutdown) or gets -1. A peer holding the socket open
and sending nothing produces none of those, so the process blocks and SIGINT is never serviced.
Reproduced before and after this change alike, row c6 above.

**2. The transport sends with no `MSG_NOSIGNAL`, so an RPC client that is not `llama-server` can
be killed by SIGPIPE before either the old abort or the new log line is reached.** Nothing in
the RPC backend installs a SIGPIPE handler or sets `SO_NOSIGPIPE`; the only place in the tree
that ignores SIGPIPE is `tools/server/server.cpp`, added for MCP child processes, which is why
`llama-server` reaches this code path at all. `llama-cli`, `llama-bench` and embedders do not.
This one is a source level hazard I could **not** demonstrate: with `llama-cli --rpc` and the
peer killed mid session, the first failing operation on this kernel is a `recv()` that returns
0, so `RPC_STATUS_ASSERT` in `negotiate_hello()` (`ggml-rpc.cpp:348`) fires first, identically
before and after. Stated as unproven rather than as a reproduction.

Also unchanged and out of scope here: `negotiate_hello()` still has an `RPC_STATUS_ASSERT`, so a
reconnect to a half dead peer still aborts. That is a connect time path, not a teardown path.

## Non-RPC builds

The change touches one file, `ggml/src/ggml-rpc/ggml-rpc.cpp`. That file is compiled only
through `ggml_add_backend(RPC)` in `ggml/src/CMakeLists.txt`, which adds the subdirectory
only if `GGML_RPC` is set, and `GGML_RPC` defaults to OFF in `ggml/CMakeLists.txt`. No
header, no public signature and no shared code path changes, so NVIDIA, AMD and CPU only
builds without RPC are byte for byte unaffected.


