### PR TITLE
Repin DiffusionGemma to the commit that merges cleanly

### DIFF
--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -18,7 +18,7 @@
     "tag + pins), so keep its pin listed until the change lands upstream."
   ],
   "prs": [
-    "https://github.com/ggml-org/llama.cpp/pull/24423/commits/c6f8d604b67611b73f7965c0bd39d26e7365a489",
+    "https://github.com/ggml-org/llama.cpp/pull/24423/commits/168b21adfb36f740989284c9d73a5ccabf679e46",
     "https://github.com/ggml-org/llama.cpp/pull/25731/commits/36df1bf409c8b257689321a971a66973ee817ee1",
     "https://github.com/unslothai/llama.cpp/pull/70/commits/883f2c9ba78f3847148454adf025da29385fff3e",
     "https://github.com/unslothai/llama.cpp/pull/61/commits/46cbf0e95786fe8f5b7c0e86d57aaf8f8eceea7f",


### PR DESCRIPTION
Repin `ggml-org/llama.cpp#24423` (DiffusionGemma) from `c6f8d604` to `168b21ad`.

## Why

The publishing run `34108333979` failed in `Resolve tag`:

```
ggml-org/llama.cpp#24423 (c6f8d604b67611b73f7965c0bd39d26e7365a489) does not merge
cleanly onto b10830 + the PRs listed before it
```

Same shape as #205, different pin. The base moved from `b10825` to `b10830` and a
second pinned PR collided with the newer upstream tree, in the same file both times:
`tests/test-llama-archs.cpp`.

The conflict is one hunk, and `additive_merge.py` was right to refuse it, because the
base line already existed and both sides edited it:

```c
base:      COHERE2MOE || MIMO2 || STEP35 || MUSE_GLIMMER || GRANITE_SWA || DOTS3NOTE
ours:      ... || DIFFUSION_GEMMA          (plus the comment explaining why)
upstream:  ... || SPARK2_5
```

Union of the two additions, keeping the DIFFUSION_GEMMA comment. `168b21ad` is that
merge on the PR branch; ggml-org/llama.cpp#24423 has gone from `CONFLICTING` to
`MERGEABLE`.

## Every pin checked against the new base this time

Rather than fix one and rediscover the next on the following run, I merged all
thirteen pins onto `b10830` individually:

| pin | onto b10830 |
| --- | --- |
| `c6f8d604` #24423 | **refused** (fixed here) |
| `36df1bf4` #25731 | resolves additively |
| `b9b8207f` #27754 | clean (the #205 fix still holds on the newer base) |
| the other ten | clean |

So this should be the last blocker for the set.

## Verification

Against the resolved tree: `libllama.so` and `llama-common` build clean, and
`test-llama-archs` builds and exits 0.

## Note on the pattern

This is now twice in two days, both in `tests/test-llama-archs.cpp`, both "upstream
added an architecture to a list while one of our pinned PRs added its own". It will
recur every time the base advances past a pinned PR that touches that list. Worth
considering separately whether `additive_merge.py` should handle a disjunction or
comma list where the merge base is non-empty but each side only appended a distinct
term; I have deliberately not changed it here, because loosening a guard that
currently refuses to guess is a bigger decision than unblocking a release.
