### PR TITLE
Repin Inkling to the commit that compiles against the new base

### DIFF
--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -19,7 +19,7 @@
   ],
   "prs": [
     "https://github.com/ggml-org/llama.cpp/pull/24423/commits/168b21adfb36f740989284c9d73a5ccabf679e46",
-    "https://github.com/ggml-org/llama.cpp/pull/25731/commits/36df1bf409c8b257689321a971a66973ee817ee1",
+    "https://github.com/ggml-org/llama.cpp/pull/25731/commits/1066edc3a533b036f630750d9c2c74ca95ff397e",
     "https://github.com/unslothai/llama.cpp/pull/70/commits/883f2c9ba78f3847148454adf025da29385fff3e",
     "https://github.com/unslothai/llama.cpp/pull/61/commits/46cbf0e95786fe8f5b7c0e86d57aaf8f8eceea7f",
     "https://github.com/unslothai/llama.cpp/pull/95/commits/3db8cb5b2e9bf291057b9f19960e8601a162da81",


### PR DESCRIPTION
Repin `ggml-org/llama.cpp#25731` (TML Inkling) from `36df1bf4` to `1066edc3`.

## Why

Run `34108333979` got past every merge for the first time, then failed a later gate:

```
::error::the pinned PRs merged cleanly and the merged tree does not compile;
fix or drop the pin rather than letting the build matrix find this

src/llama-vocab.cpp:445:13: error: duplicate case value
  445 |   case LLAMA_VOCAB_PRE_TYPE_INKLING:
src/llama-vocab.cpp:321:13: note: previously used here
  321 |   case LLAMA_VOCAB_PRE_TYPE_HY_V4:
```

This one is more interesting than the previous two repins, because the merge was
clean and still wrong. Both sides appended to the same enum and both took slot 57:

```c
b10830:  LLAMA_VOCAB_PRE_TYPE_HY_V4    = 57,
         LLAMA_VOCAB_PRE_TYPE_SPARK2_5 = 58,
#25731:  LLAMA_VOCAB_PRE_TYPE_INKLING  = 57,
```

`additive_merge.py` did exactly what it says it does: the merge base was empty at
that point, both sides only added, so it kept both. That is a pure add/add by
content, and it is still a defect, because the two additions carry the same
explicit value. The union of two `case` arms that share a value does not compile.

Resolved by keeping upstream's numbering and moving ours: `INKLING = 59`. Upstream's
values are the ones in released builds, so ours is the one that should move. The
pre-type is resolved from the tokenizer string at load time and is not serialised
into the GGUF, so renumbering does not affect existing model files.

The same commit also takes the `llama-model.cpp` arm for `SPARK2_5` alongside ours
for `INKLING`, which is a genuine add/add.

## Verification

`libllama.so`, `llama-common` and `test-llama-archs` all build clean against the
merged tree, and `test-llama-archs` exits 0. That is the specific gate that failed
in CI, reproduced locally before pushing.

## Worth noting for the merge tooling

Three repins in a row now, all from the base advancing under pinned PRs:

| pin | symptom | why the tooling could not fix it |
| --- | --- | --- |
| #27754 | conflict in `test-llama-archs.cpp` | non-empty merge base, both sides edited a line |
| #24423 | conflict in `test-llama-archs.cpp` | same |
| #25731 | clean merge, broken build | pure add/add, but the two additions collide on a value |

The third is the one to take seriously: it shows a clean additive merge is not
sufficient evidence of correctness, and the compile gate is what caught it. That
gate is doing real work and should stay. I would not extend `additive_merge.py` to
understand enum numbering; the cheaper and more honest position is that the compile
check is the backstop, which is exactly how it behaved here.
