### PR TITLE
Repin GLM-5-Next to the commit that merges cleanly

### DIFF
--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -23,7 +23,7 @@
     "https://github.com/unslothai/llama.cpp/pull/70/commits/883f2c9ba78f3847148454adf025da29385fff3e",
     "https://github.com/unslothai/llama.cpp/pull/61/commits/46cbf0e95786fe8f5b7c0e86d57aaf8f8eceea7f",
     "https://github.com/unslothai/llama.cpp/pull/95/commits/3db8cb5b2e9bf291057b9f19960e8601a162da81",
-    "https://github.com/ggml-org/llama.cpp/pull/27754/commits/629b50552801912b3e2078f9799e4d77213197d7",
+    "https://github.com/ggml-org/llama.cpp/pull/27754/commits/b9b8207fcfc2962093b9466df7af4ff29c2a81ef",
     "https://github.com/unslothai/llama.cpp/pull/137/commits/4e1865e34ec5f6ca39403215c89129c13731be70",
     "https://github.com/unslothai/llama.cpp/pull/158/commits/abfc45b9cb21eae4848cb82196e659f42c9a8341",
     "https://github.com/unslothai/llama.cpp/pull/157/commits/6c6da89266ba7839d825c9997782af4f4d26b81b",


### PR DESCRIPTION
Repin `ggml-org/llama.cpp#27754` (GLM-5-Next) from `629b5055` to `b9b8207f`.

## Why

The nightly has failed two nights running, `34063080108` (Sep 6) and `33994788048` (Sep 5), both in `Resolve tag`:

```
ggml-org/llama.cpp#27754 (629b50552801912b3e2078f9799e4d77213197d7) does not merge
cleanly onto b10825 + the PRs listed before it; reorder or drop it in
scripts/unsloth/pr-set.json
```

Nothing has published since, which now also blocks the Authenticode signing from #204 from ever reaching a release.

The error suggests reordering, but that cannot work here: I checked, and `629b5055` conflicts against a **bare `b10825` with no other pins applied at all**, producing the same two files. It is a base conflict, not an ordering one.

`additive_merge.py` was right to refuse. Both conflicts have a non-empty merge base, meaning each side edited an existing line, which the script never resolves by design:

```c
base:   if (arch == LLM_ARCH_DEEPSEEK4 || (arch == LLM_ARCH_DFLASH && ...)) {
ours:   ... || arch == LLM_ARCH_HY_V4) {
theirs: ... || arch == LLM_ARCH_GLM5NEXT || ...) {
```

In this instance the union is unambiguous: it is a boolean disjunction and each side added one architecture. That is a human call, not something the script should be taught to guess, so the fix belongs in the PR rather than in `additive_merge.py`.

## What changed upstream

`b9b8207f` ("Fix merge conflicts") merges current `master` into the PR branch with both conflicts resolved as the union. ggml-org/llama.cpp#27754 has gone from `CONFLICTING` to `MERGEABLE`.

One detail worth recording, because it is the part that was easy to get wrong: `llama-graph.cpp` has **two** call sites and they are not symmetric. The base carries `HY_V4` at the second site only, and the PR adds `GLM5NEXT` at both. So only the second site takes the union; the first merges automatically and correctly ends up with `GLM5NEXT` and no `HY_V4`. Propagating `HY_V4` to both to make them look consistent would have introduced behaviour the base never had.

## Verification

Against the resolved tree:

- `libllama.so` and `llama-common` build clean
- `test-llama-archs` builds and exits 0
- no conflict markers anywhere in the tree

Caveat, stated rather than glossed: my local replay of the full 13-pin set diverges from CI at `#25731` (I hit `AUTHORS` and `.github/workflows/*` conflicts that CI does not), so I have proven this fix against the base and against `master`, but **not** that the complete pin set now merges end to end. The first nightly after this merges is what settles that.

Upstream CI is running on `b9b8207f` now. Worth waiting for it to go green before merging this, since the pin is only as good as that commit.
