### PR TITLE
Sign the Windows prebuilt binaries with Azure Trusted Signing

### DIFF
--- a/.github/actions/sign-windows/action.yml
+++ b/.github/actions/sign-windows/action.yml
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+name: Sign Windows binaries
+description: >-
+  Authenticode-sign every PE in a built Windows tree with Azure Trusted Signing,
+  so the bundles the Unsloth Studio installer downloads are not blocked by Smart
+  App Control when they load on a user machine.
+
+inputs:
+  path:
+    description: Directory to sign, searched recursively.
+    required: true
+  azure-client-id:
+    description: AZURE_CLIENT_ID from the release-signing environment.
+    required: false
+    default: ''
+  azure-client-secret:
+    description: AZURE_CLIENT_SECRET from the release-signing environment.
+    required: false
+    default: ''
+  azure-tenant-id:
+    description: AZURE_TENANT_ID from the release-signing environment.
+    required: false
+    default: ''
+  azure-account:
+    description: AZURE_TRUSTED_SIGNING_ACCOUNT_NAME from the release-signing environment.
+    required: false
+    default: ''
+  azure-certificate-profile:
+    description: AZURE_CERTIFICATE_PROFILE_NAME from the release-signing environment.
+    required: false
+    default: ''
+  endpoint:
+    description: Azure Trusted Signing endpoint for the account's region.
+    required: false
+    default: https://eus.codesigning.azure.net
+
+outputs:
+  signed:
+    description: '"true" when the tree was signed, "false" when signing was skipped on a fork.'
+    value: ${{ steps.gate.outputs.signed }}
+
+runs:
+  using: composite
+  steps:
+    # Forks cannot read the signing secrets, so their builds are allowed through
+    # unsigned rather than failing on something a contributor cannot fix. On the
+    # canonical repo the same missing secret is a hard error: silently shipping
+    # an unsigned release is the exact failure this action exists to prevent,
+    # and a skip that looks like a pass is how the Defender scan in
+    # unslothai/unsloth#8358 went missing for five releases.
+    - name: Decide whether signing runs
+      id: gate
+      shell: pwsh
+      env:
+        AZURE_CLIENT_ID: ${{ inputs.azure-client-id }}
+      run: |
+        $ErrorActionPreference = 'Continue'
+        $haveSecrets = -not [string]::IsNullOrWhiteSpace($env:AZURE_CLIENT_ID)
+        $canonical = ($env:GITHUB_REPOSITORY -eq 'unslothai/llama.cpp')
+        if ($haveSecrets) {
+          Add-Content -Path $env:GITHUB_OUTPUT -Value 'signed=true'
+          Write-Host 'Azure Trusted Signing credentials present; signing.'
+        } elseif ($canonical) {
+          Write-Host '::error::Azure Trusted Signing secrets are missing on unslothai/llama.cpp.'
+          Write-Host 'Add AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_TENANT_ID,'
+          Write-Host 'AZURE_TRUSTED_SIGNING_ACCOUNT_NAME and AZURE_CERTIFICATE_PROFILE_NAME'
+          Write-Host 'to the release-signing environment. Refusing to publish unsigned binaries.'
+          exit 1
+        } else {
+          Add-Content -Path $env:GITHUB_OUTPUT -Value 'signed=false'
+          Write-Host "::warning::No signing secrets on $env:GITHUB_REPOSITORY; leaving binaries unsigned."
+        }
+
+    # Pinned by digest. This binary runs in the step that holds the signing
+    # credentials, so where it comes from is itself a key-handling question.
+    - name: Install trusted-signing-cli
+      if: ${{ steps.gate.outputs.signed == 'true' }}
+      shell: pwsh
+      env:
+        TRUSTED_SIGNING_CLI_URL: https://github.com/Levminer/artifact-signing-cli/releases/download/0.10.0/trusted-signing-cli.exe
+        TRUSTED_SIGNING_CLI_SHA256: 8c9d750ca582891a7433925dcf302d5d3761fbed757b46c4bf5b417562dccb0e
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $dir = Join-Path $env:RUNNER_TEMP 'trusted-signing-cli'
+        New-Item -ItemType Directory -Force -Path $dir | Out-Null
+        $dest = Join-Path $dir 'trusted-signing-cli.exe'
+        Invoke-WebRequest -Uri $env:TRUSTED_SIGNING_CLI_URL -OutFile $dest -MaximumRetryCount 3 -RetryIntervalSec 5
+        $actual = (Get-FileHash $dest -Algorithm SHA256).Hash.ToLower()
+        $expected = $env:TRUSTED_SIGNING_CLI_SHA256.ToLower()
+        if ($actual -ne $expected) {
+          Write-Host "::error::trusted-signing-cli digest mismatch, refusing to sign with an unverified binary. Expected $expected, got $actual."
+          exit 1
+        }
+        Write-Host "verified trusted-signing-cli sha256=$actual"
+        Add-Content -Path $env:GITHUB_PATH -Value $dir
+
+    - name: Sign every PE in the build tree
+      if: ${{ steps.gate.outputs.signed == 'true' }}
+      shell: pwsh
+      env:
+        AZURE_CLIENT_ID: ${{ inputs.azure-client-id }}
+        AZURE_CLIENT_SECRET: ${{ inputs.azure-client-secret }}
+        AZURE_TENANT_ID: ${{ inputs.azure-tenant-id }}
+        AZURE_TRUSTED_SIGNING_ACCOUNT_NAME: ${{ inputs.azure-account }}
+        AZURE_CERTIFICATE_PROFILE_NAME: ${{ inputs.azure-certificate-profile }}
+      run: |
+        $ErrorActionPreference = 'Continue'
+        & "$env:GITHUB_ACTION_PATH/../../scripts/sign-windows-tree.ps1" -Path "${{ inputs.path }}" -Endpoint "${{ inputs.endpoint }}"
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/.github/actions/sign-windows/action.yml
+++ b/.github/actions/sign-windows/action.yml
@@ -95,6 +95,43 @@ runs:
         Write-Host "verified trusted-signing-cli sha256=$actual"
         Add-Content -Path $env:GITHUB_PATH -Value $dir
 
+    # Fails closed, matching the desktop release workflow. Without this a
+    # missing or broken binary only surfaces later as a signing error with no
+    # obvious cause.
+    - name: Verify trusted-signing-cli
+      if: ${{ steps.gate.outputs.signed == 'true' }}
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $cli = Get-Command trusted-signing-cli -ErrorAction SilentlyContinue
+        if (-not $cli) {
+          Write-Output "::error::trusted-signing-cli is not on PATH. Check the install step above."
+          exit 1
+        }
+        # sign-windows-tree.ps1 invokes this by bare name, so whatever PATH
+        # resolves is what signs. Only the digest-verified copy may do that;
+        # anything else under the same name is unverified by definition.
+        $verified = [IO.Path]::GetFullPath((Join-Path (Join-Path $env:RUNNER_TEMP 'trusted-signing-cli') 'trusted-signing-cli.exe'))
+        if ([IO.Path]::GetFullPath($cli.Source) -ne $verified) {
+          Write-Output "::error::trusted-signing-cli resolved to $($cli.Source), not the verified $verified. Refusing to sign with a binary that was never digest checked."
+          exit 1
+        }
+        # Two distinct failure modes, neither covering the other: a truncated
+        # download cannot start at all, which raises under Stop and must be
+        # caught; a binary that starts and exits non-zero does not raise, so
+        # $LASTEXITCODE has to be read.
+        try {
+          & $cli.Source --version
+        } catch {
+          $detail = ($_.Exception.Message -replace '\s+', ' ').Trim()
+          Write-Output "::error::trusted-signing-cli could not be started. Re-run to fetch it again; if it persists the pinned asset is bad. Underlying error: $detail"
+          exit 1
+        }
+        if ($LASTEXITCODE -ne 0) {
+          Write-Output "::error::trusted-signing-cli is on PATH but exited $LASTEXITCODE."
+          exit 1
+        }
+
     - name: Sign every PE in the build tree
       if: ${{ steps.gate.outputs.signed == 'true' }}
       shell: pwsh

--- a/.github/scripts/assert-windows-bundle-signed.ps1
+++ b/.github/scripts/assert-windows-bundle-signed.ps1
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+# Fail if any PE inside a packaged Windows bundle is unsigned.
+#
+# This is the release gate. sign-windows-tree.ps1 signs the build output, but the
+# packaging steps copy extra files in afterwards (the OpenMP runtime out of the
+# Visual Studio redist tree, and the ROCm runtime DLLs out of the TheRock dist),
+# so the only place that can prove what actually ships is the finished zip.
+#
+# Runs against zips rather than directories on purpose: an unsigned file that
+# gets added between signing and packaging is invisible to any earlier check.
+
+param(
+    # Bundle zips to verify; every PE inside each is checked.
+    [Parameter(Mandatory = $true)][string[]] $Path,
+    # 7-Zip, preinstalled on the GitHub Windows images.
+    [string] $SevenZip = '7z',
+    # Known-unsigned leaf names to accept. Keep this empty. Anything listed here
+    # is a file we ship that Smart App Control can still refuse to load.
+    [string[]] $Allow = @()
+)
+
+$ErrorActionPreference = 'Continue'
+$peExtensions = @('.exe', '.dll', '.pyd', '.sys', '.ocx', '.cpl', '.scr')
+
+$unsigned = @()
+$checked = 0
+
+foreach ($bundle in $Path) {
+    if (-not (Test-Path -LiteralPath $bundle -PathType Leaf)) {
+        Write-Host "::error::bundle not found: $bundle"
+        exit 1
+    }
+    $name = Split-Path $bundle -Leaf
+    Write-Host ''
+    Write-Host "=== $name ==="
+
+    $root = if ($env:RUNNER_TEMP) { $env:RUNNER_TEMP } else { [System.IO.Path]::GetTempPath() }
+    $dest = Join-Path $root ('sigcheck-' + [System.IO.Path]::GetFileNameWithoutExtension($name))
+    Remove-Item -LiteralPath $dest -Recurse -Force -ErrorAction SilentlyContinue
+    & $SevenZip x -y "-o$dest" $bundle | Out-Null
+    # 7-Zip leaves a partial tree behind on error, so a created directory proves
+    # nothing about whether the archive was fully extracted.
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "::error::7-Zip exited $LASTEXITCODE unpacking $name; contents not verified"
+        exit 1
+    }
+    if (-not (Test-Path -LiteralPath $dest)) {
+        Write-Host "::error::could not unpack $name; cannot verify its contents"
+        exit 1
+    }
+
+    $inner = @(
+        Get-ChildItem -LiteralPath $dest -Recurse -File |
+            Where-Object { $peExtensions -contains $_.Extension.ToLowerInvariant() }
+    )
+    # No hits means the archive did not contain what we think it does, not that
+    # the payload is clean.
+    if ($inner.Count -eq 0) {
+        Write-Host "::error::no executable payload found inside $name; contents not verified"
+        exit 1
+    }
+
+    foreach ($f in ($inner | Sort-Object Name)) {
+        $checked++
+        $s = Get-AuthenticodeSignature -LiteralPath $f.FullName
+        if ($s.Status -eq 'Valid') {
+            Write-Host ('  signed    {0}' -f $f.Name)
+        } elseif ($Allow -contains $f.Name) {
+            Write-Host ('  ALLOWED   {0}  ({1}) - explicitly accepted as unsigned' -f $f.Name, $s.Status)
+        } else {
+            # UnknownError covers both "no signature at all" and "chain did not
+            # build"; StatusMessage is what distinguishes them.
+            Write-Host ('  UNSIGNED  {0}  ({1})  {2}' -f $f.Name, $s.Status, $s.StatusMessage)
+            $unsigned += [pscustomobject]@{ Bundle = $name; File = $f.Name; Status = [string]$s.Status }
+        }
+    }
+    Remove-Item -LiteralPath $dest -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host ''
+Write-Host "checked $checked file(s) across $($Path.Count) bundle(s)"
+
+if ($unsigned.Count -eq 0) {
+    Write-Host 'Every PE in every bundle is validly signed.'
+    exit 0
+}
+
+Write-Host ''
+Write-Host '================ UNSIGNED FILES ================'
+$unsigned | Format-Table Bundle, File, Status -AutoSize | Out-String | Write-Host
+foreach ($u in $unsigned) {
+    Write-Host "::error file=$($u.File)::$($u.File) in $($u.Bundle) is $($u.Status) and needs signing"
+}
+Write-Host ''
+Write-Host 'These ship to user machines and are loaded by llama-server.'
+Write-Host 'Smart App Control blocks unknown unsigned binaries as they load.'
+exit 1

--- a/.github/scripts/sign-windows-tree.ps1
+++ b/.github/scripts/sign-windows-tree.ps1
@@ -52,6 +52,32 @@ if ($files.Count -eq 0) {
     exit 1
 }
 
+# Leave an existing valid signature alone. Signing replaces it, and some of
+# what we bundle arrives already signed by its vendor: the OpenMP runtime is
+# signed by Microsoft, and re-signing it would strip that and substitute ours
+# for no gain. Files that are unsigned, or whose chain does not build, are ours
+# to sign. Everything is re-verified at the end either way.
+$alreadySigned = @()
+$toSign = @()
+foreach ($f in $files) {
+    if ((Get-AuthenticodeSignature -LiteralPath $f.FullName).Status -eq 'Valid') {
+        $alreadySigned += $f
+    } else {
+        $toSign += $f
+    }
+}
+
+if ($alreadySigned.Count -gt 0) {
+    Write-Host "leaving $($alreadySigned.Count) already-signed file(s) untouched:"
+    foreach ($f in $alreadySigned) { Write-Host "  $($f.Name)" }
+}
+
+if ($toSign.Count -eq 0) {
+    Write-Host "all $($files.Count) PE file(s) under $Path are already validly signed"
+    exit 0
+}
+
+$files = $toSign
 Write-Host "signing $($files.Count) PE file(s) under $Path"
 
 # Retried only for Azure auth flakiness. A signing rejection is a real failure

--- a/.github/scripts/sign-windows-tree.ps1
+++ b/.github/scripts/sign-windows-tree.ps1
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+# Authenticode-sign every PE in a built Windows tree with Azure Trusted Signing.
+#
+# The bundles produced here are downloaded and executed on user machines by the
+# Unsloth Studio installer, which fetches them after its own signed installer has
+# already run. Nothing else signs them, so an unsigned file here reaches the user
+# unsigned. Windows Smart App Control evaluates every binary as it loads and
+# blocks unknown unsigned code, reporting it as a "Bad Image" dialog with status
+# 0xc0e90002 naming whichever dependent DLL it refused, so signing only the
+# launcher executables is not enough: every DLL in the tree has to be signed.
+#
+# Signing is batched. trusted-signing-cli takes any number of trailing paths and
+# authenticates to Azure once per invocation, so a bundle of ~50 files costs one
+# round trip instead of fifty.
+
+param(
+    # Directory to sign, searched recursively.
+    [Parameter(Mandatory = $true)][string] $Path,
+    # Azure Trusted Signing endpoint, matched to the account's region.
+    [string] $Endpoint = 'https://eus.codesigning.azure.net',
+    # Signature description shown in the Windows UAC/properties dialog.
+    [string] $Description = 'Unsloth',
+    # Files per trusted-signing-cli invocation. Batching amortizes Azure auth;
+    # an unbounded batch would risk the Windows command line length limit.
+    [int] $BatchSize = 40,
+    [int] $MaxAttempts = 3
+)
+
+$ErrorActionPreference = 'Continue'
+
+# Extensions Smart App Control and WDAC evaluate at load time. .pyd is included
+# because the ROCm and CUDA bundles can carry Python extension modules, which are
+# ordinary PEs under a different suffix.
+$peExtensions = @('.exe', '.dll', '.pyd', '.sys', '.ocx', '.cpl', '.scr')
+
+if (-not (Test-Path -LiteralPath $Path)) {
+    Write-Host "::error::sign-windows-tree: path not found: $Path"
+    exit 1
+}
+
+$files = @(
+    Get-ChildItem -LiteralPath $Path -Recurse -File |
+        Where-Object { $peExtensions -contains $_.Extension.ToLowerInvariant() } |
+        Sort-Object FullName
+)
+
+# An empty tree means the build step silently produced nothing. Signing zero
+# files and reporting success would let that reach the release.
+if ($files.Count -eq 0) {
+    Write-Host "::error::sign-windows-tree: no PE files found under $Path; nothing was built"
+    exit 1
+}
+
+Write-Host "signing $($files.Count) PE file(s) under $Path"
+
+# Retried only for Azure auth flakiness. A signing rejection is a real failure
+# and repeating it just burns quota.
+$retryPatterns = @(
+    'No subscriptions found',
+    'login via azure cli',
+    'az\.cmd.*exited with code 1',
+    'Failed to acquire token',
+    'temporarily unavailable',
+    'Response status code does not indicate success: 429',
+    'Response status code does not indicate success: 50[0-9]'
+)
+
+$batches = [System.Collections.Generic.List[object]]::new()
+for ($i = 0; $i -lt $files.Count; $i += $BatchSize) {
+    $end = [Math]::Min($i + $BatchSize, $files.Count) - 1
+    $batches.Add(@($files[$i..$end]))
+}
+
+$batchNumber = 0
+foreach ($batch in $batches) {
+    $batchNumber++
+    $paths = @($batch | ForEach-Object { $_.FullName })
+    Write-Host ''
+    Write-Host "=== batch $batchNumber/$($batches.Count): $($paths.Count) file(s) ==="
+
+    $signed = $false
+    for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+        $cliArgs = @('-e', $Endpoint, '-d', $Description) + $paths
+        $output = & trusted-signing-cli @cliArgs 2>&1
+        $exitCode = $LASTEXITCODE
+        if ($null -eq $exitCode) { $exitCode = 1 }
+        $text = $output | Out-String
+        foreach ($line in $output) { Write-Output $line }
+
+        if ($exitCode -eq 0) { $signed = $true; break }
+
+        $isRetryable = $false
+        foreach ($pattern in $retryPatterns) {
+            if ($text -match $pattern) { $isRetryable = $true; break }
+        }
+        if (-not $isRetryable -or $attempt -eq $MaxAttempts) {
+            Write-Host "::error::trusted-signing-cli exited $exitCode on batch $batchNumber"
+            exit $exitCode
+        }
+        Write-Warning "trusted-signing-cli hit a transient Azure error; retrying batch $batchNumber."
+        Start-Sleep -Seconds (5 * $attempt)
+    }
+
+    if (-not $signed) {
+        Write-Host "::error::batch $batchNumber was not signed"
+        exit 1
+    }
+}
+
+Write-Host ''
+Write-Host "signed $($files.Count) file(s); verifying"
+
+# Verify here as well as in the release gate. Catching an unsigned file in the
+# job that produced it names the build leg directly, where the gate downstream
+# can only say which bundle was wrong.
+$bad = @()
+foreach ($f in $files) {
+    $sig = Get-AuthenticodeSignature -LiteralPath $f.FullName
+    if ($sig.Status -ne 'Valid') {
+        $bad += [pscustomobject]@{ File = $f.Name; Status = [string]$sig.Status; Message = $sig.StatusMessage }
+    }
+}
+
+if ($bad.Count -gt 0) {
+    Write-Host ''
+    $bad | Format-Table File, Status, Message -AutoSize | Out-String | Write-Host
+    foreach ($b in $bad) {
+        Write-Host "::error file=$($b.File)::$($b.File) is $($b.Status) after signing"
+    }
+    exit 1
+}
+
+Write-Host "all $($files.Count) file(s) report a valid Authenticode signature"
+exit 0

--- a/.github/workflows/unsloth-prebuilt-cpu.yml
+++ b/.github/workflows/unsloth-prebuilt-cpu.yml
@@ -239,6 +239,17 @@ jobs:
     # windows-cpu job. CUDA stays on MSVC (mandatory for nvcc on Windows), but
     # the CPU build uses clang/LLVM to match upstream's proven CPU recipe.
     runs-on: windows-2025-vs2026
+    # Every Azure Trusted Signing secret in this workflow is read by this job
+    # and no other. Naming an environment is what makes them gateable: without
+    # it there is no place to hang a required reviewer, so anyone who can
+    # dispatch the parent workflow can sign under our identity.
+    #
+    # Inert until protection rules exist. GitHub creates a referenced-but-absent
+    # environment on first run with no rules and no branch policy, and
+    # repository secrets keep resolving inside a job that names an environment,
+    # so this line alone changes nothing about how a build runs. Same shape as
+    # release-desktop.yml in unslothai/unsloth.
+    environment: release-signing
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/unsloth-prebuilt-cpu.yml
+++ b/.github/workflows/unsloth-prebuilt-cpu.yml
@@ -329,6 +329,17 @@ jobs:
       # globbing the MSVC version dir so an image bump does not break the path.
       # Sort newest-first: older toolsets' libomp lacks entry points current
       # clang imports (__kmpc_dispatch_deinit -> STATUS_ENTRYPOINT_NOT_FOUND).
+      # The build legs extract a source tarball rather than checking this repo
+      # out, so the signing action and its scripts are not on disk. Fetch just
+      # .github into a subdirectory: a checkout at the workspace root would
+      # clean the extracted source tree out from under the build.
+      - name: Fetch signing tooling
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
+        with:
+          path: signing-tooling
+          sparse-checkout: .github
+          persist-credentials: false
+
       # Authenticode-sign before packaging. The Studio installer downloads these
       # zips after its own signed installer has run, so nothing downstream signs
       # them. Smart App Control evaluates every binary as it loads and refuses
@@ -337,7 +348,7 @@ jobs:
       # the launcher executables.
       - name: Sign Windows binaries
         id: sign_windows
-        uses: ./.github/actions/sign-windows
+        uses: ./signing-tooling/.github/actions/sign-windows
         with:
           path: src/build/bin/Release
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -382,7 +393,7 @@ jobs:
       - name: Verify every binary in the bundle is signed
         if: ${{ steps.sign_windows.outputs.signed == 'true' }}
         shell: pwsh
-        run: .github/scripts/assert-windows-bundle-signed.ps1 -Path 'dist/app-${{ inputs.tag }}-windows-${{ matrix.arch }}-cpu.zip'
+        run: signing-tooling/.github/scripts/assert-windows-bundle-signed.ps1 -Path 'dist/app-${{ inputs.tag }}-windows-${{ matrix.arch }}-cpu.zip'
 
       - name: Upload bundle artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0

--- a/.github/workflows/unsloth-prebuilt-cpu.yml
+++ b/.github/workflows/unsloth-prebuilt-cpu.yml
@@ -41,6 +41,23 @@ on:
         default: ''
         type: string
 
+    secrets:
+      AZURE_CLIENT_ID:
+        description: 'Azure Trusted Signing client id; empty on forks, which then build unsigned'
+        required: false
+      AZURE_CLIENT_SECRET:
+        description: 'Azure Trusted Signing client secret'
+        required: false
+      AZURE_TENANT_ID:
+        description: 'Azure Trusted Signing tenant id'
+        required: false
+      AZURE_TRUSTED_SIGNING_ACCOUNT_NAME:
+        description: 'Azure Trusted Signing account name'
+        required: false
+      AZURE_CERTIFICATE_PROFILE_NAME:
+        description: 'Azure Trusted Signing certificate profile name'
+        required: false
+
 permissions:
   contents: read
 
@@ -312,6 +329,23 @@ jobs:
       # globbing the MSVC version dir so an image bump does not break the path.
       # Sort newest-first: older toolsets' libomp lacks entry points current
       # clang imports (__kmpc_dispatch_deinit -> STATUS_ENTRYPOINT_NOT_FOUND).
+      # Authenticode-sign before packaging. The Studio installer downloads these
+      # zips after its own signed installer has run, so nothing downstream signs
+      # them. Smart App Control evaluates every binary as it loads and refuses
+      # unknown unsigned code, naming whichever dependent DLL it blocked in a Bad
+      # Image dialog (status 0xc0e90002), so the whole tree is signed, not just
+      # the launcher executables.
+      - name: Sign Windows binaries
+        id: sign_windows
+        uses: ./.github/actions/sign-windows
+        with:
+          path: src/build/bin/Release
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-account: ${{ secrets.AZURE_TRUSTED_SIGNING_ACCOUNT_NAME }}
+          azure-certificate-profile: ${{ secrets.AZURE_CERTIFICATE_PROFILE_NAME }}
+
       - name: Package bundle (zip)
         run: |
           $rel = "src/build/bin/Release"
@@ -341,6 +375,14 @@ jobs:
           $rel = "src/build/bin/Release"
           & "$rel\llama-server.exe" --version
           if ($LASTEXITCODE -ne 0) { Write-Error "llama-server --version failed: $LASTEXITCODE"; exit 1 }
+
+      # Verify the finished zip, not the build tree: packaging copies extra
+      # runtimes in afterwards, and only the archive shows what actually ships.
+      # Skipped on forks, which have no signing credentials and build unsigned.
+      - name: Verify every binary in the bundle is signed
+        if: ${{ steps.sign_windows.outputs.signed == 'true' }}
+        shell: pwsh
+        run: .github/scripts/assert-windows-bundle-signed.ps1 -Path 'dist/app-${{ inputs.tag }}-windows-${{ matrix.arch }}-cpu.zip'
 
       - name: Upload bundle artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0

--- a/.github/workflows/unsloth-prebuilt-cuda-windows.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda-windows.yml
@@ -38,6 +38,23 @@ on:
         required: true
         type: string
 
+    secrets:
+      AZURE_CLIENT_ID:
+        description: 'Azure Trusted Signing client id; empty on forks, which then build unsigned'
+        required: false
+      AZURE_CLIENT_SECRET:
+        description: 'Azure Trusted Signing client secret'
+        required: false
+      AZURE_TENANT_ID:
+        description: 'Azure Trusted Signing tenant id'
+        required: false
+      AZURE_TRUSTED_SIGNING_ACCOUNT_NAME:
+        description: 'Azure Trusted Signing account name'
+        required: false
+      AZURE_CERTIFICATE_PROFILE_NAME:
+        description: 'Azure Trusted Signing certificate profile name'
+        required: false
+
 permissions:
   contents: read
 
@@ -255,6 +272,23 @@ jobs:
           }
           exit 0
 
+      # Authenticode-sign before packaging. The Studio installer downloads these
+      # zips after its own signed installer has run, so nothing downstream signs
+      # them. Smart App Control evaluates every binary as it loads and refuses
+      # unknown unsigned code, naming whichever dependent DLL it blocked in a Bad
+      # Image dialog (status 0xc0e90002), so the whole tree is signed, not just
+      # the launcher executables.
+      - name: Sign Windows binaries
+        id: sign_windows
+        uses: ./.github/actions/sign-windows
+        with:
+          path: src/build/bin
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-account: ${{ secrets.AZURE_TRUSTED_SIGNING_ACCOUNT_NAME }}
+          azure-certificate-profile: ${{ secrets.AZURE_CERTIFICATE_PROFILE_NAME }}
+
       - name: Package bundle
         env:
           PLATFORM: windows
@@ -275,6 +309,14 @@ jobs:
           ARCHS: ${{ matrix.archs }}
           SMS: ${{ matrix.sms }}
         run: python tooling/scripts/unsloth/package_bundle.py
+
+      # Verify the finished zip, not the build tree: packaging copies extra
+      # runtimes in afterwards, and only the archive shows what actually ships.
+      # Skipped on forks, which have no signing credentials and build unsigned.
+      - name: Verify every binary in the bundle is signed
+        if: ${{ steps.sign_windows.outputs.signed == 'true' }}
+        shell: pwsh
+        run: .github/scripts/assert-windows-bundle-signed.ps1 -Path 'dist/app-${{ inputs.tag }}-windows-x64-${{ matrix.profile }}.zip'
 
       - name: Upload bundle artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0

--- a/.github/workflows/unsloth-prebuilt-cuda-windows.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda-windows.yml
@@ -280,7 +280,7 @@ jobs:
       # the launcher executables.
       - name: Sign Windows binaries
         id: sign_windows
-        uses: ./.github/actions/sign-windows
+        uses: ./tooling/.github/actions/sign-windows
         with:
           path: src/build/bin
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -316,7 +316,7 @@ jobs:
       - name: Verify every binary in the bundle is signed
         if: ${{ steps.sign_windows.outputs.signed == 'true' }}
         shell: pwsh
-        run: .github/scripts/assert-windows-bundle-signed.ps1 -Path 'dist/app-${{ inputs.tag }}-windows-x64-${{ matrix.profile }}.zip'
+        run: tooling/.github/scripts/assert-windows-bundle-signed.ps1 -Path 'dist/app-${{ inputs.tag }}-windows-x64-${{ matrix.profile }}.zip'
 
       - name: Upload bundle artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0

--- a/.github/workflows/unsloth-prebuilt-cuda-windows.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda-windows.yml
@@ -62,6 +62,17 @@ jobs:
   build:
     name: x64/${{ matrix.profile }}
     runs-on: ${{ matrix.runner }}
+    # Every Azure Trusted Signing secret in this workflow is read by this job
+    # and no other. Naming an environment is what makes them gateable: without
+    # it there is no place to hang a required reviewer, so anyone who can
+    # dispatch the parent workflow can sign under our identity.
+    #
+    # Inert until protection rules exist. GitHub creates a referenced-but-absent
+    # environment on first run with no rules and no branch policy, and
+    # repository secrets keep resolving inside a job that names an environment,
+    # so this line alone changes nothing about how a build runs. Same shape as
+    # release-desktop.yml in unslothai/unsloth.
+    environment: release-signing
     # Hang guard only. Without it the job inherits GitHub's 360-minute default,
     # which is above both assemble's `timeout-minutes: 350` and, more to the
     # point, the "Wait for the build matrix" step's own 330-minute deadline in

--- a/.github/workflows/unsloth-prebuilt-rocm.yml
+++ b/.github/workflows/unsloth-prebuilt-rocm.yml
@@ -477,6 +477,17 @@ jobs:
         Write-Host "Final build artifacts (including ROCm core files):"
         Get-ChildItem -Recurse | Format-Table Name, Length, LastWriteTime
 
+    # The build legs extract a source tarball rather than checking this repo
+    # out, so the signing action and its scripts are not on disk. Fetch just
+    # .github into a subdirectory: a checkout at the workspace root would
+    # clean the extracted source tree out from under the build.
+    - name: Fetch signing tooling
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
+      with:
+        path: signing-tooling
+        sparse-checkout: .github
+        persist-credentials: false
+
     # Authenticode-sign before packaging. The Studio installer downloads these
     # zips after its own signed installer has run, so nothing downstream signs
     # them. Smart App Control evaluates every binary as it loads and refuses
@@ -485,7 +496,7 @@ jobs:
     # the launcher executables.
     - name: Sign Windows binaries
       id: sign_windows
-      uses: ./.github/actions/sign-windows
+      uses: ./signing-tooling/.github/actions/sign-windows
       with:
         path: llama.cpp/build/bin
         azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -509,7 +520,7 @@ jobs:
     - name: Verify every binary in the bundle is signed
       if: ${{ steps.sign_windows.outputs.signed == 'true' }}
       shell: pwsh
-      run: .github/scripts/assert-windows-bundle-signed.ps1 -Path 'dist/app-${{ inputs.tag }}-windows-x64-rocm-${{ matrix.gfx_target }}.zip'
+      run: signing-tooling/.github/scripts/assert-windows-bundle-signed.ps1 -Path 'dist/app-${{ inputs.tag }}-windows-x64-rocm-${{ matrix.gfx_target }}.zip'
 
     - name: Upload bundle artifact
       uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0

--- a/.github/workflows/unsloth-prebuilt-rocm.yml
+++ b/.github/workflows/unsloth-prebuilt-rocm.yml
@@ -59,6 +59,23 @@ on:
         default: ''
         type: string
 
+    secrets:
+      AZURE_CLIENT_ID:
+        description: 'Azure Trusted Signing client id; empty on forks, which then build unsigned'
+        required: false
+      AZURE_CLIENT_SECRET:
+        description: 'Azure Trusted Signing client secret'
+        required: false
+      AZURE_TENANT_ID:
+        description: 'Azure Trusted Signing tenant id'
+        required: false
+      AZURE_TRUSTED_SIGNING_ACCOUNT_NAME:
+        description: 'Azure Trusted Signing account name'
+        required: false
+      AZURE_CERTIFICATE_PROFILE_NAME:
+        description: 'Azure Trusted Signing certificate profile name'
+        required: false
+
 permissions:
   contents: read
 
@@ -460,6 +477,23 @@ jobs:
         Write-Host "Final build artifacts (including ROCm core files):"
         Get-ChildItem -Recurse | Format-Table Name, Length, LastWriteTime
 
+    # Authenticode-sign before packaging. The Studio installer downloads these
+    # zips after its own signed installer has run, so nothing downstream signs
+    # them. Smart App Control evaluates every binary as it loads and refuses
+    # unknown unsigned code, naming whichever dependent DLL it blocked in a Bad
+    # Image dialog (status 0xc0e90002), so the whole tree is signed, not just
+    # the launcher executables.
+    - name: Sign Windows binaries
+      id: sign_windows
+      uses: ./.github/actions/sign-windows
+      with:
+        path: llama.cpp/build/bin
+        azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+        azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        azure-account: ${{ secrets.AZURE_TRUSTED_SIGNING_ACCOUNT_NAME }}
+        azure-certificate-profile: ${{ secrets.AZURE_CERTIFICATE_PROFILE_NAME }}
+
     - name: Package bundle (zip)
       shell: bash
       run: |
@@ -468,6 +502,14 @@ jobs:
         mkdir -p dist
         (cd llama.cpp/build/bin && 7z a -tzip "${GITHUB_WORKSPACE}/dist/${ASSET}" .)
         ls -la dist
+
+    # Verify the finished zip, not the build tree: packaging copies extra
+    # runtimes in afterwards, and only the archive shows what actually ships.
+    # Skipped on forks, which have no signing credentials and build unsigned.
+    - name: Verify every binary in the bundle is signed
+      if: ${{ steps.sign_windows.outputs.signed == 'true' }}
+      shell: pwsh
+      run: .github/scripts/assert-windows-bundle-signed.ps1 -Path 'dist/app-${{ inputs.tag }}-windows-x64-rocm-${{ matrix.gfx_target }}.zip'
 
     - name: Upload bundle artifact
       uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0

--- a/.github/workflows/unsloth-prebuilt-rocm.yml
+++ b/.github/workflows/unsloth-prebuilt-rocm.yml
@@ -83,6 +83,17 @@ jobs:
   build-windows:
     name: windows/${{ matrix.gfx_target }}
     runs-on: windows-2022
+    # Every Azure Trusted Signing secret in this workflow is read by this job
+    # and no other. Naming an environment is what makes them gateable: without
+    # it there is no place to hang a required reviewer, so anyone who can
+    # dispatch the parent workflow can sign under our identity.
+    #
+    # Inert until protection rules exist. GitHub creates a referenced-but-absent
+    # environment on first run with no rules and no branch policy, and
+    # repository secrets keep resolving inside a job that names an environment,
+    # so this line alone changes nothing about how a build runs. Same shape as
+    # release-desktop.yml in unslothai/unsloth.
+    environment: release-signing
     if: contains(inputs.operating_systems, 'windows')
     strategy:
       matrix: ${{ fromJson(inputs.matrix) }}

--- a/.github/workflows/unsloth-prebuilt-vulkan.yml
+++ b/.github/workflows/unsloth-prebuilt-vulkan.yml
@@ -280,6 +280,17 @@ jobs:
   build-windows:
     name: windows/x64
     runs-on: windows-2022
+    # Every Azure Trusted Signing secret in this workflow is read by this job
+    # and no other. Naming an environment is what makes them gateable: without
+    # it there is no place to hang a required reviewer, so anyone who can
+    # dispatch the parent workflow can sign under our identity.
+    #
+    # Inert until protection rules exist. GitHub creates a referenced-but-absent
+    # environment on first run with no rules and no branch policy, and
+    # repository secrets keep resolving inside a job that names an environment,
+    # so this line alone changes nothing about how a build runs. Same shape as
+    # release-desktop.yml in unslothai/unsloth.
+    environment: release-signing
     defaults:
       run:
         shell: pwsh

--- a/.github/workflows/unsloth-prebuilt-vulkan.yml
+++ b/.github/workflows/unsloth-prebuilt-vulkan.yml
@@ -382,6 +382,17 @@ jobs:
           }
           exit 0
 
+      # The build legs extract a source tarball rather than checking this repo
+      # out, so the signing action and its scripts are not on disk. Fetch just
+      # .github into a subdirectory: a checkout at the workspace root would
+      # clean the extracted source tree out from under the build.
+      - name: Fetch signing tooling
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
+        with:
+          path: signing-tooling
+          sparse-checkout: .github
+          persist-credentials: false
+
       # Authenticode-sign before packaging. The Studio installer downloads these
       # zips after its own signed installer has run, so nothing downstream signs
       # them. Smart App Control evaluates every binary as it loads and refuses
@@ -390,7 +401,7 @@ jobs:
       # the launcher executables.
       - name: Sign Windows binaries
         id: sign_windows
-        uses: ./.github/actions/sign-windows
+        uses: ./signing-tooling/.github/actions/sign-windows
         with:
           path: src/build/bin
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -415,7 +426,7 @@ jobs:
       - name: Verify every binary in the bundle is signed
         if: ${{ steps.sign_windows.outputs.signed == 'true' }}
         shell: pwsh
-        run: .github/scripts/assert-windows-bundle-signed.ps1 -Path 'dist/app-${{ inputs.tag }}-windows-x64-vulkan.zip'
+        run: signing-tooling/.github/scripts/assert-windows-bundle-signed.ps1 -Path 'dist/app-${{ inputs.tag }}-windows-x64-vulkan.zip'
 
       - name: Upload bundle artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0

--- a/.github/workflows/unsloth-prebuilt-vulkan.yml
+++ b/.github/workflows/unsloth-prebuilt-vulkan.yml
@@ -38,6 +38,23 @@ on:
         default: ''
         type: string
 
+    secrets:
+      AZURE_CLIENT_ID:
+        description: 'Azure Trusted Signing client id; empty on forks, which then build unsigned'
+        required: false
+      AZURE_CLIENT_SECRET:
+        description: 'Azure Trusted Signing client secret'
+        required: false
+      AZURE_TENANT_ID:
+        description: 'Azure Trusted Signing tenant id'
+        required: false
+      AZURE_TRUSTED_SIGNING_ACCOUNT_NAME:
+        description: 'Azure Trusted Signing account name'
+        required: false
+      AZURE_CERTIFICATE_PROFILE_NAME:
+        description: 'Azure Trusted Signing certificate profile name'
+        required: false
+
 permissions:
   contents: read
 
@@ -365,6 +382,23 @@ jobs:
           }
           exit 0
 
+      # Authenticode-sign before packaging. The Studio installer downloads these
+      # zips after its own signed installer has run, so nothing downstream signs
+      # them. Smart App Control evaluates every binary as it loads and refuses
+      # unknown unsigned code, naming whichever dependent DLL it blocked in a Bad
+      # Image dialog (status 0xc0e90002), so the whole tree is signed, not just
+      # the launcher executables.
+      - name: Sign Windows binaries
+        id: sign_windows
+        uses: ./.github/actions/sign-windows
+        with:
+          path: src/build/bin
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-account: ${{ secrets.AZURE_TRUSTED_SIGNING_ACCOUNT_NAME }}
+          azure-certificate-profile: ${{ secrets.AZURE_CERTIFICATE_PROFILE_NAME }}
+
       - name: Package bundle (zip)
         shell: bash
         run: |
@@ -374,6 +408,14 @@ jobs:
           mkdir -p dist
           (cd src/build/bin && 7z a -tzip "${GITHUB_WORKSPACE}/dist/${ASSET}" .)
           ls -la dist
+
+      # Verify the finished zip, not the build tree: packaging copies extra
+      # runtimes in afterwards, and only the archive shows what actually ships.
+      # Skipped on forks, which have no signing credentials and build unsigned.
+      - name: Verify every binary in the bundle is signed
+        if: ${{ steps.sign_windows.outputs.signed == 'true' }}
+        shell: pwsh
+        run: .github/scripts/assert-windows-bundle-signed.ps1 -Path 'dist/app-${{ inputs.tag }}-windows-x64-vulkan.zip'
 
       - name: Upload bundle artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -530,6 +530,7 @@ jobs:
       source_artifact: ${{ needs.resolve.outputs.source_artifact }}
       commit: ${{ needs.resolve.outputs.commit }}
       matrix: ${{ needs.resolve.outputs.win_cuda_matrix }}
+    secrets: inherit
 
   build-rocm:
     name: ROCm
@@ -544,6 +545,7 @@ jobs:
       operating_systems: ${{ github.event.inputs.operating_systems || 'windows,ubuntu' }}
       rocm_version: ${{ github.event.inputs.rocm_version || 'weekly' }}
       rocm_cutoff: ${{ needs.resolve.outputs.rocm_cutoff }}
+    secrets: inherit
 
   build-macos:
     name: macOS
@@ -565,6 +567,7 @@ jobs:
       tag: ${{ needs.resolve.outputs.tag }}
       repo: ${{ needs.resolve.outputs.repo }}
       source_artifact: ${{ needs.resolve.outputs.source_artifact }}
+    secrets: inherit
 
   build-vulkan:
     name: Vulkan
@@ -575,6 +578,7 @@ jobs:
       tag: ${{ needs.resolve.outputs.tag }}
       repo: ${{ needs.resolve.outputs.repo }}
       source_artifact: ${{ needs.resolve.outputs.source_artifact }}
+    secrets: inherit
 
   assemble:
     name: Assemble metadata + publish


### PR DESCRIPTION
## What this fixes

Every PE we ship in the Windows bundles is unsigned. Parsing the PE certificate tables of the published assets directly:

| bundle (`b10798-mix-659e406`) | PE files | signed |
| --- | --- | --- |
| `windows-x64-cuda12-legacy` | 47 | 0 |
| `windows-x64-cpu` | 52 | 1 |
| `windows-x64-cpu` (`b10715-mix-86bd2d3`) | 52 | 1 |

The single signature is `libomp140.x86_64.dll`, which Microsoft signed before we vendored it out of the Visual Studio redist tree. `llama-server.exe`, `llama-common.dll`, `llama.dll`, the `ggml` backends and the ROCm runtime DLLs have no certificate table at all. VirusTotal returns 404 for all of them, so they carry no prevalence either.

Smart App Control evaluates every binary as it loads, not just installers, and blocks unknown unsigned code. When it does, Windows shows a Bad Image dialog naming the dependent DLL it refused, with status `0xc0e90002` (`STATUS_SYSTEM_INTEGRITY_POLICY_VIOLATION`, CodeIntegrity event 3077). Users have reported exactly that against `llama-common.dll` under `~\.unsloth\llama.cpp\build\bin\Release`:

```
llama-server.exe - Bad Image
C:\Users\...\.unsloth\llama.cpp\build\bin\Release\llama-common.dll is either not
designed to run on Windows or it contains an error. ... Error status 0xc0e90002.
```

The block clears when Smart App Control is turned off and returns after a reboot, which is consistent with a per file hash reputation verdict being re-evaluated from a cleared cache.

The Studio installer downloads these bundles after its own signed installer has already run, so they sit outside that installer's Authenticode scope and nothing downstream signs them. The SHA-256 manifest proves the bytes arrived intact but establishes no trust.

Related history: unslothai/unsloth#6588 and unslothai/unsloth#6648 hit the same mechanism against unsigned ROCm DLLs, and #6648 recorded Smart App Control changing its verdict on a byte identical file.

## What changed

- `.github/actions/sign-windows` is a composite action that installs a digest pinned `trusted-signing-cli` and signs a build tree.
- `.github/scripts/sign-windows-tree.ps1` signs every `.exe`, `.dll`, `.pyd`, `.sys`, `.ocx`, `.cpl` and `.scr` under a directory. Signing is batched, since `trusted-signing-cli` accepts any number of trailing paths and authenticates to Azure once per invocation, so a bundle costs one round trip rather than one per file.
- `.github/scripts/assert-windows-bundle-signed.ps1` is the release gate. It verifies the finished zip rather than the build tree, because packaging copies extra runtimes in afterwards (the OpenMP DLL from the Visual Studio redist tree, the ROCm DLLs from the TheRock dist), and only the archive shows what actually ships.
- All four Windows legs (CPU, CUDA, Vulkan, ROCm) sign before packaging and verify after it. The parent workflow passes the signing secrets down with `secrets: inherit`.

Nothing about the build itself changes. No compiler flags, no toolchain, no DLL set.

## Secrets

Added at repository level on `unslothai/llama.cpp`, the same five names the desktop release uses:

```
AZURE_CLIENT_ID
AZURE_CLIENT_SECRET
AZURE_TENANT_ID
AZURE_TRUSTED_SIGNING_ACCOUNT_NAME
AZURE_CERTIFICATE_PROFILE_NAME
```

`TAURI_SIGNING_PRIVATE_KEY` is the updater's minisign key and is not needed here.

The Windows jobs name `environment: release-signing`, matching the build job in `release-desktop.yml`. That is inert today: the environment has no protection rules, and repository secrets resolve normally inside a job that names one, so nothing about a build changes. What it buys is a place to hang a required reviewer later. Without it, anyone who can dispatch the parent workflow can sign under our identity. Approval is per (run, environment), so one approval would cover all four Windows legs.

Forks have no credentials and keep building unsigned, so contributors are not blocked. On this repo a missing secret is a hard error instead. A skip that looks like a pass is how the desktop Defender scan went missing for five releases in unslothai/unsloth#8358.

## How to verify

Signature inventory of any bundle, from Windows:

```powershell
$ext = '.exe','.dll','.pyd','.sys','.ocx','.cpl','.scr'
Expand-Archive .\app-<tag>-windows-x64-cpu.zip -DestinationPath .\bundle
Get-ChildItem .\bundle -Recurse -File |
  Where-Object { $ext -contains $_.Extension.ToLowerInvariant() } |
  ForEach-Object {
    $s = Get-AuthenticodeSignature -LiteralPath $_.FullName
    [pscustomobject]@{
      Name    = $_.Name
      Status  = $s.Status
      Subject = $s.SignerCertificate.Subject
    }
  } | Sort-Object Status, Name | Format-Table -AutoSize
```

Today every row except `libomp140.*.dll` reports `NotSigned` or `UnknownError`. After this lands every row should report `Valid`.

The same check runs in CI as `assert-windows-bundle-signed.ps1`, which fails the job and annotates each offending file.

## What this does not prove

Signing removes the signature half of a Smart App Control verdict. It does not on its own guarantee a given build clears cloud reputation, and the evidence that reputation is what users are hitting is currently one screenshot rather than a controlled reproduction. Shipping roughly 850 unsigned, zero prevalence files per release is worth fixing regardless. A separate change adds a reproducible Windows probe that collects CodeIntegrity 3076/3077 events so the reputation half can be measured properly.
