### PR TITLE
CI: warm ccache shards for the CUDA legs, redist toolkit install, prune to one generation under the 75 GB limit

### DIFF
--- a/.github/actions/unsloth-cuda-linux-setup/action.yml
+++ b/.github/actions/unsloth-cuda-linux-setup/action.yml
@@ -34,10 +34,7 @@ inputs:
 runs:
   using: composite
   steps:
-    # The parent's resolve job built the source tree (upstream base + any mix
-    # PRs, with the build number/commit and Unsloth fingerprint baked
-    # into cmake/build-info.cmake) and uploaded it as an artifact; extract it
-    # instead of cloning -- no .git needed, the build number is already baked.
+    # Source tree is resolve's app-source artifact, build number and fingerprint already baked in.
     - name: Download source @ ${{ inputs.tag }}
       uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6.0.0
       with:
@@ -69,16 +66,8 @@ runs:
           echo "CUDAHOSTCXX=g++-14"
         } >> "$GITHUB_ENV"
 
-    # The toolkit comes straight from NVIDIA's redist CDN for every CUDA line,
-    # the way the 13.3 leg has always done it: the component archives that
-    # the build actually uses, extracted into one prefix. Component versions
-    # are from NVIDIA's redistrib_<version>.json, chosen to match the compiler
-    # and runtime the previous install method produced (see below). Jimver/cuda-toolkit used to
-    # install 12.8.0 through apt and took 4.1 to 5.1 minutes per Linux job on
-    # run 34168016006 (7.3 to 7.7 on Windows) against 0.6 to 1.5 for the
-    # redist path; with a warm shard in front of every build that install
-    # sat on the critical path twice. Same nvcc bytes either way, so the
-    # content-hashed ccache entries carry over.
+    # Toolkit from NVIDIA's redist CDN (the 13.3 path, generalised): about 1 min per job against
+    # 4 to 5 for Jimver apt. Component versions match what Jimver produced, so ccache entries carry over.
     - name: Install CUDA toolkit ${{ inputs.cuda }} (NVIDIA redist)
       shell: bash
       run: |
@@ -88,13 +77,9 @@ runs:
           arm64) PLAT=linux-sbsa ;;
           *) echo "unsupported arch ${{ inputs.arch }}" >&2; exit 1 ;;
         esac
-        # The 12.8.0 profile maps to the 12.8.1 archives on Linux, on purpose:
-        # Jimver's apt path installed the cuda-toolkit-12-8 metapackage, which
-        # NVIDIA's repo serves at its newest patch, so every Linux CUDA 12 bundle
-        # to date was compiled by nvcc V12.8.93 and ships libcublas 12.8.4.1
-        # (run 34168016006 logs). Windows Jimver installed the 12.8.0 installer
-        # (V12.8.61, libcublas 12.8.3.14) and its action keeps that. The
-        # shipped bits must not change with the install method.
+        # 12.8.0 maps to the 12.8.1 archives on purpose: Jimver's apt metapackage served the
+        # newest patch, so every Linux CUDA 12 bundle was built by nvcc V12.8.93 with libcublas
+        # 12.8.4.1 (run 34168016006). Shipped bits must not change with the install method.
         case "${{ inputs.cuda }}" in
           12.8.0) COMPONENTS="cuda_cudart:12.8.90 cuda_nvcc:12.8.93 cuda_nvrtc:12.8.93 libcublas:12.8.4.1 cuda_nvtx:12.8.90 cuda_profiler_api:12.8.90 cuda_cccl:12.8.90" ;;
           13.3)   COMPONENTS="cuda_crt:13.3.33 cuda_cudart:13.3.29 cuda_nvcc:13.3.33 cuda_nvrtc:13.3.33 libcublas:13.5.1.27 libnvvm:13.3.33 cuda_nvtx:13.3.29 cuda_profiler_api:13.3.27 cccl:13.3.3.3.1" ;;
@@ -124,20 +109,9 @@ runs:
       shell: bash
       run: nvcc --version
 
-    # ccache 4.13 from the action's pinned binary on every OS (apt on
-    # ubuntu-22.04 ships 4.5.1). Restores the newest generation of this
-    # profile by prefix; the explicit actions/cache/save at the end of the
-    # calling job writes the next one. save: false here for that reason.
-    #
-    # Not sccache. Measured 2026-09-08 on this box for the b10830 -> b10840
-    # bump that cost run 34168016006 its 189 minute Windows portable leg:
-    # sccache's per-arch cicc/ptxas caching rebuilt in 710 s against ccache's
-    # 698 s (the PTX stage misses on every TU and that is where the time is),
-    # its warm rebuild took 111 s against 1 s (no direct mode), and the hoped
-    # for sharing of per-arch results between the older/newer/portable
-    # profiles is impossible for ggml: nvcc passes __CUDA_ARCH_LIST__ into
-    # every preprocess and ggml-cuda reads it, so 0% of cicc results carry
-    # across arch lists.
+    # ccache 4.13 from the action's binary (apt ships 4.5.1); save: false because the calling job
+    # saves under its own key. Not sccache: measured 2026-09-08, no faster on the churn rebuild,
+    # 111 s vs 1 s warm, and 0% per-arch sharing (nvcc passes __CUDA_ARCH_LIST__ into every preprocess).
     - name: ccache
       uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03  # v1.2.23
       with:
@@ -152,13 +126,8 @@ runs:
 
     - name: Configure ccache
       shell: bash
-      # compiler_check=content: the toolkit is re-extracted every run, so an
-      # mtime identity (the Linux default) can miss on a byte-identical nvcc.
-      # The timestamp sloppiness only relaxes ccache's same-second race guard,
-      # which a tarball-extracted source tree never needs; pch_defines and
-      # locale are the documented safe set. compression_level=6 trades a few
-      # seconds of zstd per miss for a smaller cache dir, so more objects fit
-      # under max_size and the actions/cache round trip moves fewer bytes.
+      # compiler_check=content: the toolkit is re-extracted every run, so mtime identity misses a
+      # byte-identical nvcc. Sloppiness is the documented safe set; level 6 fits more under max_size.
       run: |
         ccache --set-config=compiler_check=content
         ccache --set-config=sloppiness=include_file_mtime,include_file_ctime,pch_defines,locale
@@ -171,22 +140,11 @@ runs:
       working-directory: src
       run: |
         set -eux
-        # Three non-obvious flags:
-        #  - CMAKE_INSTALL_RPATH=$ORIGIN + RPATH knobs: the tar.gz layout
-        #    ships sibling .so files in the same directory as the binaries.
-        #  - CMAKE_CUDA_ARCHITECTURES: explicit per-profile arch list, the
-        #    whole point of the matrix.
-        #  - CMAKE_*_COMPILER_LAUNCHER=ccache: nvcc lives in the redist
-        #    prefix, not /usr/local/bin, so PATH-symlinked ccache misses CUDA
-        #    TUs -- setting the launcher explicitly caches nvcc too.
-        # No LLAMA_FATAL_WARNINGS on this leg, unlike cpu/vulkan/macos. Here it also
-        # sets nvcc -Werror all-warnings, and the host warnings arrive through an
-        # -Xcompiler list llama.cpp composes itself, which CMAKE_CXX_FLAGS does not
-        # reach -- verified on 08-27, where the suppression added that morning was
-        # absent from the actual nvcc command line. So the warning set here is
-        # all-or-nothing, and 'all' means every libstdc++ false positive fails a
-        # release: cuda13-newer and cuda13-portable both died on a GCC 11
-        # -Wstringop-overflow inside std::copy, from ggml_cuda_try_fuse.
+        # RPATH=$ORIGIN: sibling .so files ship next to the binaries. COMPILER_LAUNCHER set
+        # explicitly: nvcc lives in the redist prefix, so a PATH-symlinked ccache misses CUDA TUs.
+        # No LLAMA_FATAL_WARNINGS: it also sets nvcc -Werror all-warnings via an -Xcompiler list
+        # CMAKE_CXX_FLAGS cannot reach, so any libstdc++ false positive fails a release
+        # (cuda13-newer/portable died on GCC 11 -Wstringop-overflow in ggml_cuda_try_fuse).
         cmake -S . -B build -G Ninja \
           -DCMAKE_BUILD_TYPE=Release \
           -DGGML_NATIVE=OFF \

--- a/.github/actions/unsloth-cuda-linux-setup/action.yml
+++ b/.github/actions/unsloth-cuda-linux-setup/action.yml
@@ -1,0 +1,208 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+name: Unsloth CUDA build setup (Linux)
+description: >-
+  Source tree, CUDA toolkit, ccache and the CMake configure that the Linux
+  CUDA legs of unsloth-prebuilt-cuda.yml share. Both the `warm` shards and
+  the `build` job of a profile run exactly this, so every object they compile
+  hashes the same and the shards' ccache entries are hits for the build.
+
+inputs:
+  tag:
+    description: Upstream llama.cpp release tag (b#### or b####-mix-<hash>), resolved by the parent.
+    required: true
+  source_artifact:
+    description: Workflow artifact (app-source-*) holding the stamped source tree.
+    required: true
+  cuda:
+    description: CUDA toolkit version (12.8.0 or 13.3), installed from the NVIDIA redist CDN.
+    required: true
+  arch:
+    description: x64 or arm64.
+    required: true
+  archs:
+    description: Space-separated CMAKE_CUDA_ARCHITECTURES list for this profile.
+    required: true
+  profile:
+    description: Profile name (cuda12-portable ...), part of the ccache key.
+    required: true
+  max-size:
+    description: ccache max_size for this profile (portable holds the most objects).
+    required: false
+    default: 4G
+
+runs:
+  using: composite
+  steps:
+    # The parent's resolve job built the source tree (upstream base + any mix
+    # PRs, with the build number/commit and Unsloth fingerprint baked
+    # into cmake/build-info.cmake) and uploaded it as an artifact; extract it
+    # instead of cloning -- no .git needed, the build number is already baked.
+    - name: Download source @ ${{ inputs.tag }}
+      uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6.0.0
+      with:
+        name: ${{ inputs.source_artifact }}
+        path: srcpkg
+    - name: Extract source
+      shell: bash
+      run: |
+        set -eux
+        mkdir -p src
+        tar -xzf "srcpkg/llama.cpp-source-${{ inputs.tag }}.tar.gz" -C src --strip-components=1
+
+    - name: Install build dependencies
+      shell: bash
+      run: |
+        set -eux
+        sudo apt-get update
+        sudo apt-get install -y build-essential libssl-dev
+
+    - name: Install ARM64 host compiler (gcc-14)
+      if: inputs.arch == 'arm64'
+      shell: bash
+      run: |
+        set -eux
+        sudo apt-get install -y gcc-14 g++-14
+        {
+          echo "CC=gcc-14"
+          echo "CXX=g++-14"
+          echo "CUDAHOSTCXX=g++-14"
+        } >> "$GITHUB_ENV"
+
+    # The toolkit comes straight from NVIDIA's redist CDN for every CUDA line,
+    # the way the 13.3 leg has always done it: the component archives that
+    # the build actually uses, extracted into one prefix. Component versions
+    # are from NVIDIA's redistrib_<version>.json, chosen to match the compiler
+    # and runtime the previous install method produced (see below). Jimver/cuda-toolkit used to
+    # install 12.8.0 through apt and took 4.1 to 5.1 minutes per Linux job on
+    # run 34168016006 (7.3 to 7.7 on Windows) against 0.6 to 1.5 for the
+    # redist path; with a warm shard in front of every build that install
+    # sat on the critical path twice. Same nvcc bytes either way, so the
+    # content-hashed ccache entries carry over.
+    - name: Install CUDA toolkit ${{ inputs.cuda }} (NVIDIA redist)
+      shell: bash
+      run: |
+        set -eux
+        case "${{ inputs.arch }}" in
+          x64)   PLAT=linux-x86_64 ;;
+          arm64) PLAT=linux-sbsa ;;
+          *) echo "unsupported arch ${{ inputs.arch }}" >&2; exit 1 ;;
+        esac
+        # The 12.8.0 profile maps to the 12.8.1 archives on Linux, on purpose:
+        # Jimver's apt path installed the cuda-toolkit-12-8 metapackage, which
+        # NVIDIA's repo serves at its newest patch, so every Linux CUDA 12 bundle
+        # to date was compiled by nvcc V12.8.93 and ships libcublas 12.8.4.1
+        # (run 34168016006 logs). Windows Jimver installed the 12.8.0 installer
+        # (V12.8.61, libcublas 12.8.3.14) and its action keeps that. The
+        # shipped bits must not change with the install method.
+        case "${{ inputs.cuda }}" in
+          12.8.0) COMPONENTS="cuda_cudart:12.8.90 cuda_nvcc:12.8.93 cuda_nvrtc:12.8.93 libcublas:12.8.4.1 cuda_nvtx:12.8.90 cuda_profiler_api:12.8.90 cuda_cccl:12.8.90" ;;
+          13.3)   COMPONENTS="cuda_crt:13.3.33 cuda_cudart:13.3.29 cuda_nvcc:13.3.33 cuda_nvrtc:13.3.33 libcublas:13.5.1.27 libnvvm:13.3.33 cuda_nvtx:13.3.29 cuda_profiler_api:13.3.27 cccl:13.3.3.3.1" ;;
+          *) echo "no redist component table for CUDA ${{ inputs.cuda }}" >&2; exit 1 ;;
+        esac
+        PREFIX="$HOME/cuda-${{ inputs.cuda }}"
+        mkdir -p "$PREFIX"
+        BASE="https://developer.download.nvidia.com/compute/cuda/redist"
+        for cv in $COMPONENTS; do
+          comp="${cv%:*}"; ver="${cv#*:}"
+          name="${comp}-${PLAT}-${ver}-archive"
+          curl -fsSL --retry 3 -o comp.tar.xz "$BASE/${comp}/${PLAT}/${name}.tar.xz"
+          tar -xf comp.tar.xz
+          cp -a "${name}/." "$PREFIX"/
+          rm -rf comp.tar.xz "${name}"
+        done
+        # Redist ships libs under lib/; some CMake CUDA discovery expects lib64.
+        ln -sfn lib "$PREFIX/lib64"
+        {
+          echo "CUDA_PATH=$PREFIX"
+          echo "CUDA_HOME=$PREFIX"
+          echo "LD_LIBRARY_PATH=$PREFIX/lib:${LD_LIBRARY_PATH:-}"
+        } >> "$GITHUB_ENV"
+        echo "$PREFIX/bin" >> "$GITHUB_PATH"
+
+    - name: Verify CUDA
+      shell: bash
+      run: nvcc --version
+
+    # ccache 4.13 from the action's pinned binary on every OS (apt on
+    # ubuntu-22.04 ships 4.5.1). Restores the newest generation of this
+    # profile by prefix; the explicit actions/cache/save at the end of the
+    # calling job writes the next one. save: false here for that reason.
+    #
+    # Not sccache. Measured 2026-09-08 on this box for the b10830 -> b10840
+    # bump that cost run 34168016006 its 189 minute Windows portable leg:
+    # sccache's per-arch cicc/ptxas caching rebuilt in 710 s against ccache's
+    # 698 s (the PTX stage misses on every TU and that is where the time is),
+    # its warm rebuild took 111 s against 1 s (no direct mode), and the hoped
+    # for sharing of per-arch results between the older/newer/portable
+    # profiles is impossible for ggml: nvcc passes __CUDA_ARCH_LIST__ into
+    # every preprocess and ggml-cuda reads it, so 0% of cicc results carry
+    # across arch lists.
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03  # v1.2.23
+      with:
+        key: cuda-${{ inputs.cuda }}-${{ inputs.arch }}-${{ inputs.profile }}-${{ inputs.tag }}
+        restore-keys: |
+          cuda-${{ inputs.cuda }}-${{ inputs.arch }}-${{ inputs.profile }}
+        append-timestamp: false
+        variant: ccache
+        install: binary
+        max-size: ${{ inputs.max-size }}
+        save: false
+
+    - name: Configure ccache
+      shell: bash
+      # compiler_check=content: the toolkit is re-extracted every run, so an
+      # mtime identity (the Linux default) can miss on a byte-identical nvcc.
+      # The timestamp sloppiness only relaxes ccache's same-second race guard,
+      # which a tarball-extracted source tree never needs; pch_defines and
+      # locale are the documented safe set. compression_level=6 trades a few
+      # seconds of zstd per miss for a smaller cache dir, so more objects fit
+      # under max_size and the actions/cache round trip moves fewer bytes.
+      run: |
+        ccache --set-config=compiler_check=content
+        ccache --set-config=sloppiness=include_file_mtime,include_file_ctime,pch_defines,locale
+        ccache --set-config=compression_level=6
+        ccache -p | grep -E "compiler_check|sloppiness|compression|max_size|cache_dir"
+        ccache -z
+
+    - name: Configure
+      shell: bash
+      working-directory: src
+      run: |
+        set -eux
+        # Three non-obvious flags:
+        #  - CMAKE_INSTALL_RPATH=$ORIGIN + RPATH knobs: the tar.gz layout
+        #    ships sibling .so files in the same directory as the binaries.
+        #  - CMAKE_CUDA_ARCHITECTURES: explicit per-profile arch list, the
+        #    whole point of the matrix.
+        #  - CMAKE_*_COMPILER_LAUNCHER=ccache: nvcc lives in the redist
+        #    prefix, not /usr/local/bin, so PATH-symlinked ccache misses CUDA
+        #    TUs -- setting the launcher explicitly caches nvcc too.
+        # No LLAMA_FATAL_WARNINGS on this leg, unlike cpu/vulkan/macos. Here it also
+        # sets nvcc -Werror all-warnings, and the host warnings arrive through an
+        # -Xcompiler list llama.cpp composes itself, which CMAKE_CXX_FLAGS does not
+        # reach -- verified on 08-27, where the suppression added that morning was
+        # absent from the actual nvcc command line. So the warning set here is
+        # all-or-nothing, and 'all' means every libstdc++ false positive fails a
+        # release: cuda13-newer and cuda13-portable both died on a GCC 11
+        # -Wstringop-overflow inside std::copy, from ggml_cuda_try_fuse.
+        cmake -S . -B build -G Ninja \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DGGML_NATIVE=OFF \
+          -DGGML_BACKEND_DL=ON \
+          -DGGML_CPU_ALL_VARIANTS=ON \
+          -DGGML_RPC=ON \
+          -DGGML_CUDA=ON \
+          -DGGML_CUDA_CUB_3DOT2=ON \
+          -DLLAMA_BUILD_TESTS=OFF \
+          -DLLAMA_BUILD_EXAMPLES=OFF \
+          -DLLAMA_BUILD_TOOLS=ON \
+          -DLLAMA_BUILD_SERVER=ON \
+          -DCMAKE_CUDA_ARCHITECTURES="$(echo '${{ inputs.archs }}' | tr ' ' ';')" \
+          -DCMAKE_INSTALL_RPATH='$ORIGIN' \
+          -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
+          -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=OFF \
+          -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache

--- a/.github/actions/unsloth-cuda-windows-setup/action.yml
+++ b/.github/actions/unsloth-cuda-windows-setup/action.yml
@@ -32,20 +32,8 @@ inputs:
 runs:
   using: composite
   steps:
-    # Report both fixed volumes at job start. The work is split across two:
-    # the CUDA toolkit, the tool cache and Program Files land on C:, while
-    # GITHUB_WORKSPACE -- the source tree and the CMake build tree -- is on D:.
-    # A leg that dies mid-build can only be read against the volume it was
-    # writing to, so both are printed here and again after the toolkit install.
-    #
-    # No cleanup step, deliberately. One was written and then measured on a
-    # live windows-2022 runner: D: starts at 147.0 GB free of 150.0 and C: at
-    # 84.3 of 255.4, and the CUDA 12.8 toolkit is 4.79 GB, so C: never drops
-    # below about 106 GB. Reclaiming ~33 GB of preinstalled SDKs on every leg
-    # would have freed the volume that was not under pressure, on every
-    # release, forever. The 87-minute "runner lost communication" failure was
-    # not disk exhaustion, and unsloth-prebuilt-retry.yml already covers that
-    # class of infrastructure loss.
+    # No cleanup step: D: starts 147 GB free, C: 84 GB with a 4.8 GB toolkit; the 87-minute
+    # runner-loss failure was not disk exhaustion (unsloth-prebuilt-retry.yml covers it).
     - name: Report disk space
       shell: pwsh
       run: |
@@ -54,18 +42,9 @@ runs:
           "{0} {1:N1} GB free of {2:N1} GB" -f $_.DeviceID, ($_.FreeSpace / 1GB), ($_.Size / 1GB)
         }
 
-    # No Defender exclusion step. The same profile builds 1.6x slower here
-    # than on the Linux runner (189 vs 117 minutes on run 34168016006), and
-    # real-time scanning of the per-arch .ptx / .cubin / .ii cascade was the
-    # suspect, so it was A/B tested on windows-2022 (2026-09-08, cold
-    # ggml-cuda for two arches, -j 3): 1675 s with the scan on, 1764 s with
-    # Add-MpPreference -ExclusionPath on the workspace and RUNNER_TEMP. The
-    # compile is CPU bound in nvcc; the scan is not where the 1.6x goes.
+    # No Defender exclusion: A/B on windows-2022 showed no gain (1675 s scan on vs 1764 s excluded).
 
-    # The parent's resolve job built the source tree (upstream base + any mix
-    # PRs, with the build number/commit and Unsloth fingerprint baked
-    # into cmake/build-info.cmake) and uploaded it as an artifact; extract it
-    # instead of cloning -- no .git needed, the build number is already baked.
+    # Source tree is resolve's app-source artifact, build number and fingerprint already baked in.
     - name: Download source @ ${{ inputs.tag }}
       uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6.0.0
       with:
@@ -82,8 +61,7 @@ runs:
       with:
         python-version: "3.11"
 
-    # Ninja is on the windows-2022 image; choco was a network round trip per
-    # job for the same binary. Fails loudly if an image update drops it.
+    # Ninja is on the image; choco was a network round trip for the same binary.
     - name: Check Ninja
       shell: pwsh
       run: |
@@ -93,19 +71,8 @@ runs:
     - name: Setup MSVC
       uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756  # v1
 
-    # The toolkit comes straight from NVIDIA's redist CDN for every CUDA line,
-    # the way the 13.3 leg has always done it (block descended from
-    # ggml-org/llama.cpp .github/actions/windows-setup-cuda). Component
-    # versions are from NVIDIA's redistrib_<version>.json. Jimver/cuda-toolkit
-    # used to install 12.8.0 and took 7.3 to 7.7 minutes per Windows job on
-    # run 34168016006 against 0.8 to 1.0 for the redist path; with a warm
-    # shard in front of every build that install sat on the critical path
-    # twice. Same nvcc bytes either way, so the content-hashed ccache entries
-    # carry over: the 12.8.0 archives are the same nvcc V12.8.61 and libcublas
-    # 12.8.3.14 the Jimver installer put down (run 34168016006 logs), so the
-    # shipped bits do not change with the install method. (Linux maps 12.8.0
-    # to the 12.8.1 archives for the same reason; see that action.) bsdtar
-    # (tar.exe on the image) reads the zips, no choco.
+    # Toolkit from NVIDIA's redist CDN: about 1 min per job against 7 to 8 for Jimver. The 12.8.0
+    # archives are the same nvcc V12.8.61 and libcublas 12.8.3.14 Jimver installed, so shipped bits are unchanged.
     - name: Install CUDA toolkit ${{ inputs.cuda }} (NVIDIA redist)
       shell: pwsh
       run: |
@@ -141,8 +108,6 @@ runs:
       shell: pwsh
       run: nvcc --version
 
-    # Headroom going into the build, with the toolkit on C: and the build tree
-    # on D:. First numbers to read if a leg dies mid-build.
     - name: Report disk space before build
       shell: pwsh
       run: |
@@ -165,8 +130,6 @@ runs:
 
     - name: Configure ccache
       shell: pwsh
-      # Same policy as the Linux action; the action already sets
-      # compiler_check=content on Windows, repeated here so the two agree.
       run: |
         ccache --set-config=compiler_check=content
         ccache --set-config=sloppiness=include_file_mtime,include_file_ctime,pch_defines,locale
@@ -178,9 +141,7 @@ runs:
       shell: pwsh
       working-directory: src
       run: |
-        # CMAKE_CUDA_ARCHITECTURES is the explicit per-profile arch list (the
-        # whole point of the matrix). ccache launchers cache nvcc + cl.exe;
-        # no RPATH knobs -- Windows loads sibling DLLs from the binary's dir.
+        # Launchers cache nvcc and cl.exe; no RPATH knobs, Windows loads sibling DLLs from the binary's dir.
         $archs = "${{ inputs.archs }}".Replace(' ', ';')
         cmake -S . -B build -G Ninja `
           -DCMAKE_BUILD_TYPE=Release `

--- a/.github/actions/unsloth-cuda-windows-setup/action.yml
+++ b/.github/actions/unsloth-cuda-windows-setup/action.yml
@@ -1,0 +1,202 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+name: Unsloth CUDA build setup (Windows)
+description: >-
+  Source tree, MSVC + Ninja, CUDA toolkit, ccache and the CMake configure
+  that the CUDA Windows legs of unsloth-prebuilt-cuda-windows.yml share. Both
+  the `warm` shards and the `build` job of a profile run exactly this, so
+  every object they compile hashes the same and the shards' ccache entries
+  are hits for the build. Mirrors unsloth-cuda-linux-setup.
+
+inputs:
+  tag:
+    description: Upstream llama.cpp release tag (b#### or b####-mix-<hash>), resolved by the parent.
+    required: true
+  source_artifact:
+    description: Workflow artifact (app-source-*) holding the stamped source tree.
+    required: true
+  cuda:
+    description: CUDA toolkit version (12.8.0 or 13.3), installed from the NVIDIA redist CDN.
+    required: true
+  archs:
+    description: Space-separated CMAKE_CUDA_ARCHITECTURES list for this profile.
+    required: true
+  profile:
+    description: Profile name (cuda12-portable ...), part of the ccache key.
+    required: true
+  max-size:
+    description: ccache max_size for this profile (portable holds the most objects).
+    required: false
+    default: 4G
+
+runs:
+  using: composite
+  steps:
+    # Report both fixed volumes at job start. The work is split across two:
+    # the CUDA toolkit, the tool cache and Program Files land on C:, while
+    # GITHUB_WORKSPACE -- the source tree and the CMake build tree -- is on D:.
+    # A leg that dies mid-build can only be read against the volume it was
+    # writing to, so both are printed here and again after the toolkit install.
+    #
+    # No cleanup step, deliberately. One was written and then measured on a
+    # live windows-2022 runner: D: starts at 147.0 GB free of 150.0 and C: at
+    # 84.3 of 255.4, and the CUDA 12.8 toolkit is 4.79 GB, so C: never drops
+    # below about 106 GB. Reclaiming ~33 GB of preinstalled SDKs on every leg
+    # would have freed the volume that was not under pressure, on every
+    # release, forever. The 87-minute "runner lost communication" failure was
+    # not disk exhaustion, and unsloth-prebuilt-retry.yml already covers that
+    # class of infrastructure loss.
+    - name: Report disk space
+      shell: pwsh
+      run: |
+        "workspace: $env:GITHUB_WORKSPACE"
+        Get-CimInstance Win32_LogicalDisk -Filter 'DriveType = 3' | Sort-Object DeviceID | ForEach-Object {
+          "{0} {1:N1} GB free of {2:N1} GB" -f $_.DeviceID, ($_.FreeSpace / 1GB), ($_.Size / 1GB)
+        }
+
+    # No Defender exclusion step. The same profile builds 1.6x slower here
+    # than on the Linux runner (189 vs 117 minutes on run 34168016006), and
+    # real-time scanning of the per-arch .ptx / .cubin / .ii cascade was the
+    # suspect, so it was A/B tested on windows-2022 (2026-09-08, cold
+    # ggml-cuda for two arches, -j 3): 1675 s with the scan on, 1764 s with
+    # Add-MpPreference -ExclusionPath on the workspace and RUNNER_TEMP. The
+    # compile is CPU bound in nvcc; the scan is not where the 1.6x goes.
+
+    # The parent's resolve job built the source tree (upstream base + any mix
+    # PRs, with the build number/commit and Unsloth fingerprint baked
+    # into cmake/build-info.cmake) and uploaded it as an artifact; extract it
+    # instead of cloning -- no .git needed, the build number is already baked.
+    - name: Download source @ ${{ inputs.tag }}
+      uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6.0.0
+      with:
+        name: ${{ inputs.source_artifact }}
+        path: srcpkg
+    - name: Extract source
+      shell: bash
+      run: |
+        set -eux
+        mkdir -p src
+        tar -xzf "srcpkg/llama.cpp-source-${{ inputs.tag }}.tar.gz" -C src --strip-components=1
+
+    - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+      with:
+        python-version: "3.11"
+
+    # Ninja is on the windows-2022 image; choco was a network round trip per
+    # job for the same binary. Fails loudly if an image update drops it.
+    - name: Check Ninja
+      shell: pwsh
+      run: |
+        (Get-Command ninja.exe -ErrorAction Stop).Source
+        ninja --version
+
+    - name: Setup MSVC
+      uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756  # v1
+
+    # The toolkit comes straight from NVIDIA's redist CDN for every CUDA line,
+    # the way the 13.3 leg has always done it (block descended from
+    # ggml-org/llama.cpp .github/actions/windows-setup-cuda). Component
+    # versions are from NVIDIA's redistrib_<version>.json. Jimver/cuda-toolkit
+    # used to install 12.8.0 and took 7.3 to 7.7 minutes per Windows job on
+    # run 34168016006 against 0.8 to 1.0 for the redist path; with a warm
+    # shard in front of every build that install sat on the critical path
+    # twice. Same nvcc bytes either way, so the content-hashed ccache entries
+    # carry over: the 12.8.0 archives are the same nvcc V12.8.61 and libcublas
+    # 12.8.3.14 the Jimver installer put down (run 34168016006 logs), so the
+    # shipped bits do not change with the install method. (Linux maps 12.8.0
+    # to the 12.8.1 archives for the same reason; see that action.) bsdtar
+    # (tar.exe on the image) reads the zips, no choco.
+    - name: Install CUDA toolkit ${{ inputs.cuda }} (NVIDIA redist)
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        switch ("${{ inputs.cuda }}") {
+          '12.8.0' { $components = @('cuda_cudart:12.8.57', 'cuda_nvcc:12.8.61', 'cuda_nvrtc:12.8.61', 'libcublas:12.8.3.14', 'cuda_nvtx:12.8.55', 'cuda_profiler_api:12.8.55', 'cuda_cccl:12.8.55', 'visual_studio_integration:12.8.55') }
+          '13.3'   { $components = @('cuda_crt:13.3.33', 'cuda_cudart:13.3.29', 'cuda_nvcc:13.3.33', 'cuda_nvrtc:13.3.33', 'libcublas:13.5.1.27', 'libnvvm:13.3.33', 'cuda_nvtx:13.3.29', 'cuda_profiler_api:13.3.27', 'cccl:13.3.3.3.1', 'visual_studio_integration:13.3.27') }
+          default  { throw "no redist component table for CUDA ${{ inputs.cuda }}" }
+        }
+        $line = "${{ inputs.cuda }}" -replace '^(\d+\.\d+).*$', '$1'
+        $prefix = "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v$line"
+        $stage = Join-Path $env:RUNNER_TEMP 'cuda-redist'
+        New-Item -ItemType Directory -Force -Path $prefix, $stage | Out-Null
+        foreach ($cv in $components) {
+          $comp, $ver = $cv.Split(':')
+          $name = "$comp-windows-x86_64-$ver-archive"
+          $zip = Join-Path $stage "$name.zip"
+          curl.exe -fsSL --retry 3 -o $zip "https://developer.download.nvidia.com/compute/cuda/redist/$comp/windows-x86_64/$name.zip"
+          if ($LASTEXITCODE -ne 0) { throw "download failed: $name" }
+          tar.exe -xf $zip -C $stage
+          if ($LASTEXITCODE -ne 0) { throw "extract failed: $name" }
+          robocopy (Join-Path $stage $name) $prefix /E /NFL /NDL /NJH /NJS /NP | Out-Null
+          if ($LASTEXITCODE -ge 8) { throw "copy failed: $name ($LASTEXITCODE)" }
+          Remove-Item -Recurse -Force $zip, (Join-Path $stage $name)
+        }
+        "$prefix\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        "CUDA_PATH=$prefix" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        "CUDA_HOME=$prefix" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        "CUDA_PATH_V$($line.Replace('.', '_'))=$prefix" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        exit 0
+
+    - name: Verify CUDA
+      shell: pwsh
+      run: nvcc --version
+
+    # Headroom going into the build, with the toolkit on C: and the build tree
+    # on D:. First numbers to read if a leg dies mid-build.
+    - name: Report disk space before build
+      shell: pwsh
+      run: |
+        "workspace: $env:GITHUB_WORKSPACE"
+        Get-CimInstance Win32_LogicalDisk -Filter 'DriveType = 3' | Sort-Object DeviceID | ForEach-Object {
+          "{0} {1:N1} GB free of {2:N1} GB" -f $_.DeviceID, ($_.FreeSpace / 1GB), ($_.Size / 1GB)
+        }
+
+    # See unsloth-cuda-linux-setup for the ccache setup and why not sccache.
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03  # v1.2.23
+      with:
+        key: cuda-${{ inputs.cuda }}-windows-${{ inputs.profile }}-${{ inputs.tag }}
+        restore-keys: |
+          cuda-${{ inputs.cuda }}-windows-${{ inputs.profile }}
+        append-timestamp: false
+        variant: ccache
+        max-size: ${{ inputs.max-size }}
+        save: false
+
+    - name: Configure ccache
+      shell: pwsh
+      # Same policy as the Linux action; the action already sets
+      # compiler_check=content on Windows, repeated here so the two agree.
+      run: |
+        ccache --set-config=compiler_check=content
+        ccache --set-config=sloppiness=include_file_mtime,include_file_ctime,pch_defines,locale
+        ccache --set-config=compression_level=6
+        ccache -p | Select-String -Pattern "compiler_check|sloppiness|compression|max_size|cache_dir"
+        ccache -z
+
+    - name: Configure
+      shell: pwsh
+      working-directory: src
+      run: |
+        # CMAKE_CUDA_ARCHITECTURES is the explicit per-profile arch list (the
+        # whole point of the matrix). ccache launchers cache nvcc + cl.exe;
+        # no RPATH knobs -- Windows loads sibling DLLs from the binary's dir.
+        $archs = "${{ inputs.archs }}".Replace(' ', ';')
+        cmake -S . -B build -G Ninja `
+          -DCMAKE_BUILD_TYPE=Release `
+          -DGGML_NATIVE=OFF `
+          -DGGML_BACKEND_DL=ON `
+          -DGGML_CPU_ALL_VARIANTS=ON `
+          -DGGML_RPC=ON `
+          -DGGML_CUDA=ON `
+          -DGGML_CUDA_CUB_3DOT2=ON `
+          -DLLAMA_BUILD_TESTS=OFF `
+          -DLLAMA_BUILD_EXAMPLES=OFF `
+          -DLLAMA_BUILD_TOOLS=ON `
+          -DLLAMA_BUILD_SERVER=ON `
+          -DLLAMA_BUILD_BORINGSSL=ON `
+          -DCMAKE_CUDA_ARCHITECTURES="$archs" `
+          -DCMAKE_C_COMPILER_LAUNCHER=ccache `
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache `
+          -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/.github/workflows/unsloth-prebuilt-cpu.yml
+++ b/.github/workflows/unsloth-prebuilt-cpu.yml
@@ -120,20 +120,14 @@ jobs:
             cpu-linux-${{ matrix.arch }}
           append-timestamp: false
           variant: ccache
-          # apt on ubuntu-22.04 ships ccache 4.5.1; the binary the action pins is
-          # 4.13, the same one the Windows legs already run.
+          # ccache 4.13 from the action's binary; apt on ubuntu-22.04 ships 4.5.1.
           install: binary
           max-size: 2G
           save: false
 
       - name: Configure ccache
-        # compiler_check=content: the toolchain is reinstalled on every run, so an
-        # mtime identity (the Linux default) can miss on a byte-identical compiler.
-        # The timestamp sloppiness only relaxes ccache's same-second race guard,
-        # which a tarball-extracted source tree never needs; pch_defines and locale
-        # are the documented safe set. compression_level=6 trades a few seconds of
-        # zstd per miss for a smaller cache dir, so more objects fit under max-size
-        # and the actions/cache round trip moves fewer bytes.
+        # compiler_check=content: the toolchain is reinstalled every run, so mtime identity misses a
+        # byte-identical compiler. Sloppiness is the documented safe set; level 6 fits more under max-size.
         run: |
           ccache --set-config=compiler_check=content
           ccache --set-config=sloppiness=include_file_mtime,include_file_ctime,pch_defines,locale
@@ -304,13 +298,8 @@ jobs:
           save: false
 
       - name: Configure ccache
-        # compiler_check=content: the toolchain is reinstalled on every run, so an
-        # mtime identity (the Linux default) can miss on a byte-identical compiler.
-        # The timestamp sloppiness only relaxes ccache's same-second race guard,
-        # which a tarball-extracted source tree never needs; pch_defines and locale
-        # are the documented safe set. compression_level=6 trades a few seconds of
-        # zstd per miss for a smaller cache dir, so more objects fit under max-size
-        # and the actions/cache round trip moves fewer bytes.
+        # compiler_check=content: the toolchain is reinstalled every run, so mtime identity misses a
+        # byte-identical compiler. Sloppiness is the documented safe set; level 6 fits more under max-size.
         run: |
           ccache --set-config=compiler_check=content
           ccache --set-config=sloppiness=include_file_mtime,include_file_ctime,pch_defines,locale

--- a/.github/workflows/unsloth-prebuilt-cpu.yml
+++ b/.github/workflows/unsloth-prebuilt-cpu.yml
@@ -120,8 +120,24 @@ jobs:
             cpu-linux-${{ matrix.arch }}
           append-timestamp: false
           variant: ccache
+          # apt on ubuntu-22.04 ships ccache 4.5.1; the binary the action pins is
+          # 4.13, the same one the Windows legs already run.
+          install: binary
           max-size: 2G
           save: false
+
+      - name: Configure ccache
+        # compiler_check=content: the toolchain is reinstalled on every run, so an
+        # mtime identity (the Linux default) can miss on a byte-identical compiler.
+        # The timestamp sloppiness only relaxes ccache's same-second race guard,
+        # which a tarball-extracted source tree never needs; pch_defines and locale
+        # are the documented safe set. compression_level=6 trades a few seconds of
+        # zstd per miss for a smaller cache dir, so more objects fit under max-size
+        # and the actions/cache round trip moves fewer bytes.
+        run: |
+          ccache --set-config=compiler_check=content
+          ccache --set-config=sloppiness=include_file_mtime,include_file_ctime,pch_defines,locale
+          ccache --set-config=compression_level=6
 
       - name: Configure
         working-directory: src
@@ -214,7 +230,7 @@ jobs:
         # it, and a 2 GB cache is not quick to write.
         if: ${{ !cancelled() }}
         continue-on-error: true
-        run: ccache --evict-older-than 14d
+        run: ccache --evict-older-than 7d
 
       - name: Save ccache
         # Save even when the build failed: the objects compiled before the
@@ -230,7 +246,7 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ${{ github.workspace }}/.ccache
-          key: ccache-cpu-linux-${{ matrix.arch }}-${{ inputs.tag }}-
+          key: ccache-cpu-linux-${{ matrix.arch }}-${{ inputs.tag }}-${{ github.run_id }}-${{ github.run_attempt }}
 
   build-windows:
     name: windows/${{ matrix.arch }}
@@ -286,6 +302,19 @@ jobs:
           variant: ccache
           max-size: 2G
           save: false
+
+      - name: Configure ccache
+        # compiler_check=content: the toolchain is reinstalled on every run, so an
+        # mtime identity (the Linux default) can miss on a byte-identical compiler.
+        # The timestamp sloppiness only relaxes ccache's same-second race guard,
+        # which a tarball-extracted source tree never needs; pch_defines and locale
+        # are the documented safe set. compression_level=6 trades a few seconds of
+        # zstd per miss for a smaller cache dir, so more objects fit under max-size
+        # and the actions/cache round trip moves fewer bytes.
+        run: |
+          ccache --set-config=compiler_check=content
+          ccache --set-config=sloppiness=include_file_mtime,include_file_ctime,pch_defines,locale
+          ccache --set-config=compression_level=6
 
       - name: Install Ninja
         run: choco install ninja --no-progress
@@ -421,7 +450,7 @@ jobs:
         # it, and a 2 GB cache is not quick to write.
         if: ${{ !cancelled() }}
         continue-on-error: true
-        run: ccache --evict-older-than 14d
+        run: ccache --evict-older-than 7d
 
       - name: Save ccache
         # Save even when the build failed: the objects compiled before the
@@ -437,4 +466,4 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ${{ github.workspace }}\.ccache
-          key: ccache-cpu-windows-${{ matrix.arch }}-${{ inputs.tag }}-
+          key: ccache-cpu-windows-${{ matrix.arch }}-${{ inputs.tag }}-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/unsloth-prebuilt-cuda-windows.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda-windows.yml
@@ -46,11 +46,6 @@ on:
         required: false
         default: ''
         type: string
-      warm_only:
-        description: 'Run the warm shards only and save their deltas; skip the build job (daytime cache warming)'
-        required: false
-        default: false
-        type: boolean
 
     secrets:
       AZURE_CLIENT_ID:
@@ -105,9 +100,10 @@ jobs:
           max-size: ${{ matrix.klass == 'portable' && '4G' || '3G' }}
 
       # The shards restore the previous shard deltas too (any tag: the
-      # restore-keys fall back to a tagless prefix), so a daytime warm-only run
-      # leaves deltas the nightly's shards hit on, and each shard compiles only
-      # what changed since the newest delta, not since the last generation.
+      # restore-keys fall back to a tagless prefix), so a retry of the same
+      # tag, or a night whose base bump left some objects untouched, compiles
+      # only what changed since the newest delta, not since the last
+      # generation.
       - name: Restore warm shard 0
         if: ${{ matrix.shards >= 1 }}
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
@@ -223,7 +219,7 @@ jobs:
     name: x64/${{ matrix.profile }}
     # See the Linux child: shards are best effort, only a cancelled run stops here.
     needs: warm
-    if: ${{ !cancelled() && !inputs.warm_only }}
+    if: ${{ !cancelled() }}
     runs-on: ${{ matrix.runner }}
     # Every Azure Trusted Signing secret in this workflow is read by this job
     # and no other. Naming an environment is what makes them gateable: without

--- a/.github/workflows/unsloth-prebuilt-cuda-windows.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda-windows.yml
@@ -159,12 +159,18 @@ jobs:
           ccache -z
           exit 0
 
-      # See the Linux child: the export below ships only what the compile adds.
-      - name: Stamp the restored cache
+      # See the Linux child: path + size for every file, a hash for the
+      # manifests, so the export ships only what the compile changed.
+      - name: Snapshot the restored cache
         run: |
-          Start-Sleep -Seconds 1
-          New-Item -ItemType File -Force -Path shard.stamp | Out-Null
-          Start-Sleep -Seconds 1
+          $src = "${{ github.workspace }}\.ccache"
+          $snap = @{}
+          Get-ChildItem -LiteralPath $src -Recurse -File | ForEach-Object {
+            $rel = $_.FullName.Substring($src.Length + 1)
+            $snap[$rel] = if ($_.Name.EndsWith('M')) { (Get-FileHash -LiteralPath $_.FullName -Algorithm SHA256).Hash } else { [string]$_.Length }
+          }
+          $snap | ConvertTo-Json -Compress | Set-Content -LiteralPath "${{ github.workspace }}\shard.before.json"
+          "$($snap.Count) files snapshotted"
 
       - name: Compile shard ${{ matrix.shard }} of ${{ matrix.shards }}
         working-directory: src
@@ -190,11 +196,14 @@ jobs:
         run: |
           $src = "${{ github.workspace }}\.ccache"
           $dst = "${{ github.workspace }}\shards\${{ matrix.shard }}"
-          $stamp = (Get-Item "${{ github.workspace }}\shard.stamp").LastWriteTimeUtc
+          $before = @{}
+          (Get-Content -LiteralPath "${{ github.workspace }}\shard.before.json" -Raw | ConvertFrom-Json).PSObject.Properties | ForEach-Object { $before[$_.Name] = $_.Value }
           New-Item -ItemType Directory -Force -Path $dst | Out-Null
           $n = 0; $bytes = 0
-          Get-ChildItem -LiteralPath $src -Recurse -File | Where-Object { $_.LastWriteTimeUtc -gt $stamp } | ForEach-Object {
+          Get-ChildItem -LiteralPath $src -Recurse -File | ForEach-Object {
             $rel = $_.FullName.Substring($src.Length + 1)
+            $now = if ($_.Name.EndsWith('M')) { (Get-FileHash -LiteralPath $_.FullName -Algorithm SHA256).Hash } else { [string]$_.Length }
+            if ($before.ContainsKey($rel) -and $before[$rel] -eq $now) { return }
             $to = Join-Path $dst $rel
             New-Item -ItemType Directory -Force -Path (Split-Path -Parent $to) | Out-Null
             Copy-Item -LiteralPath $_.FullName -Destination $to

--- a/.github/workflows/unsloth-prebuilt-cuda-windows.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda-windows.yml
@@ -135,6 +135,15 @@ jobs:
           restore-keys: |
             ccache-shard2-cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-${{ inputs.tag }}-
             ccache-shard2-cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-
+      - name: Restore warm shard 3
+        if: ${{ matrix.shards >= 4 }}
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: shards/3
+          key: ccache-shard3-cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-${{ inputs.tag }}-
+          restore-keys: |
+            ccache-shard3-cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-${{ inputs.tag }}-
+            ccache-shard3-cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-
 
       - name: Merge warm shards into the ccache
         if: ${{ matrix.shards >= 1 }}
@@ -288,6 +297,15 @@ jobs:
           restore-keys: |
             ccache-shard2-cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-${{ inputs.tag }}-
             ccache-shard2-cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-
+      - name: Restore warm shard 3
+        if: ${{ matrix.shards >= 4 }}
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: shards/3
+          key: ccache-shard3-cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-${{ inputs.tag }}-
+          restore-keys: |
+            ccache-shard3-cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-${{ inputs.tag }}-
+            ccache-shard3-cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-
 
       - name: Merge warm shards into the ccache
         if: ${{ matrix.shards >= 1 }}

--- a/.github/workflows/unsloth-prebuilt-cuda-windows.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda-windows.yml
@@ -11,6 +11,10 @@ name: "Unsloth prebuilt: CUDA Windows"
 # toolchain, BoringSSL instead of system OpenSSL, no RPATH (Windows resolves
 # DLLs from the executable's directory), and a .zip archive. CUDA compiles
 # entirely in software here -- no GPU is present on the runner.
+#
+# Same two-job shape as the Linux child (warm shards through ccache, unioned
+# into the build job's cache); see its header and
+# .github/actions/unsloth-cuda-windows-setup.
 
 on:
   workflow_call:
@@ -34,8 +38,13 @@ on:
         default: ''
         type: string
       matrix:
-        description: 'Matrix JSON {include:[...]} produced by the parent resolve job'
+        description: 'Matrix JSON {include:[...]} produced by the parent resolve job; each row carries `shards`'
         required: true
+        type: string
+      warm_matrix:
+        description: 'Matrix JSON {include:[...]} of (profile row x shard) for the warm job, or empty to skip warming'
+        required: false
+        default: ''
         type: string
 
     secrets:
@@ -59,8 +68,93 @@ permissions:
   contents: read
 
 jobs:
+  warm:
+    name: warm x64/${{ matrix.profile }} ${{ matrix.shard }}/${{ matrix.shards }}
+    # See the Linux child for why an empty string and not an empty include.
+    if: ${{ inputs.warm_matrix != '' }}
+    runs-on: ${{ matrix.runner }}
+    # Best effort; the parent's waiter excludes ` / warm ` jobs from its
+    # all-legs-green check. No signing environment: shards ship nothing.
+    continue-on-error: true
+    timeout-minutes: 150
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(inputs.warm_matrix) }}
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - name: Checkout build tooling (this repo)
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
+        with:
+          path: tooling
+
+      - name: Source, toolkit, ccache, configure
+        uses: ./tooling/.github/actions/unsloth-cuda-windows-setup
+        with:
+          tag: ${{ inputs.tag }}
+          source_artifact: ${{ inputs.source_artifact }}
+          cuda: ${{ matrix.cuda }}
+          archs: ${{ matrix.archs }}
+          profile: ${{ matrix.profile }}
+          max-size: ${{ matrix.klass == 'portable' && '4G' || '3G' }}
+
+      # See the Linux child: the export below ships only what the compile adds.
+      - name: Stamp the restored cache
+        run: |
+          Start-Sleep -Seconds 1
+          New-Item -ItemType File -Force -Path shard.stamp | Out-Null
+          Start-Sleep -Seconds 1
+
+      - name: Compile shard ${{ matrix.shard }} of ${{ matrix.shards }}
+        working-directory: src
+        shell: bash
+        run: |
+          set -euo pipefail
+          # See the Linux child: every ggml-cuda object, stable order, dealt
+          # round-robin across the shards.
+          ninja -C build -t targets all \
+            | grep -E 'ggml-cuda\.dir[/\\].*\.cu\.obj:' | cut -d: -f1 | sort \
+            | awk -v s="${{ matrix.shard }}" -v k="${{ matrix.shards }}" 'NR % k == s' > shard.txt
+          echo "$(wc -l < shard.txt) CUDA objects in this shard"
+          xargs -a shard.txt ninja -C build -j 3
+
+      - name: ccache stats
+        if: ${{ always() }}
+        run: ccache -s -v
+
+      # See the Linux child: only the files this job added or rewrote, tree
+      # layout preserved.
+      - name: Export the shard delta
+        if: ${{ always() }}
+        run: |
+          $src = "${{ github.workspace }}\.ccache"
+          $dst = "${{ github.workspace }}\shards\${{ matrix.shard }}"
+          $stamp = (Get-Item "${{ github.workspace }}\shard.stamp").LastWriteTimeUtc
+          New-Item -ItemType Directory -Force -Path $dst | Out-Null
+          $n = 0; $bytes = 0
+          Get-ChildItem -LiteralPath $src -Recurse -File | Where-Object { $_.LastWriteTimeUtc -gt $stamp } | ForEach-Object {
+            $rel = $_.FullName.Substring($src.Length + 1)
+            $to = Join-Path $dst $rel
+            New-Item -ItemType Directory -Force -Path (Split-Path -Parent $to) | Out-Null
+            Copy-Item -LiteralPath $_.FullName -Destination $to
+            $n++; $bytes += $_.Length
+          }
+          "{0} files, {1:N0} MB" -f $n, ($bytes / 1MB)
+
+      - name: Save shard ccache
+        if: ${{ always() }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: shards/${{ matrix.shard }}
+          # See the Linux child for the key layout.
+          key: ccache-shard${{ matrix.shard }}-cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-${{ inputs.tag }}-${{ github.run_id }}-${{ github.run_attempt }}
+
   build:
     name: x64/${{ matrix.profile }}
+    # See the Linux child: shards are best effort, only a cancelled run stops here.
+    needs: warm
+    if: ${{ !cancelled() }}
     runs-on: ${{ matrix.runner }}
     # Every Azure Trusted Signing secret in this workflow is read by this job
     # and no other. Naming an environment is what makes them gateable: without
@@ -85,7 +179,8 @@ jobs:
     # leg the max is 305.1 and nothing falls between 215 and 305, so a tighter
     # cap buys no hang detection and would have destroyed that publish -- one
     # killed leg fails the bundle-coverage gate and the whole night ships
-    # nothing.
+    # nothing. The warm shards should make that history, but the cap stays
+    # until a few cold nights have shown the new ceiling.
     #
     # Note this cannot by itself rescue a slow run: the waiter's 330-minute
     # deadline is wall-clock from assemble start and INCLUDES the child's queue
@@ -99,156 +194,64 @@ jobs:
       run:
         shell: pwsh
     steps:
-      # Report both fixed volumes at job start. The work is split across two:
-      # the CUDA toolkit, the tool cache and Program Files land on C:, while
-      # GITHUB_WORKSPACE -- the source tree, the CMake build tree and the ccache
-      # -- is on D:. A leg that dies mid-build can only be read against the
-      # volume it was writing to, so both are printed here and again after the
-      # toolkit install.
-      #
-      # No cleanup step, deliberately. One was written and then measured on a
-      # live windows-2022 runner: D: starts at 147.0 GB free of 150.0 and C: at
-      # 84.3 of 255.4, and the CUDA 12.8 toolkit is 4.79 GB, so C: never drops
-      # below about 106 GB. Reclaiming ~33 GB of preinstalled SDKs on every leg
-      # would have freed the volume that was not under pressure, on every
-      # release, forever. The 87-minute "runner lost communication" failure was
-      # not disk exhaustion, and unsloth-prebuilt-retry.yml already covers that
-      # class of infrastructure loss.
-      - name: Report disk space
-        run: |
-          "workspace: $env:GITHUB_WORKSPACE"
-          Get-CimInstance Win32_LogicalDisk -Filter 'DriveType = 3' | Sort-Object DeviceID | ForEach-Object {
-            "{0} {1:N1} GB free of {2:N1} GB" -f $_.DeviceID, ($_.FreeSpace / 1GB), ($_.Size / 1GB)
-          }
-
       - name: Checkout build tooling (this repo)
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
         with:
           path: tooling
 
-      # The parent's resolve job built the source tree (upstream base + any mix
-      # PRs, with the build number/commit and Unsloth fingerprint baked
-      # into cmake/build-info.cmake) and uploaded it as an artifact; extract it
-      # instead of cloning -- no .git needed, the build number is already baked.
-      - name: Download source @ ${{ inputs.tag }}
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6.0.0
+      - name: Source, toolkit, ccache, configure
+        uses: ./tooling/.github/actions/unsloth-cuda-windows-setup
         with:
-          name: ${{ inputs.source_artifact }}
-          path: srcpkg
-      - name: Extract source
-        shell: bash
-        run: |
-          set -eux
-          mkdir -p src
-          tar -xzf "srcpkg/llama.cpp-source-${{ inputs.tag }}.tar.gz" -C src --strip-components=1
-
-      - name: ccache
-        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03  # v1.2.23
-        with:
-          key: cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-${{ inputs.tag }}
-          restore-keys: |
-            cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}
-          append-timestamp: false
-          variant: ccache
-          max-size: 2G
-          save: false
-
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
-        with:
-          python-version: "3.11"
-
-      - name: Install Ninja
-        run: choco install ninja --no-progress
-
-      - name: Setup MSVC
-        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756  # v1
-
-      # Jimver's action has no mapping for CUDA 13.3 yet, so for that version we
-      # fall back to llama.cpp's own install method: curl the individual NVIDIA
-      # redist component archives and assemble the toolkit by hand. Block copied
-      # verbatim from ggml-org/llama.cpp .github/actions/windows-setup-cuda
-      # (the cuda_version == '13.3' case). Any other version uses Jimver.
-      - name: Install CUDA toolkit 13.3 (NVIDIA redist)
-        if: matrix.cuda == '13.3'
-        run: |
-          mkdir -p "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.3"
-          choco install unzip -y
-          curl -O "https://developer.download.nvidia.com/compute/cuda/redist/cuda_crt/windows-x86_64/cuda_crt-windows-x86_64-13.3.33-archive.zip"
-          curl -O "https://developer.download.nvidia.com/compute/cuda/redist/cuda_cudart/windows-x86_64/cuda_cudart-windows-x86_64-13.3.29-archive.zip"
-          curl -O "https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvcc/windows-x86_64/cuda_nvcc-windows-x86_64-13.3.33-archive.zip"
-          curl -O "https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvrtc/windows-x86_64/cuda_nvrtc-windows-x86_64-13.3.33-archive.zip"
-          curl -O "https://developer.download.nvidia.com/compute/cuda/redist/libcublas/windows-x86_64/libcublas-windows-x86_64-13.5.1.27-archive.zip"
-          curl -O "https://developer.download.nvidia.com/compute/cuda/redist/libnvvm/windows-x86_64/libnvvm-windows-x86_64-13.3.33-archive.zip"
-          curl -O "https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvtx/windows-x86_64/cuda_nvtx-windows-x86_64-13.3.29-archive.zip"
-          curl -O "https://developer.download.nvidia.com/compute/cuda/redist/cuda_profiler_api/windows-x86_64/cuda_profiler_api-windows-x86_64-13.3.27-archive.zip"
-          curl -O "https://developer.download.nvidia.com/compute/cuda/redist/visual_studio_integration/windows-x86_64/visual_studio_integration-windows-x86_64-13.3.27-archive.zip"
-          curl -O "https://developer.download.nvidia.com/compute/cuda/redist/cccl/windows-x86_64/cccl-windows-x86_64-13.3.3.3.1-archive.zip"
-          unzip '*.zip' -d "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.3"
-          xcopy "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.3\cuda_crt-windows-x86_64-13.3.33-archive\*" "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.3" /E /I /H /Y
-          xcopy "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.3\cuda_cudart-windows-x86_64-13.3.29-archive\*" "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.3" /E /I /H /Y
-          xcopy "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.3\cuda_nvcc-windows-x86_64-13.3.33-archive\*" "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.3" /E /I /H /Y
-          xcopy "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.3\cuda_nvrtc-windows-x86_64-13.3.33-archive\*" "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.3" /E /I /H /Y
-          xcopy "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.3\libcublas-windows-x86_64-13.5.1.27-archive\*" "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.3" /E /I /H /Y
-          xcopy "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.3\libnvvm-windows-x86_64-13.3.33-archive\*" "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.3" /E /I /H /Y
-          xcopy "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.3\cuda_nvtx-windows-x86_64-13.3.29-archive\*" "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.3" /E /I /H /Y
-          xcopy "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.3\cuda_profiler_api-windows-x86_64-13.3.27-archive\*" "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.3" /E /I /H /Y
-          xcopy "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.3\visual_studio_integration-windows-x86_64-13.3.27-archive\*" "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.3" /E /I /H /Y
-          xcopy "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.3\cccl-windows-x86_64-13.3.3.3.1-archive\*" "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.3" /E /I /H /Y
-          echo "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.3\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          echo "CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.3" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-          echo "CUDA_PATH_V13_3=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.3" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-
-      - name: Install CUDA toolkit ${{ matrix.cuda }} (Jimver)
-        if: matrix.cuda != '13.3'
-        uses: Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec76  # v0.2.35
-        id: cuda-toolkit
-        with:
+          tag: ${{ inputs.tag }}
+          source_artifact: ${{ inputs.source_artifact }}
           cuda: ${{ matrix.cuda }}
-          method: 'network'
+          archs: ${{ matrix.archs }}
+          profile: ${{ matrix.profile }}
+          max-size: ${{ matrix.klass == 'portable' && '4G' || '3G' }}
 
-      - name: Set up CUDA environment (Jimver)
-        if: matrix.cuda != '13.3'
+      # See the Linux child for the shard restore and merge rationale.
+      - name: Restore warm shard 0
+        if: ${{ matrix.shards >= 1 }}
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: shards/0
+          key: ccache-shard0-cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-${{ inputs.tag }}-
+          restore-keys: |
+            ccache-shard0-cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-${{ inputs.tag }}-
+      - name: Restore warm shard 1
+        if: ${{ matrix.shards >= 2 }}
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: shards/1
+          key: ccache-shard1-cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-${{ inputs.tag }}-
+          restore-keys: |
+            ccache-shard1-cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-${{ inputs.tag }}-
+      - name: Restore warm shard 2
+        if: ${{ matrix.shards >= 3 }}
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: shards/2
+          key: ccache-shard2-cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-${{ inputs.tag }}-
+          restore-keys: |
+            ccache-shard2-cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-${{ inputs.tag }}-
+
+      # robocopy /E /XO: lay each delta over the cache, newer file wins (the
+      # cp -au of the Linux child; see there for why that is the right merge).
+      # robocopy exit codes below 8 are success variants, so the check is
+      # explicit.
+      - name: Merge warm shards into the ccache
+        if: ${{ matrix.shards >= 1 }}
         run: |
-          echo "CUDA_PATH=$env:CUDA_PATH" >> $env:GITHUB_ENV
-          echo "CUDA_HOME=$env:CUDA_PATH" >> $env:GITHUB_ENV
-
-      - name: Verify CUDA
-        run: nvcc --version
-
-      # Headroom going into the build, with the toolkit on C: and the restored
-      # ccache in the workspace on D:. First numbers to read if a leg dies
-      # mid-build; the build itself writes to the workspace volume.
-      - name: Report disk space before build
-        run: |
-          "workspace: $env:GITHUB_WORKSPACE"
-          Get-CimInstance Win32_LogicalDisk -Filter 'DriveType = 3' | Sort-Object DeviceID | ForEach-Object {
-            "{0} {1:N1} GB free of {2:N1} GB" -f $_.DeviceID, ($_.FreeSpace / 1GB), ($_.Size / 1GB)
+          if (Test-Path shards) {
+            Get-ChildItem -Directory shards | ForEach-Object {
+              "merging $($_.FullName) ($((Get-ChildItem -LiteralPath $_.FullName -Recurse -File).Count) files)"
+              robocopy $_.FullName "${{ github.workspace }}\.ccache" /E /XO /NFL /NDL /NJH /NP | Out-Null
+              if ($LASTEXITCODE -ge 8) { throw "robocopy failed with $LASTEXITCODE" }
+            }
+            Remove-Item -Recurse -Force shards
           }
-
-      - name: Configure
-        working-directory: src
-        run: |
-          # CMAKE_CUDA_ARCHITECTURES is the explicit per-profile arch list (the
-          # whole point of the matrix). ccache launchers cache nvcc + cl.exe;
-          # no RPATH knobs -- Windows loads sibling DLLs from the binary's dir.
-          $archs = "${{ matrix.archs }}".Replace(' ', ';')
-          cmake -S . -B build -G Ninja `
-            -DCMAKE_BUILD_TYPE=Release `
-            -DGGML_NATIVE=OFF `
-            -DGGML_BACKEND_DL=ON `
-            -DGGML_CPU_ALL_VARIANTS=ON `
-            -DGGML_RPC=ON `
-            -DGGML_CUDA=ON `
-            -DGGML_CUDA_CUB_3DOT2=ON `
-            -DLLAMA_BUILD_TESTS=OFF `
-            -DLLAMA_BUILD_EXAMPLES=OFF `
-            -DLLAMA_BUILD_TOOLS=ON `
-            -DLLAMA_BUILD_SERVER=ON `
-            -DLLAMA_BUILD_BORINGSSL=ON `
-            -DCMAKE_CUDA_ARCHITECTURES="$archs" `
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache `
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache `
-            -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache
+          ccache -z
+          exit 0
 
       - name: Build
         working-directory: src
@@ -283,6 +286,20 @@ jobs:
           }
           exit 0
 
+      # See the Linux child for how to read these.
+      - name: ccache stats
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          ccache -s -v
+          {
+            echo "### ccache windows x64/${{ matrix.profile }}"
+            echo ""
+            echo '```'
+            ccache -s
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       # Authenticode-sign before packaging. The Studio installer downloads these
       # zips after its own signed installer has run, so nothing downstream signs
       # them. Smart App Control evaluates every binary as it loads and refuses
@@ -316,6 +333,9 @@ jobs:
           KLASS: ${{ matrix.klass }}
           RANK: ${{ matrix.rank }}
           TOOLKIT_LINE: ${{ matrix.toolkit_line }}
+          # Provenance label kept byte for byte as it was under the Jimver
+          # install: the bundles must stay identical, metadata included, and
+          # the compiler behind the label is the same nvcc build either way.
           DOCKER_IMAGE: github-hosted ${{ matrix.runner }}, CUDA ${{ matrix.cuda }} ${{ matrix.cuda == '13.3' && '(NVIDIA redist)' || '(Jimver)' }}
           ARCHS: ${{ matrix.archs }}
           SMS: ${{ matrix.sms }}
@@ -337,14 +357,10 @@ jobs:
           if-no-files-found: error
 
       - name: Evict stale ccache files
-        # !cancelled(), unlike the save below: on a timeout the job gets a
-        # single ~5 minute teardown window (measured ~4m50s after process
-        # kill), shared by every remaining step and not replenished. Evicting
-        # spends that window on housekeeping; the save is what actually needs
-        # it, and a 2 GB cache is not quick to write.
+        # See the Linux child: housekeeping before the save, 7 days not 14.
         if: ${{ !cancelled() }}
         continue-on-error: true
-        run: ccache --evict-older-than 14d
+        run: ccache --evict-older-than 7d
 
       - name: Save ccache
         # Save even when the build failed: the objects compiled before the
@@ -356,8 +372,10 @@ jobs:
         # the CANCELLATION path, not the failure path, so !cancelled() would
         # skip the save on the single most expensive case -- a leg that
         # compiled for hours and then hit the cap.
+        #
+        # Run id and attempt on the key, see the Linux child.
         if: ${{ always() }}
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ${{ github.workspace }}\.ccache
-          key: ccache-cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-${{ inputs.tag }}-
+          key: ccache-cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-${{ inputs.tag }}-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/unsloth-prebuilt-cuda-windows.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda-windows.yml
@@ -12,9 +12,7 @@ name: "Unsloth prebuilt: CUDA Windows"
 # DLLs from the executable's directory), and a .zip archive. CUDA compiles
 # entirely in software here -- no GPU is present on the runner.
 #
-# Same two-job shape as the Linux child (warm shards through ccache, unioned
-# into the build job's cache); see its header and
-# .github/actions/unsloth-cuda-windows-setup.
+# Same two-job shape as the Linux child; see its header and .github/actions/unsloth-cuda-windows-setup.
 
 on:
   workflow_call:
@@ -70,11 +68,9 @@ permissions:
 jobs:
   warm:
     name: warm x64/${{ matrix.profile }} ${{ matrix.shard }}/${{ matrix.shards }}
-    # See the Linux child for why an empty string and not an empty include.
     if: ${{ inputs.warm_matrix != '' }}
     runs-on: ${{ matrix.runner }}
-    # Best effort; the parent's waiter excludes ` / warm ` jobs from its
-    # all-legs-green check. No signing environment: shards ship nothing.
+    # Best effort; no signing environment, shards ship nothing.
     continue-on-error: true
     timeout-minutes: 150
     strategy:
@@ -99,11 +95,6 @@ jobs:
           profile: ${{ matrix.profile }}
           max-size: ${{ matrix.klass == 'portable' && '4G' || '3G' }}
 
-      # The shards restore the previous shard deltas too (any tag: the
-      # restore-keys fall back to a tagless prefix), so a retry of the same
-      # tag, or a night whose base bump left some objects untouched, compiles
-      # only what changed since the newest delta, not since the last
-      # generation.
       - name: Restore warm shard 0
         if: ${{ matrix.shards >= 1 }}
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
@@ -155,8 +146,6 @@ jobs:
           ccache -z
           exit 0
 
-      # See the Linux child: path + size for every file, a hash for the
-      # manifests, so the export ships only what the compile changed.
       - name: Snapshot the restored cache
         run: |
           $src = "${{ github.workspace }}\.ccache"
@@ -173,8 +162,6 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # See the Linux child: every ggml-cuda object, stable order, dealt
-          # round-robin across the shards.
           ninja -C build -t targets all \
             | grep -E 'ggml-cuda\.dir[/\\].*\.cu\.obj:' | cut -d: -f1 | sort \
             | awk -v s="${{ matrix.shard }}" -v k="${{ matrix.shards }}" 'NR % k == s' > shard.txt
@@ -185,8 +172,6 @@ jobs:
         if: ${{ always() }}
         run: ccache -s -v
 
-      # See the Linux child: only the files this job added or rewrote, tree
-      # layout preserved.
       - name: Export the shard delta
         if: ${{ always() }}
         run: |
@@ -212,12 +197,10 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: shards/${{ matrix.shard }}
-          # See the Linux child for the key layout.
           key: ccache-shard${{ matrix.shard }}-cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-${{ inputs.tag }}-${{ github.run_id }}-${{ github.run_attempt }}
 
   build:
     name: x64/${{ matrix.profile }}
-    # See the Linux child: shards are best effort, only a cancelled run stops here.
     needs: warm
     if: ${{ !cancelled() }}
     runs-on: ${{ matrix.runner }}
@@ -244,8 +227,7 @@ jobs:
     # leg the max is 305.1 and nothing falls between 215 and 305, so a tighter
     # cap buys no hang detection and would have destroyed that publish -- one
     # killed leg fails the bundle-coverage gate and the whole night ships
-    # nothing. The warm shards should make that history, but the cap stays
-    # until a few cold nights have shown the new ceiling.
+    # nothing. Shards should make that history; the cap stays until cold nights show the new ceiling.
     #
     # Note this cannot by itself rescue a slow run: the waiter's 330-minute
     # deadline is wall-clock from assemble start and INCLUDES the child's queue
@@ -274,7 +256,6 @@ jobs:
           profile: ${{ matrix.profile }}
           max-size: ${{ matrix.klass == 'portable' && '4G' || '3G' }}
 
-      # See the Linux child for the shard restore and merge rationale.
       - name: Restore warm shard 0
         if: ${{ matrix.shards >= 1 }}
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
@@ -359,7 +340,6 @@ jobs:
           }
           exit 0
 
-      # See the Linux child for how to read these.
       - name: ccache stats
         if: ${{ always() }}
         shell: bash
@@ -406,9 +386,8 @@ jobs:
           KLASS: ${{ matrix.klass }}
           RANK: ${{ matrix.rank }}
           TOOLKIT_LINE: ${{ matrix.toolkit_line }}
-          # Provenance label kept byte for byte as it was under the Jimver
-          # install: the bundles must stay identical, metadata included, and
-          # the compiler behind the label is the same nvcc build either way.
+          # Provenance label kept byte for byte as under the Jimver install: bundles must stay
+          # identical, metadata included, and the compiler behind the label is the same nvcc.
           DOCKER_IMAGE: github-hosted ${{ matrix.runner }}, CUDA ${{ matrix.cuda }} ${{ matrix.cuda == '13.3' && '(NVIDIA redist)' || '(Jimver)' }}
           ARCHS: ${{ matrix.archs }}
           SMS: ${{ matrix.sms }}
@@ -430,7 +409,6 @@ jobs:
           if-no-files-found: error
 
       - name: Evict stale ccache files
-        # See the Linux child: housekeeping before the save, 7 days not 14.
         if: ${{ !cancelled() }}
         continue-on-error: true
         run: ccache --evict-older-than 7d
@@ -445,8 +423,6 @@ jobs:
         # the CANCELLATION path, not the failure path, so !cancelled() would
         # skip the save on the single most expensive case -- a leg that
         # compiled for hours and then hit the cap.
-        #
-        # Run id and attempt on the key, see the Linux child.
         if: ${{ always() }}
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:

--- a/.github/workflows/unsloth-prebuilt-cuda-windows.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda-windows.yml
@@ -46,6 +46,11 @@ on:
         required: false
         default: ''
         type: string
+      warm_only:
+        description: 'Run the warm shards only and save their deltas; skip the build job (daytime cache warming)'
+        required: false
+        default: false
+        type: boolean
 
     secrets:
       AZURE_CLIENT_ID:
@@ -98,6 +103,52 @@ jobs:
           archs: ${{ matrix.archs }}
           profile: ${{ matrix.profile }}
           max-size: ${{ matrix.klass == 'portable' && '4G' || '3G' }}
+
+      # The shards restore the previous shard deltas too (any tag: the
+      # restore-keys fall back to a tagless prefix), so a daytime warm-only run
+      # leaves deltas the nightly's shards hit on, and each shard compiles only
+      # what changed since the newest delta, not since the last generation.
+      - name: Restore warm shard 0
+        if: ${{ matrix.shards >= 1 }}
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: shards/0
+          key: ccache-shard0-cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-${{ inputs.tag }}-
+          restore-keys: |
+            ccache-shard0-cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-${{ inputs.tag }}-
+            ccache-shard0-cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-
+      - name: Restore warm shard 1
+        if: ${{ matrix.shards >= 2 }}
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: shards/1
+          key: ccache-shard1-cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-${{ inputs.tag }}-
+          restore-keys: |
+            ccache-shard1-cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-${{ inputs.tag }}-
+            ccache-shard1-cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-
+      - name: Restore warm shard 2
+        if: ${{ matrix.shards >= 3 }}
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: shards/2
+          key: ccache-shard2-cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-${{ inputs.tag }}-
+          restore-keys: |
+            ccache-shard2-cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-${{ inputs.tag }}-
+            ccache-shard2-cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-
+
+      - name: Merge warm shards into the ccache
+        if: ${{ matrix.shards >= 1 }}
+        run: |
+          if (Test-Path shards) {
+            Get-ChildItem -Directory shards | ForEach-Object {
+              "merging $($_.FullName) ($((Get-ChildItem -LiteralPath $_.FullName -Recurse -File).Count) files)"
+              robocopy $_.FullName "${{ github.workspace }}\.ccache" /E /XO /NFL /NDL /NJH /NP | Out-Null
+              if ($LASTEXITCODE -ge 8) { throw "robocopy failed with $LASTEXITCODE" }
+            }
+            Remove-Item -Recurse -Force shards
+          }
+          ccache -z
+          exit 0
 
       # See the Linux child: the export below ships only what the compile adds.
       - name: Stamp the restored cache
@@ -154,7 +205,7 @@ jobs:
     name: x64/${{ matrix.profile }}
     # See the Linux child: shards are best effort, only a cancelled run stops here.
     needs: warm
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && !inputs.warm_only }}
     runs-on: ${{ matrix.runner }}
     # Every Azure Trusted Signing secret in this workflow is read by this job
     # and no other. Naming an environment is what makes them gateable: without
@@ -218,6 +269,7 @@ jobs:
           key: ccache-shard0-cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-${{ inputs.tag }}-
           restore-keys: |
             ccache-shard0-cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-${{ inputs.tag }}-
+            ccache-shard0-cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-
       - name: Restore warm shard 1
         if: ${{ matrix.shards >= 2 }}
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
@@ -226,6 +278,7 @@ jobs:
           key: ccache-shard1-cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-${{ inputs.tag }}-
           restore-keys: |
             ccache-shard1-cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-${{ inputs.tag }}-
+            ccache-shard1-cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-
       - name: Restore warm shard 2
         if: ${{ matrix.shards >= 3 }}
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
@@ -234,11 +287,8 @@ jobs:
           key: ccache-shard2-cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-${{ inputs.tag }}-
           restore-keys: |
             ccache-shard2-cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-${{ inputs.tag }}-
+            ccache-shard2-cuda-${{ matrix.cuda }}-windows-${{ matrix.profile }}-
 
-      # robocopy /E /XO: lay each delta over the cache, newer file wins (the
-      # cp -au of the Linux child; see there for why that is the right merge).
-      # robocopy exit codes below 8 are success variants, so the check is
-      # explicit.
       - name: Merge warm shards into the ccache
         if: ${{ matrix.shards >= 1 }}
         run: |

--- a/.github/workflows/unsloth-prebuilt-cuda.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda.yml
@@ -7,32 +7,12 @@ name: "Unsloth prebuilt: CUDA"
 # the parent's `resolve` job filtered into `matrix`. Each entry uploads a
 # single app-*.tar.gz artifact for the parent's assemble step to pick up.
 #
-# Two jobs per profile since 2026-09:
-#
-#   warm   N shards (parent decides N per profile; 0 for legacy) that each
-#          restore the profile's newest ccache generation, compile a 1/N slice
-#          of the ggml-cuda objects through it (hits cost nothing, so only the
-#          objects the base bump actually invalidated get compiled), and save
-#          the DELTA (every cache file newer than a stamp taken after the
-#          restore) as a small shard cache. Best effort: a dead shard means
-#          the build compiles more itself, never that a release is lost.
-#   build  restores the same generation plus every shard delta, lays the
-#          deltas over the generation newest-file-wins (results are content
-#          addressed; a manifest a shard rewrote is a superset of the one it
-#          restored, and the slices are disjoint so no two shards rewrite the
-#          same manifest) and runs the full build as before, which then
-#          direct-hits everything the shards produced.
-#
-# This is how a 4 vCPU runner gets a cold CUDA leg down from ~190 minutes
-# (run 34168016006, Windows portable) to one shard's worth plus a mostly
-# hitting build. A base bump that edits ggml-cuda/common.cuh (every .cu
-# includes it; upstream touches it ~6x a month) invalidates every CUDA object
-# and no cache setting changes that, so parallelism is the lever that is
-# left without larger runners.
-#
-# Both jobs run the identical setup (.github/actions/unsloth-cuda-linux-setup)
-# so the hashes agree; that action also records why sccache was measured and
-# rejected for these legs.
+# Two jobs per profile since 2026-09. `warm` shards (N per profile from the parent, 0 = skipped)
+# each restore the newest ccache generation, compile a 1/N slice of the ggml-cuda objects and save
+# only what the compile added or rewrote; `build` merges the deltas over the generation
+# newest-file-wins (slices are disjoint) and runs the full build. Shards are best effort: a dead
+# one costs compile time, never a release. A base bump touching ggml-cuda/common.cuh invalidates
+# every CUDA object; parallel shards are the only lever without larger runners.
 
 on:
   workflow_call:
@@ -71,16 +51,12 @@ permissions:
 jobs:
   warm:
     name: warm ${{ matrix.arch }}/${{ matrix.profile }} ${{ matrix.shard }}/${{ matrix.shards }}
-    # An empty string, not an empty include list: a job whose `if` is false
-    # never evaluates its strategy, and fromJSON('{"include":[]}') would fail
-    # the job instead of skipping it.
+    # An empty string, not an empty include list: with the `if` false the strategy is never
+    # evaluated, while fromJSON('{"include":[]}') fails the job instead of skipping it.
     if: ${{ inputs.warm_matrix != '' }}
     runs-on: ${{ matrix.runner }}
-    # Best effort, see the header. The parent's waiter also excludes ` / warm `
-    # jobs from its all-legs-green check.
+    # Best effort (see header); the parent's waiter excludes ` / warm ` jobs.
     continue-on-error: true
-    # A shard is a third of a profile; the whole cold profile fit in 305
-    # minutes on the slowest night on record, so this is generous.
     timeout-minutes: 150
     strategy:
       fail-fast: false
@@ -112,11 +88,7 @@ jobs:
           profile: ${{ matrix.profile }}
           max-size: ${{ matrix.klass == 'portable' && '4G' || '3G' }}
 
-      # The shards restore the previous shard deltas too (any tag: the
-      # restore-keys fall back to a tagless prefix), so a retry of the same
-      # tag, or a night whose base bump left some objects untouched, compiles
-      # only what changed since the newest delta, not since the last
-      # generation.
+      # Previous deltas are restored too (tagless fallback), so a retry compiles only what changed since them.
       - name: Restore warm shard 0
         if: ${{ matrix.shards >= 1 }}
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
@@ -166,14 +138,8 @@ jobs:
           rm -rf shards
           ccache -z
 
-      # Snapshot of the restored cache so the export below ships only what the
-      # compile changed. Not mtimes: ccache touches every result it hits (LRU
-      # bookkeeping), so on a warm night "newer than a stamp" is the whole
-      # slice again (426 of 426 files on a 100% hit rebuild, measured
-      # 2026-09-08) while one stats file had actually changed. Path + size
-      # catches new results and rewritten manifests (an entry added makes the
-      # manifest grow); the manifests are hashed as well because that is the
-      # one file ccache rewrites in place and it is small.
+      # Path + size, manifests by hash (the one file ccache rewrites in place). Not mtimes:
+      # ccache touches every hit, so on a warm night everything looks newer.
       - name: Snapshot the restored cache
         run: |
           set -euo pipefail
@@ -185,29 +151,18 @@ jobs:
         working-directory: src
         run: |
           set -euo pipefail
-          # Every ggml-cuda object target in the configured graph, in a stable
-          # order, dealt round-robin across the shards. The template-instance
-          # files dominate (2-8 minutes each for 8 arches) and are spread by
-          # name, which balances well enough; the build job compiles whatever a
-          # shard did not reach.
+          # Stable order, dealt round-robin; the build compiles whatever a shard did not reach.
           ninja -C build -t targets all \
             | grep -E 'ggml-cuda\.dir[/\\].*\.cu\.o:' | cut -d: -f1 | sort \
             | awk -v s="${{ matrix.shard }}" -v k="${{ matrix.shards }}" 'NR % k == s' > shard.txt
           echo "$(wc -l < shard.txt) CUDA objects in this shard"
-          # -j 3: same reasoning as the build job below.
           xargs -a shard.txt ninja -C build -j 3
 
       - name: ccache stats
         if: ${{ always() }}
         run: ccache -s -v
 
-      # Only the files this job added or rewrote: new results, the manifests
-      # of the TUs it compiled and the stats counters. The restored generation
-      # stays behind, so a shard is MBs on a warm night and a couple of
-      # hundred MB on a cold one, not another 4 GB copy of the generation;
-      # 40-odd shard caches a night have to fit next to the generations under
-      # the 75 GB repo limit. Tree layout preserved so the build job can lay
-      # the delta straight over its own cache dir.
+      # Only what this job added or rewrote, tree layout preserved: never a 4 GB copy of the generation.
       - name: Export the shard delta
         if: ${{ always() }}
         run: |
@@ -227,18 +182,12 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: shards/${{ matrix.shard }}
-          # The shard index sits in front of the profile so the composite's
-          # generation restore (prefix ccache-cuda-<cuda>-<arch>-<profile>)
-          # never picks a shard, and the pruner groups each shard as its own
-          # prefix; the run id and attempt keep every save unique so a retry
-          # of the same tag can save an improved shard.
+          # Shard index ahead of the profile so the generation prefix restore never picks a shard.
           key: ccache-shard${{ matrix.shard }}-cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ inputs.tag }}-${{ github.run_id }}-${{ github.run_attempt }}
 
   build:
     name: ${{ matrix.arch }}/${{ matrix.profile }}
-    # Runs after the shards, whatever they did: `warm` skipped (no shards for
-    # this profile set), failed or timed out all mean "fewer hits", not "no
-    # release". Only a cancelled run stops here.
+    # Runs whatever the shards did (fewer hits at worst); only a cancelled run stops here.
     needs: warm
     if: ${{ !cancelled() }}
     runs-on: ${{ matrix.runner }}
@@ -272,9 +221,7 @@ jobs:
           profile: ${{ matrix.profile }}
           max-size: ${{ matrix.klass == 'portable' && '4G' || '3G' }}
 
-      # One restore step per possible shard (the parent never asks for more
-      # than four). A shard that never saved is a cache miss here and nothing
-      # else. Prefix restore, newest first, so a retry sees the latest attempt.
+      # One restore per possible shard (max four); a shard that never saved is just a miss.
       - name: Restore warm shard 0
         if: ${{ matrix.shards >= 1 }}
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
@@ -333,9 +280,8 @@ jobs:
           # -j 3: this multi-arch nvcc build peaks at ~3 GB host RSS on the
           # 4 vCPU / 16 GB GitHub-hosted runners (x64 and arm64 alike, measured
           # over a 1s sampler), so 3 parallel TUs leave ~13 GB free. -j 4 adds
-          # no speed (the runner is ~2 physical cores + HT), so 3 is the sweet
-          # spot. nvcc --threads was measured too (2026-09-08, 4 cores): -j 2
-          # with --threads 2 came in 5% under -j 3, not worth a flag change.
+          # no speed (the runner is ~2 physical cores + HT), so 3 is the sweet spot;
+          # -j 2 with nvcc --threads 2 measured within 5%, not worth the flag.
           cmake --build build --config Release -j 3
           strip build/bin/llama-* || true
 
@@ -363,9 +309,7 @@ jobs:
           fi
           exit 0
 
-      # The number to read when a leg is slow. Misses here after warm shards
-      # ran means the shards did not finish; misses on every CUDA TU with the
-      # C++ hitting is a base bump that touched a shared CUDA header.
+      # Misses on every CUDA TU with C++ hitting is a base bump that touched a shared CUDA header.
       - name: ccache stats
         if: ${{ always() }}
         run: |
@@ -394,9 +338,8 @@ jobs:
           KLASS: ${{ matrix.klass }}
           RANK: ${{ matrix.rank }}
           TOOLKIT_LINE: ${{ matrix.toolkit_line }}
-          # Provenance label kept byte for byte as it was under the Jimver
-          # install: the bundles must stay identical, metadata included, and
-          # the compiler behind the label is the same nvcc build either way.
+          # Provenance label kept byte for byte as under the Jimver install: bundles must stay
+          # identical, metadata included, and the compiler behind the label is the same nvcc.
           DOCKER_IMAGE: github-hosted ${{ matrix.runner }}, CUDA ${{ matrix.cuda }} ${{ matrix.cuda == '13.3' && '(NVIDIA redist)' || '(Jimver)' }}
           ARCHS: ${{ matrix.archs }}
           SMS: ${{ matrix.sms }}
@@ -414,9 +357,8 @@ jobs:
         # single ~5 minute teardown window (measured ~4m50s after process
         # kill), shared by every remaining step and not replenished. Evicting
         # spends that window on housekeeping; the save is what actually needs
-        # it, and a multi-GB cache is not quick to write. 7 days, not 14: with
-        # a daily base bump an object that stopped hitting a week ago is dead,
-        # and the smaller dir is what keeps restore and save near a minute.
+        # it, and a multi-GB cache is not quick to write. 7 days: with a daily base bump an
+        # object idle for a week is dead, and the smaller dir keeps restore and save near a minute.
         if: ${{ !cancelled() }}
         continue-on-error: true
         run: ccache --evict-older-than 7d
@@ -432,9 +374,8 @@ jobs:
         # skip the save on the single most expensive case -- a leg that
         # compiled for hours and then hit the cap.
         #
-        # Run id and attempt on the key: cache entries are immutable, so
-        # without them a retry of the same tag could never replace a partial
-        # save with a complete one. The restore prefix ignores the suffix.
+        # Run id and attempt on the key: entries are immutable, so a same-tag retry could
+        # otherwise never replace a partial save. The restore prefix ignores the suffix.
         if: ${{ always() }}
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:

--- a/.github/workflows/unsloth-prebuilt-cuda.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda.yml
@@ -64,11 +64,6 @@ on:
         required: false
         default: ''
         type: string
-      warm_only:
-        description: 'Run the warm shards only and save their deltas; skip the build job (daytime cache warming)'
-        required: false
-        default: false
-        type: boolean
 
 permissions:
   contents: read
@@ -118,9 +113,10 @@ jobs:
           max-size: ${{ matrix.klass == 'portable' && '4G' || '3G' }}
 
       # The shards restore the previous shard deltas too (any tag: the
-      # restore-keys fall back to a tagless prefix), so a daytime warm-only run
-      # leaves deltas the nightly's shards hit on, and each shard compiles only
-      # what changed since the newest delta, not since the last generation.
+      # restore-keys fall back to a tagless prefix), so a retry of the same
+      # tag, or a night whose base bump left some objects untouched, compiles
+      # only what changed since the newest delta, not since the last
+      # generation.
       - name: Restore warm shard 0
         if: ${{ matrix.shards >= 1 }}
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
@@ -244,7 +240,7 @@ jobs:
     # this profile set), failed or timed out all mean "fewer hits", not "no
     # release". Only a cancelled run stops here.
     needs: warm
-    if: ${{ !cancelled() && !inputs.warm_only }}
+    if: ${{ !cancelled() }}
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false

--- a/.github/workflows/unsloth-prebuilt-cuda.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda.yml
@@ -170,11 +170,20 @@ jobs:
           rm -rf shards
           ccache -z
 
-      # Everything the restore put in place is older than this file; the
-      # export below ships only what the compile adds. The sleeps keep a
-      # same-second write on either side from landing on the wrong side.
-      - name: Stamp the restored cache
-        run: sleep 1 && touch shard.stamp && sleep 1
+      # Snapshot of the restored cache so the export below ships only what the
+      # compile changed. Not mtimes: ccache touches every result it hits (LRU
+      # bookkeeping), so on a warm night "newer than a stamp" is the whole
+      # slice again (426 of 426 files on a 100% hit rebuild, measured
+      # 2026-09-08) while one stats file had actually changed. Path + size
+      # catches new results and rewritten manifests (an entry added makes the
+      # manifest grow); the manifests are hashed as well because that is the
+      # one file ccache rewrites in place and it is small.
+      - name: Snapshot the restored cache
+        run: |
+          set -euo pipefail
+          cd "${{ github.workspace }}/.ccache"
+          find . -type f -printf '%p\t%s\n' | sort > "${{ github.workspace }}/shard.before"
+          find . -type f -name '*M' -print0 | xargs -0 -r sha256sum | sort -k2 > "${{ github.workspace }}/shard.before.m"
 
       - name: Compile shard ${{ matrix.shard }} of ${{ matrix.shards }}
         working-directory: src
@@ -197,21 +206,25 @@ jobs:
         run: ccache -s -v
 
       # Only the files this job added or rewrote: new results, the manifests
-      # of the TUs it compiled (ccache rewrites a manifest in place when it
-      # adds an entry) and the stats counters. The restored generation stays
-      # behind, so a shard is a few hundred MB, not another 4 GB copy of the
-      # generation; 40-odd shard caches a night have to fit next to the
-      # generations under the 75 GB repo limit. Tree layout preserved so the
-      # build job can lay the delta straight over its own cache dir.
+      # of the TUs it compiled and the stats counters. The restored generation
+      # stays behind, so a shard is MBs on a warm night and a couple of
+      # hundred MB on a cold one, not another 4 GB copy of the generation;
+      # 40-odd shard caches a night have to fit next to the generations under
+      # the 75 GB repo limit. Tree layout preserved so the build job can lay
+      # the delta straight over its own cache dir.
       - name: Export the shard delta
         if: ${{ always() }}
         run: |
           set -euo pipefail
-          mkdir -p "shards/${{ matrix.shard }}"
-          cd "${{ github.workspace }}/.ccache"
-          find . -type f -newer "${{ github.workspace }}/shard.stamp" -print0 \
-            | xargs -0 -r cp --parents -a -t "${{ github.workspace }}/shards/${{ matrix.shard }}/"
-          echo "$(find "${{ github.workspace }}/shards/${{ matrix.shard }}" -type f | wc -l) files, $(du -sh "${{ github.workspace }}/shards/${{ matrix.shard }}" | cut -f1)"
+          W="${{ github.workspace }}"
+          mkdir -p "$W/shards/${{ matrix.shard }}"
+          cd "$W/.ccache"
+          find . -type f -printf '%p\t%s\n' | sort > "$W/shard.after"
+          find . -type f -name '*M' -print0 | xargs -0 -r sha256sum | sort -k2 > "$W/shard.after.m"
+          { comm -13 "$W/shard.before" "$W/shard.after" | cut -f1
+            comm -13 "$W/shard.before.m" "$W/shard.after.m" | awk '{ print $2 }'; } | sort -u > "$W/shard.changed"
+          xargs -a "$W/shard.changed" -d '\n' -r cp --parents -a -t "$W/shards/${{ matrix.shard }}/"
+          echo "$(find "$W/shards/${{ matrix.shard }}" -type f | wc -l) files, $(du -sh "$W/shards/${{ matrix.shard }}" | cut -f1)"
 
       - name: Save shard ccache
         if: ${{ always() }}

--- a/.github/workflows/unsloth-prebuilt-cuda.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda.yml
@@ -6,6 +6,33 @@ name: "Unsloth prebuilt: CUDA"
 # Reusable child of unsloth-prebuilt.yml. Builds the per-profile CUDA bundles
 # the parent's `resolve` job filtered into `matrix`. Each entry uploads a
 # single app-*.tar.gz artifact for the parent's assemble step to pick up.
+#
+# Two jobs per profile since 2026-09:
+#
+#   warm   N shards (parent decides N per profile; 0 for legacy) that each
+#          restore the profile's newest ccache generation, compile a 1/N slice
+#          of the ggml-cuda objects through it (hits cost nothing, so only the
+#          objects the base bump actually invalidated get compiled), and save
+#          the DELTA (every cache file newer than a stamp taken after the
+#          restore) as a small shard cache. Best effort: a dead shard means
+#          the build compiles more itself, never that a release is lost.
+#   build  restores the same generation plus every shard delta, lays the
+#          deltas over the generation newest-file-wins (results are content
+#          addressed; a manifest a shard rewrote is a superset of the one it
+#          restored, and the slices are disjoint so no two shards rewrite the
+#          same manifest) and runs the full build as before, which then
+#          direct-hits everything the shards produced.
+#
+# This is how a 4 vCPU runner gets a cold CUDA leg down from ~190 minutes
+# (run 34168016006, Windows portable) to one shard's worth plus a mostly
+# hitting build. A base bump that edits ggml-cuda/common.cuh (every .cu
+# includes it; upstream touches it ~6x a month) invalidates every CUDA object
+# and no cache setting changes that, so parallelism is the lever that is
+# left without larger runners.
+#
+# Both jobs run the identical setup (.github/actions/unsloth-cuda-linux-setup)
+# so the hashes agree; that action also records why sccache was measured and
+# rejected for these legs.
 
 on:
   workflow_call:
@@ -29,16 +56,124 @@ on:
         default: ''
         type: string
       matrix:
-        description: 'Matrix JSON {include:[...]} produced by the parent resolve job'
+        description: 'Matrix JSON {include:[...]} produced by the parent resolve job; each row carries `shards`'
         required: true
+        type: string
+      warm_matrix:
+        description: 'Matrix JSON {include:[...]} of (profile row x shard) for the warm job, or empty to skip warming'
+        required: false
+        default: ''
         type: string
 
 permissions:
   contents: read
 
 jobs:
+  warm:
+    name: warm ${{ matrix.arch }}/${{ matrix.profile }} ${{ matrix.shard }}/${{ matrix.shards }}
+    # An empty string, not an empty include list: a job whose `if` is false
+    # never evaluates its strategy, and fromJSON('{"include":[]}') would fail
+    # the job instead of skipping it.
+    if: ${{ inputs.warm_matrix != '' }}
+    runs-on: ${{ matrix.runner }}
+    # Best effort, see the header. The parent's waiter also excludes ` / warm `
+    # jobs from its all-legs-green check.
+    continue-on-error: true
+    # A shard is a third of a profile; the whole cold profile fit in 305
+    # minutes on the slowest night on record, so this is generous.
+    timeout-minutes: 150
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(inputs.warm_matrix) }}
+    steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          swap-storage: true
+
+      - name: Checkout build tooling (this repo)
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
+        with:
+          path: tooling
+
+      - name: Source, toolkit, ccache, configure
+        uses: ./tooling/.github/actions/unsloth-cuda-linux-setup
+        with:
+          tag: ${{ inputs.tag }}
+          source_artifact: ${{ inputs.source_artifact }}
+          cuda: ${{ matrix.cuda }}
+          arch: ${{ matrix.arch }}
+          archs: ${{ matrix.archs }}
+          profile: ${{ matrix.profile }}
+          max-size: ${{ matrix.klass == 'portable' && '4G' || '3G' }}
+
+      # Everything the restore put in place is older than this file; the
+      # export below ships only what the compile adds. The sleeps keep a
+      # same-second write on either side from landing on the wrong side.
+      - name: Stamp the restored cache
+        run: sleep 1 && touch shard.stamp && sleep 1
+
+      - name: Compile shard ${{ matrix.shard }} of ${{ matrix.shards }}
+        working-directory: src
+        run: |
+          set -euo pipefail
+          # Every ggml-cuda object target in the configured graph, in a stable
+          # order, dealt round-robin across the shards. The template-instance
+          # files dominate (2-8 minutes each for 8 arches) and are spread by
+          # name, which balances well enough; the build job compiles whatever a
+          # shard did not reach.
+          ninja -C build -t targets all \
+            | grep -E 'ggml-cuda\.dir[/\\].*\.cu\.o:' | cut -d: -f1 | sort \
+            | awk -v s="${{ matrix.shard }}" -v k="${{ matrix.shards }}" 'NR % k == s' > shard.txt
+          echo "$(wc -l < shard.txt) CUDA objects in this shard"
+          # -j 3: same reasoning as the build job below.
+          xargs -a shard.txt ninja -C build -j 3
+
+      - name: ccache stats
+        if: ${{ always() }}
+        run: ccache -s -v
+
+      # Only the files this job added or rewrote: new results, the manifests
+      # of the TUs it compiled (ccache rewrites a manifest in place when it
+      # adds an entry) and the stats counters. The restored generation stays
+      # behind, so a shard is a few hundred MB, not another 4 GB copy of the
+      # generation; 40-odd shard caches a night have to fit next to the
+      # generations under the 75 GB repo limit. Tree layout preserved so the
+      # build job can lay the delta straight over its own cache dir.
+      - name: Export the shard delta
+        if: ${{ always() }}
+        run: |
+          set -euo pipefail
+          mkdir -p "shards/${{ matrix.shard }}"
+          cd "${{ github.workspace }}/.ccache"
+          find . -type f -newer "${{ github.workspace }}/shard.stamp" -print0 \
+            | xargs -0 -r cp --parents -a -t "${{ github.workspace }}/shards/${{ matrix.shard }}/"
+          echo "$(find "${{ github.workspace }}/shards/${{ matrix.shard }}" -type f | wc -l) files, $(du -sh "${{ github.workspace }}/shards/${{ matrix.shard }}" | cut -f1)"
+
+      - name: Save shard ccache
+        if: ${{ always() }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: shards/${{ matrix.shard }}
+          # The shard index sits in front of the profile so the composite's
+          # generation restore (prefix ccache-cuda-<cuda>-<arch>-<profile>)
+          # never picks a shard, and the pruner groups each shard as its own
+          # prefix; the run id and attempt keep every save unique so a retry
+          # of the same tag can save an improved shard.
+          key: ccache-shard${{ matrix.shard }}-cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ inputs.tag }}-${{ github.run_id }}-${{ github.run_attempt }}
+
   build:
     name: ${{ matrix.arch }}/${{ matrix.profile }}
+    # Runs after the shards, whatever they did: `warm` skipped (no shards for
+    # this profile set), failed or timed out all mean "fewer hits", not "no
+    # release". Only a cancelled run stops here.
+    needs: warm
+    if: ${{ !cancelled() }}
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -59,144 +194,64 @@ jobs:
         with:
           path: tooling
 
-      # The parent's resolve job built the source tree (upstream base + any mix
-      # PRs, with the build number/commit and Unsloth fingerprint baked
-      # into cmake/build-info.cmake) and uploaded it as an artifact; extract it
-      # instead of cloning -- no .git needed, the build number is already baked.
-      - name: Download source @ ${{ inputs.tag }}
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6.0.0
+      - name: Source, toolkit, ccache, configure
+        uses: ./tooling/.github/actions/unsloth-cuda-linux-setup
         with:
-          name: ${{ inputs.source_artifact }}
-          path: srcpkg
-      - name: Extract source
-        shell: bash
-        run: |
-          set -eux
-          mkdir -p src
-          tar -xzf "srcpkg/llama.cpp-source-${{ inputs.tag }}.tar.gz" -C src --strip-components=1
-
-      - name: Install build dependencies
-        run: |
-          set -eux
-          sudo apt-get update
-          sudo apt-get install -y build-essential libssl-dev
-
-      - name: Install ARM64 host compiler (gcc-14)
-        if: matrix.arch == 'arm64'
-        run: |
-          set -eux
-          sudo apt-get install -y gcc-14 g++-14
-          {
-            echo "CC=gcc-14"
-            echo "CXX=g++-14"
-            echo "CUDAHOSTCXX=g++-14"
-          } >> "$GITHUB_ENV"
-
-      - name: ccache
-        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03  # v1.2.23
-        with:
-          key: cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ inputs.tag }}
-          restore-keys: |
-            cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}
-          append-timestamp: false
-          variant: ccache
-          max-size: 2G
-          save: false
-
-      # Jimver has no mapping for CUDA 13.3 yet, so for that version we pull the
-      # toolkit components straight from NVIDIA's redist CDN (same source Jimver
-      # and ggml-org use) and assemble a prefix by hand. Component versions are
-      # from NVIDIA's redistrib_13.3.0.json. Runs on the same ubuntu runner, so
-      # the glibc floor is unchanged. Any other version uses Jimver.
-      - name: Install CUDA toolkit 13.3 (NVIDIA redist)
-        if: matrix.cuda == '13.3'
-        run: |
-          set -eux
-          case "${{ matrix.arch }}" in
-            x64)   PLAT=linux-x86_64 ;;
-            arm64) PLAT=linux-sbsa ;;
-            *) echo "unsupported arch ${{ matrix.arch }}" >&2; exit 1 ;;
-          esac
-          PREFIX="$HOME/cuda-13.3"
-          mkdir -p "$PREFIX"
-          BASE="https://developer.download.nvidia.com/compute/cuda/redist"
-          for cv in \
-            cuda_crt:13.3.33 cuda_cudart:13.3.29 cuda_nvcc:13.3.33 \
-            cuda_nvrtc:13.3.33 libcublas:13.5.1.27 libnvvm:13.3.33 \
-            cuda_nvtx:13.3.29 cuda_profiler_api:13.3.27 cccl:13.3.3.3.1; do
-            comp="${cv%:*}"; ver="${cv#*:}"
-            name="${comp}-${PLAT}-${ver}-archive"
-            curl -fsSL -o comp.tar.xz "$BASE/${comp}/${PLAT}/${name}.tar.xz"
-            tar -xf comp.tar.xz
-            cp -a "${name}/." "$PREFIX"/
-            rm -rf comp.tar.xz "${name}"
-          done
-          # Redist ships libs under lib/; some CMake CUDA discovery expects lib64.
-          ln -sfn lib "$PREFIX/lib64"
-          {
-            echo "CUDA_PATH=$PREFIX"
-            echo "CUDA_HOME=$PREFIX"
-            echo "LD_LIBRARY_PATH=$PREFIX/lib:${LD_LIBRARY_PATH:-}"
-          } >> "$GITHUB_ENV"
-          echo "$PREFIX/bin" >> "$GITHUB_PATH"
-
-      - name: Install CUDA toolkit ${{ matrix.cuda }} (Jimver)
-        if: matrix.cuda != '13.3'
-        uses: Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec76  # v0.2.35
-        id: cuda-toolkit
-        with:
+          tag: ${{ inputs.tag }}
+          source_artifact: ${{ inputs.source_artifact }}
           cuda: ${{ matrix.cuda }}
-          method: 'network'
+          arch: ${{ matrix.arch }}
+          archs: ${{ matrix.archs }}
+          profile: ${{ matrix.profile }}
+          max-size: ${{ matrix.klass == 'portable' && '4G' || '3G' }}
 
-      - name: Set up CUDA environment (Jimver)
-        if: matrix.cuda != '13.3'
+      # One restore step per possible shard (the parent never asks for more
+      # than three). A shard that never saved is a cache miss here and nothing
+      # else. Prefix restore, newest first, so a retry sees the latest attempt.
+      - name: Restore warm shard 0
+        if: ${{ matrix.shards >= 1 }}
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: shards/0
+          key: ccache-shard0-cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ inputs.tag }}-
+          restore-keys: |
+            ccache-shard0-cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ inputs.tag }}-
+      - name: Restore warm shard 1
+        if: ${{ matrix.shards >= 2 }}
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: shards/1
+          key: ccache-shard1-cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ inputs.tag }}-
+          restore-keys: |
+            ccache-shard1-cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ inputs.tag }}-
+      - name: Restore warm shard 2
+        if: ${{ matrix.shards >= 3 }}
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: shards/2
+          key: ccache-shard2-cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ inputs.tag }}-
+          restore-keys: |
+            ccache-shard2-cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ inputs.tag }}-
+
+      # ccache stores each result under a path derived from its hash, so
+      # laying a shard delta over the restored generation is a valid cache
+      # dir; -u makes the shard's copy of a rewritten manifest (the newer,
+      # superset one) win over the generation's. Verified 2026-09-08 on this
+      # repo's CUDA objects with the b10830 -> b10840 churn: two disjoint
+      # deltas over the b10830 generation gave a direct hit on every CUDA
+      # object of the full b10840 build. -z resets the counters so the stats
+      # step below reads this build only.
+      - name: Merge warm shards into the ccache
+        if: ${{ matrix.shards >= 1 }}
         run: |
-          echo "CUDA_PATH=${{ steps.cuda-toolkit.outputs.CUDA_PATH }}" >> "$GITHUB_ENV"
-          echo "CUDA_HOME=${{ steps.cuda-toolkit.outputs.CUDA_PATH }}" >> "$GITHUB_ENV"
-          echo "LD_LIBRARY_PATH=${{ steps.cuda-toolkit.outputs.CUDA_PATH }}/lib64:${LD_LIBRARY_PATH:-}" >> "$GITHUB_ENV"
-
-      - name: Verify CUDA
-        run: nvcc --version
-
-      - name: Configure
-        working-directory: src
-        run: |
-          set -eux
-          # Three non-obvious flags:
-          #  - CMAKE_INSTALL_RPATH=$ORIGIN + RPATH knobs: the tar.gz layout
-          #    ships sibling .so files in the same directory as the binaries.
-          #  - CMAKE_CUDA_ARCHITECTURES: explicit per-profile arch list, the
-          #    whole point of the matrix.
-          #  - CMAKE_*_COMPILER_LAUNCHER=ccache: Jimver installs nvcc outside
-          #    /usr/local/bin, so PATH-symlinked ccache misses CUDA TUs --
-          #    setting the launcher explicitly caches nvcc too.
-          # No LLAMA_FATAL_WARNINGS on this leg, unlike cpu/vulkan/macos. Here it also
-          # sets nvcc -Werror all-warnings, and the host warnings arrive through an
-          # -Xcompiler list llama.cpp composes itself, which CMAKE_CXX_FLAGS does not
-          # reach -- verified on 08-27, where the suppression added that morning was
-          # absent from the actual nvcc command line. So the warning set here is
-          # all-or-nothing, and 'all' means every libstdc++ false positive fails a
-          # release: cuda13-newer and cuda13-portable both died on a GCC 11
-          # -Wstringop-overflow inside std::copy, from ggml_cuda_try_fuse.
-          cmake -S . -B build -G Ninja \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DGGML_NATIVE=OFF \
-            -DGGML_BACKEND_DL=ON \
-            -DGGML_CPU_ALL_VARIANTS=ON \
-            -DGGML_RPC=ON \
-            -DGGML_CUDA=ON \
-            -DGGML_CUDA_CUB_3DOT2=ON \
-            -DLLAMA_BUILD_TESTS=OFF \
-            -DLLAMA_BUILD_EXAMPLES=OFF \
-            -DLLAMA_BUILD_TOOLS=ON \
-            -DLLAMA_BUILD_SERVER=ON \
-            -DCMAKE_CUDA_ARCHITECTURES="$(echo '${{ matrix.archs }}' | tr ' ' ';')" \
-            -DCMAKE_INSTALL_RPATH='$ORIGIN' \
-            -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
-            -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=OFF \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache
+          set -euo pipefail
+          for d in shards/*/; do
+            [ -d "$d" ] || continue
+            echo "merging $d ($(find "$d" -type f | wc -l) files, $(du -sh "$d" | cut -f1))"
+            cp -au "$d." "${{ github.workspace }}/.ccache/"
+          done
+          rm -rf shards
+          ccache -z
 
       - name: Build
         working-directory: src
@@ -207,7 +262,9 @@ jobs:
           # -j 3: this multi-arch nvcc build peaks at ~3 GB host RSS on the
           # 4 vCPU / 16 GB GitHub-hosted runners (x64 and arm64 alike, measured
           # over a 1s sampler), so 3 parallel TUs leave ~13 GB free. -j 4 adds
-          # no speed (the runner is ~2 physical cores + HT), so 3 is the sweet spot.
+          # no speed (the runner is ~2 physical cores + HT), so 3 is the sweet
+          # spot. nvcc --threads was measured too (2026-09-08, 4 cores): -j 2
+          # with --threads 2 came in 5% under -j 3, not worth a flag change.
           cmake --build build --config Release -j 3
           strip build/bin/llama-* || true
 
@@ -235,6 +292,21 @@ jobs:
           fi
           exit 0
 
+      # The number to read when a leg is slow. Misses here after warm shards
+      # ran means the shards did not finish; misses on every CUDA TU with the
+      # C++ hitting is a base bump that touched a shared CUDA header.
+      - name: ccache stats
+        if: ${{ always() }}
+        run: |
+          ccache -s -v
+          {
+            echo "### ccache ${{ matrix.arch }}/${{ matrix.profile }}"
+            echo ""
+            echo '```'
+            ccache -s
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Package bundle
         env:
           PLATFORM: linux
@@ -251,6 +323,9 @@ jobs:
           KLASS: ${{ matrix.klass }}
           RANK: ${{ matrix.rank }}
           TOOLKIT_LINE: ${{ matrix.toolkit_line }}
+          # Provenance label kept byte for byte as it was under the Jimver
+          # install: the bundles must stay identical, metadata included, and
+          # the compiler behind the label is the same nvcc build either way.
           DOCKER_IMAGE: github-hosted ${{ matrix.runner }}, CUDA ${{ matrix.cuda }} ${{ matrix.cuda == '13.3' && '(NVIDIA redist)' || '(Jimver)' }}
           ARCHS: ${{ matrix.archs }}
           SMS: ${{ matrix.sms }}
@@ -268,10 +343,12 @@ jobs:
         # single ~5 minute teardown window (measured ~4m50s after process
         # kill), shared by every remaining step and not replenished. Evicting
         # spends that window on housekeeping; the save is what actually needs
-        # it, and a 2 GB cache is not quick to write.
+        # it, and a multi-GB cache is not quick to write. 7 days, not 14: with
+        # a daily base bump an object that stopped hitting a week ago is dead,
+        # and the smaller dir is what keeps restore and save near a minute.
         if: ${{ !cancelled() }}
         continue-on-error: true
-        run: ccache --evict-older-than 14d
+        run: ccache --evict-older-than 7d
 
       - name: Save ccache
         # Save even when the build failed: the objects compiled before the
@@ -283,8 +360,12 @@ jobs:
         # the CANCELLATION path, not the failure path, so !cancelled() would
         # skip the save on the single most expensive case -- a leg that
         # compiled for hours and then hit the cap.
+        #
+        # Run id and attempt on the key: cache entries are immutable, so
+        # without them a retry of the same tag could never replace a partial
+        # save with a complete one. The restore prefix ignores the suffix.
         if: ${{ always() }}
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ${{ github.workspace }}/.ccache
-          key: ccache-cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ inputs.tag }}-
+          key: ccache-cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ inputs.tag }}-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/unsloth-prebuilt-cuda.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda.yml
@@ -64,6 +64,11 @@ on:
         required: false
         default: ''
         type: string
+      warm_only:
+        description: 'Run the warm shards only and save their deltas; skip the build job (daytime cache warming)'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -111,6 +116,50 @@ jobs:
           archs: ${{ matrix.archs }}
           profile: ${{ matrix.profile }}
           max-size: ${{ matrix.klass == 'portable' && '4G' || '3G' }}
+
+      # The shards restore the previous shard deltas too (any tag: the
+      # restore-keys fall back to a tagless prefix), so a daytime warm-only run
+      # leaves deltas the nightly's shards hit on, and each shard compiles only
+      # what changed since the newest delta, not since the last generation.
+      - name: Restore warm shard 0
+        if: ${{ matrix.shards >= 1 }}
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: shards/0
+          key: ccache-shard0-cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ inputs.tag }}-
+          restore-keys: |
+            ccache-shard0-cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ inputs.tag }}-
+            ccache-shard0-cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-
+      - name: Restore warm shard 1
+        if: ${{ matrix.shards >= 2 }}
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: shards/1
+          key: ccache-shard1-cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ inputs.tag }}-
+          restore-keys: |
+            ccache-shard1-cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ inputs.tag }}-
+            ccache-shard1-cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-
+      - name: Restore warm shard 2
+        if: ${{ matrix.shards >= 3 }}
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: shards/2
+          key: ccache-shard2-cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ inputs.tag }}-
+          restore-keys: |
+            ccache-shard2-cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ inputs.tag }}-
+            ccache-shard2-cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-
+
+      - name: Merge warm shards into the ccache
+        if: ${{ matrix.shards >= 1 }}
+        run: |
+          set -euo pipefail
+          for d in shards/*/; do
+            [ -d "$d" ] || continue
+            echo "merging $d ($(find "$d" -type f | wc -l) files, $(du -sh "$d" | cut -f1))"
+            cp -au "$d." "${{ github.workspace }}/.ccache/"
+          done
+          rm -rf shards
+          ccache -z
 
       # Everything the restore put in place is older than this file; the
       # export below ships only what the compile adds. The sleeps keep a
@@ -173,7 +222,7 @@ jobs:
     # this profile set), failed or timed out all mean "fewer hits", not "no
     # release". Only a cancelled run stops here.
     needs: warm
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && !inputs.warm_only }}
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -216,6 +265,7 @@ jobs:
           key: ccache-shard0-cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ inputs.tag }}-
           restore-keys: |
             ccache-shard0-cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ inputs.tag }}-
+            ccache-shard0-cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-
       - name: Restore warm shard 1
         if: ${{ matrix.shards >= 2 }}
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
@@ -224,6 +274,7 @@ jobs:
           key: ccache-shard1-cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ inputs.tag }}-
           restore-keys: |
             ccache-shard1-cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ inputs.tag }}-
+            ccache-shard1-cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-
       - name: Restore warm shard 2
         if: ${{ matrix.shards >= 3 }}
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
@@ -232,15 +283,8 @@ jobs:
           key: ccache-shard2-cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ inputs.tag }}-
           restore-keys: |
             ccache-shard2-cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ inputs.tag }}-
+            ccache-shard2-cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-
 
-      # ccache stores each result under a path derived from its hash, so
-      # laying a shard delta over the restored generation is a valid cache
-      # dir; -u makes the shard's copy of a rewritten manifest (the newer,
-      # superset one) win over the generation's. Verified 2026-09-08 on this
-      # repo's CUDA objects with the b10830 -> b10840 churn: two disjoint
-      # deltas over the b10830 generation gave a direct hit on every CUDA
-      # object of the full b10840 build. -z resets the counters so the stats
-      # step below reads this build only.
       - name: Merge warm shards into the ccache
         if: ${{ matrix.shards >= 1 }}
         run: |

--- a/.github/workflows/unsloth-prebuilt-cuda.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda.yml
@@ -179,7 +179,7 @@ jobs:
           set -euo pipefail
           cd "${{ github.workspace }}/.ccache"
           find . -type f -printf '%p\t%s\n' | sort > "${{ github.workspace }}/shard.before"
-          find . -type f -name '*M' -print0 | xargs -0 -r sha256sum | sort -k2 > "${{ github.workspace }}/shard.before.m"
+          find . -type f -name '*M' -print0 | xargs -0 -r sha256sum | sort > "${{ github.workspace }}/shard.before.m"
 
       - name: Compile shard ${{ matrix.shard }} of ${{ matrix.shards }}
         working-directory: src
@@ -216,7 +216,7 @@ jobs:
           mkdir -p "$W/shards/${{ matrix.shard }}"
           cd "$W/.ccache"
           find . -type f -printf '%p\t%s\n' | sort > "$W/shard.after"
-          find . -type f -name '*M' -print0 | xargs -0 -r sha256sum | sort -k2 > "$W/shard.after.m"
+          find . -type f -name '*M' -print0 | xargs -0 -r sha256sum | sort > "$W/shard.after.m"
           { comm -13 "$W/shard.before" "$W/shard.after" | cut -f1
             comm -13 "$W/shard.before.m" "$W/shard.after.m" | awk '{ print $2 }'; } | sort -u > "$W/shard.changed"
           xargs -a "$W/shard.changed" -d '\n' -r cp --parents -a -t "$W/shards/${{ matrix.shard }}/"

--- a/.github/workflows/unsloth-prebuilt-cuda.yml
+++ b/.github/workflows/unsloth-prebuilt-cuda.yml
@@ -148,6 +148,15 @@ jobs:
           restore-keys: |
             ccache-shard2-cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ inputs.tag }}-
             ccache-shard2-cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-
+      - name: Restore warm shard 3
+        if: ${{ matrix.shards >= 4 }}
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: shards/3
+          key: ccache-shard3-cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ inputs.tag }}-
+          restore-keys: |
+            ccache-shard3-cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ inputs.tag }}-
+            ccache-shard3-cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-
 
       - name: Merge warm shards into the ccache
         if: ${{ matrix.shards >= 1 }}
@@ -255,7 +264,7 @@ jobs:
           max-size: ${{ matrix.klass == 'portable' && '4G' || '3G' }}
 
       # One restore step per possible shard (the parent never asks for more
-      # than three). A shard that never saved is a cache miss here and nothing
+      # than four). A shard that never saved is a cache miss here and nothing
       # else. Prefix restore, newest first, so a retry sees the latest attempt.
       - name: Restore warm shard 0
         if: ${{ matrix.shards >= 1 }}
@@ -284,6 +293,15 @@ jobs:
           restore-keys: |
             ccache-shard2-cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ inputs.tag }}-
             ccache-shard2-cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-
+      - name: Restore warm shard 3
+        if: ${{ matrix.shards >= 4 }}
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: shards/3
+          key: ccache-shard3-cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ inputs.tag }}-
+          restore-keys: |
+            ccache-shard3-cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ inputs.tag }}-
+            ccache-shard3-cuda-${{ matrix.cuda }}-${{ matrix.arch }}-${{ matrix.profile }}-
 
       - name: Merge warm shards into the ccache
         if: ${{ matrix.shards >= 1 }}

--- a/.github/workflows/unsloth-prebuilt-macos.yml
+++ b/.github/workflows/unsloth-prebuilt-macos.yml
@@ -84,6 +84,19 @@ jobs:
           max-size: 2G
           save: false
 
+      - name: Configure ccache
+        # compiler_check=content: the toolchain is reinstalled on every run, so an
+        # mtime identity (the Linux default) can miss on a byte-identical compiler.
+        # The timestamp sloppiness only relaxes ccache's same-second race guard,
+        # which a tarball-extracted source tree never needs; pch_defines and locale
+        # are the documented safe set. compression_level=6 trades a few seconds of
+        # zstd per miss for a smaller cache dir, so more objects fit under max-size
+        # and the actions/cache round trip moves fewer bytes.
+        run: |
+          ccache --set-config=compiler_check=content
+          ccache --set-config=sloppiness=include_file_mtime,include_file_ctime,pch_defines,locale
+          ccache --set-config=compression_level=6
+
       - name: Build (deployment target ${{ matrix.deploy_target }})
         working-directory: src
         run: |
@@ -192,7 +205,7 @@ jobs:
         # it, and a 2 GB cache is not quick to write.
         if: ${{ !cancelled() }}
         continue-on-error: true
-        run: ccache --evict-older-than 14d
+        run: ccache --evict-older-than 7d
 
       - name: Save ccache
         # Save even when the build failed: the objects compiled before the
@@ -208,4 +221,4 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ${{ github.workspace }}/.ccache
-          key: ccache-macos-${{ matrix.build }}-${{ matrix.deploy_target }}-${{ inputs.tag }}-
+          key: ccache-macos-${{ matrix.build }}-${{ matrix.deploy_target }}-${{ inputs.tag }}-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/unsloth-prebuilt-macos.yml
+++ b/.github/workflows/unsloth-prebuilt-macos.yml
@@ -85,13 +85,8 @@ jobs:
           save: false
 
       - name: Configure ccache
-        # compiler_check=content: the toolchain is reinstalled on every run, so an
-        # mtime identity (the Linux default) can miss on a byte-identical compiler.
-        # The timestamp sloppiness only relaxes ccache's same-second race guard,
-        # which a tarball-extracted source tree never needs; pch_defines and locale
-        # are the documented safe set. compression_level=6 trades a few seconds of
-        # zstd per miss for a smaller cache dir, so more objects fit under max-size
-        # and the actions/cache round trip moves fewer bytes.
+        # compiler_check=content: the toolchain is reinstalled every run, so mtime identity misses a
+        # byte-identical compiler. Sloppiness is the documented safe set; level 6 fits more under max-size.
         run: |
           ccache --set-config=compiler_check=content
           ccache --set-config=sloppiness=include_file_mtime,include_file_ctime,pch_defines,locale

--- a/.github/workflows/unsloth-prebuilt-retry.yml
+++ b/.github/workflows/unsloth-prebuilt-retry.yml
@@ -68,7 +68,11 @@ jobs:
             exit 0
           fi
 
-          FAILED="$(awk -F'\t' '$2 == "failure"' <<<"$JOBS")"
+          # Best-effort jobs never decide a retry: the start-of-run ccache prune
+          # and the CUDA warm shards run with continue-on-error, which the jobs
+          # API still reports as "failure". The names track unsloth-prebuilt.yml
+          # and its CUDA children; the assemble waiter excludes the same two.
+          FAILED="$(awk -F'\t' '$2 == "failure" && $3 != "Prune superseded ccache generations" && index($3, " / warm ") == 0' <<<"$JOBS")"
 
           # assemble waits on the build matrix from inside the job, so a leg
           # that dies fails assemble too. Alongside another failure that is a

--- a/.github/workflows/unsloth-prebuilt-rocm.yml
+++ b/.github/workflows/unsloth-prebuilt-rocm.yml
@@ -322,13 +322,8 @@ jobs:
         save: false
 
     - name: Configure ccache
-      # compiler_check=content: the toolchain is reinstalled on every run, so an
-      # mtime identity (the Linux default) can miss on a byte-identical compiler.
-      # The timestamp sloppiness only relaxes ccache's same-second race guard,
-      # which a tarball-extracted source tree never needs; pch_defines and locale
-      # are the documented safe set. compression_level=6 trades a few seconds of
-      # zstd per miss for a smaller cache dir, so more objects fit under max-size
-      # and the actions/cache round trip moves fewer bytes.
+      # compiler_check=content: the toolchain is reinstalled every run, so mtime identity misses a
+      # byte-identical compiler. Sloppiness is the documented safe set; level 6 fits more under max-size.
       run: |
         ccache --set-config=compiler_check=content
         ccache --set-config=sloppiness=include_file_mtime,include_file_ctime,pch_defines,locale
@@ -736,20 +731,14 @@ jobs:
           rocm-linux-${{ matrix.gfx_target }}-${{ env.DETECTED_ROCM_VERSION }}
         append-timestamp: false
         variant: ccache
-        # apt on ubuntu-22.04 ships ccache 4.5.1; the binary the action pins is
-        # 4.13, the same one the Windows legs already run.
+        # ccache 4.13 from the action's binary; apt on ubuntu-22.04 ships 4.5.1.
         install: binary
         max-size: 2G
         save: false
 
     - name: Configure ccache
-      # compiler_check=content: the toolchain is reinstalled on every run, so an
-      # mtime identity (the Linux default) can miss on a byte-identical compiler.
-      # The timestamp sloppiness only relaxes ccache's same-second race guard,
-      # which a tarball-extracted source tree never needs; pch_defines and locale
-      # are the documented safe set. compression_level=6 trades a few seconds of
-      # zstd per miss for a smaller cache dir, so more objects fit under max-size
-      # and the actions/cache round trip moves fewer bytes.
+      # compiler_check=content: the toolchain is reinstalled every run, so mtime identity misses a
+      # byte-identical compiler. Sloppiness is the documented safe set; level 6 fits more under max-size.
       run: |
         ccache --set-config=compiler_check=content
         ccache --set-config=sloppiness=include_file_mtime,include_file_ctime,pch_defines,locale

--- a/.github/workflows/unsloth-prebuilt-rocm.yml
+++ b/.github/workflows/unsloth-prebuilt-rocm.yml
@@ -321,6 +321,19 @@ jobs:
         max-size: 2G
         save: false
 
+    - name: Configure ccache
+      # compiler_check=content: the toolchain is reinstalled on every run, so an
+      # mtime identity (the Linux default) can miss on a byte-identical compiler.
+      # The timestamp sloppiness only relaxes ccache's same-second race guard,
+      # which a tarball-extracted source tree never needs; pch_defines and locale
+      # are the documented safe set. compression_level=6 trades a few seconds of
+      # zstd per miss for a smaller cache dir, so more objects fit under max-size
+      # and the actions/cache round trip moves fewer bytes.
+      run: |
+        ccache --set-config=compiler_check=content
+        ccache --set-config=sloppiness=include_file_mtime,include_file_ctime,pch_defines,locale
+        ccache --set-config=compression_level=6
+
     # The parent's resolve job built the source tree (upstream base + any mix
     # PRs, with the build number/commit and Unsloth fingerprint baked
     # into cmake/build-info.cmake) and uploaded it as an artifact; extract it
@@ -555,7 +568,7 @@ jobs:
       # it, and a 2 GB cache is not quick to write.
       if: ${{ !cancelled() }}
       continue-on-error: true
-      run: ccache --evict-older-than 14d
+      run: ccache --evict-older-than 7d
 
     - name: Save ccache
       # Save even when the build failed: the objects compiled before the
@@ -571,7 +584,7 @@ jobs:
       uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
       with:
         path: ${{ github.workspace }}\.ccache
-        key: ccache-rocm-windows-${{ matrix.gfx_target }}-${{ env.DETECTED_ROCM_VERSION }}-${{ inputs.tag }}-
+        key: ccache-rocm-windows-${{ matrix.gfx_target }}-${{ env.DETECTED_ROCM_VERSION }}-${{ inputs.tag }}-${{ github.run_id }}-${{ github.run_attempt }}
 
   build-ubuntu:
     name: linux/${{ matrix.gfx_target }}
@@ -723,12 +736,24 @@ jobs:
           rocm-linux-${{ matrix.gfx_target }}-${{ env.DETECTED_ROCM_VERSION }}
         append-timestamp: false
         variant: ccache
+        # apt on ubuntu-22.04 ships ccache 4.5.1; the binary the action pins is
+        # 4.13, the same one the Windows legs already run.
+        install: binary
         max-size: 2G
         save: false
 
-    # The action sets this on Windows and macOS but leaves Linux on mtime, and ROCm is re-extracted every run, so mtime is not a reliable compiler identity.
-    - name: Hash the compiler by content, not mtime
-      run: ccache --set-config=compiler_check=content
+    - name: Configure ccache
+      # compiler_check=content: the toolchain is reinstalled on every run, so an
+      # mtime identity (the Linux default) can miss on a byte-identical compiler.
+      # The timestamp sloppiness only relaxes ccache's same-second race guard,
+      # which a tarball-extracted source tree never needs; pch_defines and locale
+      # are the documented safe set. compression_level=6 trades a few seconds of
+      # zstd per miss for a smaller cache dir, so more objects fit under max-size
+      # and the actions/cache round trip moves fewer bytes.
+      run: |
+        ccache --set-config=compiler_check=content
+        ccache --set-config=sloppiness=include_file_mtime,include_file_ctime,pch_defines,locale
+        ccache --set-config=compression_level=6
 
     # The parent's resolve job built the source tree (upstream base + any mix
     # PRs, with the build number/commit and Unsloth fingerprint baked
@@ -923,7 +948,7 @@ jobs:
       # it, and a 2 GB cache is not quick to write.
       if: ${{ !cancelled() }}
       continue-on-error: true
-      run: ccache --evict-older-than 14d
+      run: ccache --evict-older-than 7d
 
     - name: Save ccache
       # Save even when the build failed: the objects compiled before the
@@ -939,4 +964,4 @@ jobs:
       uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
       with:
         path: ${{ github.workspace }}/.ccache
-        key: ccache-rocm-linux-${{ matrix.gfx_target }}-${{ env.DETECTED_ROCM_VERSION }}-${{ inputs.tag }}-
+        key: ccache-rocm-linux-${{ matrix.gfx_target }}-${{ env.DETECTED_ROCM_VERSION }}-${{ inputs.tag }}-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/unsloth-prebuilt-vulkan.yml
+++ b/.github/workflows/unsloth-prebuilt-vulkan.yml
@@ -125,20 +125,14 @@ jobs:
             vulkan-linux-${{ matrix.arch }}
           append-timestamp: false
           variant: ccache
-          # apt on ubuntu-22.04 ships ccache 4.5.1; the binary the action pins is
-          # 4.13, the same one the Windows legs already run.
+          # ccache 4.13 from the action's binary; apt on ubuntu-22.04 ships 4.5.1.
           install: binary
           max-size: 2G
           save: false
 
       - name: Configure ccache
-        # compiler_check=content: the toolchain is reinstalled on every run, so an
-        # mtime identity (the Linux default) can miss on a byte-identical compiler.
-        # The timestamp sloppiness only relaxes ccache's same-second race guard,
-        # which a tarball-extracted source tree never needs; pch_defines and locale
-        # are the documented safe set. compression_level=6 trades a few seconds of
-        # zstd per miss for a smaller cache dir, so more objects fit under max-size
-        # and the actions/cache round trip moves fewer bytes.
+        # compiler_check=content: the toolchain is reinstalled every run, so mtime identity misses a
+        # byte-identical compiler. Sloppiness is the documented safe set; level 6 fits more under max-size.
         run: |
           ccache --set-config=compiler_check=content
           ccache --set-config=sloppiness=include_file_mtime,include_file_ctime,pch_defines,locale
@@ -339,13 +333,8 @@ jobs:
           save: false
 
       - name: Configure ccache
-        # compiler_check=content: the toolchain is reinstalled on every run, so an
-        # mtime identity (the Linux default) can miss on a byte-identical compiler.
-        # The timestamp sloppiness only relaxes ccache's same-second race guard,
-        # which a tarball-extracted source tree never needs; pch_defines and locale
-        # are the documented safe set. compression_level=6 trades a few seconds of
-        # zstd per miss for a smaller cache dir, so more objects fit under max-size
-        # and the actions/cache round trip moves fewer bytes.
+        # compiler_check=content: the toolchain is reinstalled every run, so mtime identity misses a
+        # byte-identical compiler. Sloppiness is the documented safe set; level 6 fits more under max-size.
         run: |
           ccache --set-config=compiler_check=content
           ccache --set-config=sloppiness=include_file_mtime,include_file_ctime,pch_defines,locale

--- a/.github/workflows/unsloth-prebuilt-vulkan.yml
+++ b/.github/workflows/unsloth-prebuilt-vulkan.yml
@@ -125,8 +125,24 @@ jobs:
             vulkan-linux-${{ matrix.arch }}
           append-timestamp: false
           variant: ccache
+          # apt on ubuntu-22.04 ships ccache 4.5.1; the binary the action pins is
+          # 4.13, the same one the Windows legs already run.
+          install: binary
           max-size: 2G
           save: false
+
+      - name: Configure ccache
+        # compiler_check=content: the toolchain is reinstalled on every run, so an
+        # mtime identity (the Linux default) can miss on a byte-identical compiler.
+        # The timestamp sloppiness only relaxes ccache's same-second race guard,
+        # which a tarball-extracted source tree never needs; pch_defines and locale
+        # are the documented safe set. compression_level=6 trades a few seconds of
+        # zstd per miss for a smaller cache dir, so more objects fit under max-size
+        # and the actions/cache round trip moves fewer bytes.
+        run: |
+          ccache --set-config=compiler_check=content
+          ccache --set-config=sloppiness=include_file_mtime,include_file_ctime,pch_defines,locale
+          ccache --set-config=compression_level=6
 
       # Ubuntu 22.04 has an arm64 Vulkan loader, but its headers are too old for
       # the current backend and it has no glslc package. Install matching pinned
@@ -259,7 +275,7 @@ jobs:
         # it, and a 2 GB cache is not quick to write.
         if: ${{ !cancelled() }}
         continue-on-error: true
-        run: ccache --evict-older-than 14d
+        run: ccache --evict-older-than 7d
 
       - name: Save ccache
         # Save even when the build failed: the objects compiled before the
@@ -275,7 +291,7 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ${{ github.workspace }}/.ccache
-          key: ccache-vulkan-linux-${{ matrix.arch }}-${{ inputs.tag }}-
+          key: ccache-vulkan-linux-${{ matrix.arch }}-${{ inputs.tag }}-${{ github.run_id }}-${{ github.run_attempt }}
 
   build-windows:
     name: windows/x64
@@ -321,6 +337,19 @@ jobs:
           variant: ccache
           max-size: 2G
           save: false
+
+      - name: Configure ccache
+        # compiler_check=content: the toolchain is reinstalled on every run, so an
+        # mtime identity (the Linux default) can miss on a byte-identical compiler.
+        # The timestamp sloppiness only relaxes ccache's same-second race guard,
+        # which a tarball-extracted source tree never needs; pch_defines and locale
+        # are the documented safe set. compression_level=6 trades a few seconds of
+        # zstd per miss for a smaller cache dir, so more objects fit under max-size
+        # and the actions/cache round trip moves fewer bytes.
+        run: |
+          ccache --set-config=compiler_check=content
+          ccache --set-config=sloppiness=include_file_mtime,include_file_ctime,pch_defines,locale
+          ccache --set-config=compression_level=6
 
       - name: Install Ninja
         run: choco install ninja --no-progress
@@ -454,7 +483,7 @@ jobs:
         # it, and a 2 GB cache is not quick to write.
         if: ${{ !cancelled() }}
         continue-on-error: true
-        run: ccache --evict-older-than 14d
+        run: ccache --evict-older-than 7d
 
       - name: Save ccache
         # Save even when the build failed: the objects compiled before the
@@ -470,4 +499,4 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ${{ github.workspace }}\.ccache
-          key: ccache-vulkan-windows-x64-${{ inputs.tag }}-
+          key: ccache-vulkan-windows-x64-${{ inputs.tag }}-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -466,8 +466,18 @@ jobs:
           WIN_CUDA_MATRIX: ${{ steps.r.outputs.win_cuda_matrix }}
         run: |
           set -euo pipefail
-          SHARDS='if .klass == "legacy" then 0 elif .klass == "portable" and .arch == "x64" then 3 else 2 end'
-          WIN_SHARDS='if .klass == "legacy" then 0 elif .klass == "portable" then 4 else 2 end'
+          # Warm shards are DISABLED for now (every profile 0): the nightly runs
+          # its 42 jobs as before and the CUDA children skip their `warm` job.
+          # The caching fixes in this branch (ccache 4.13, content check,
+          # cache sizes, one generation per prefix, redist toolkit) do not
+          # depend on them. To enable, restore the measured sizing:
+          #   SHARDS='if .klass == "legacy" then 0 elif .klass == "portable" and .arch == "x64" then 3 else 2 end'
+          #   WIN_SHARDS='if .klass == "legacy" then 0 elif .klass == "portable" then 4 else 2 end'
+          # (staging run 34205486511: cuda12-older cold leg 100 -> 64 min on
+          # Windows, 53 -> 43 on Linux; every CUDA object a direct hit in the
+          # build after the shard merge).
+          SHARDS='0'
+          WIN_SHARDS='0'
           expand_warm() { # $1 = shard rule
             jq -c ".include | [.[] | . as \$r | ($1) as \$k | select(\$k > 0) | range(\$k) as \$s | \$r + {shards: \$k, shard: \$s}]"
           }

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -29,14 +29,6 @@ name: Unsloth prebuilt (full release)
 on:
   schedule:
     - cron: '13 20 * * *'      # ~1PM San Francisco PDT / ~12PM PST (UTC; not DST adjusted)
-    # Daytime warm, six hours ahead of the nightly: resolves the newest
-    # upstream tag with no aging window (which is exactly the tag the nightly
-    # will pick six hours later, when it has aged six hours), runs only the
-    # CUDA warm shards against it and saves their deltas. The nightly's shards
-    # then restore those deltas and compile just what changed since 14:13
-    # instead of since yesterday. No bundle is built, nothing is published,
-    # so the shipped bits cannot change; it is purely cache preparation.
-    - cron: '13 14 * * *'
   workflow_dispatch:
     inputs:
       tag:
@@ -80,11 +72,6 @@ on:
         default: false
         required: false
         type: boolean
-      warm_only:
-        description: 'Only run the CUDA warm shards and save their cache deltas (what the 14:13 UTC schedule does); no bundles, no publish'
-        default: false
-        required: false
-        type: boolean
 
 permissions:
   contents: write
@@ -95,8 +82,6 @@ env:
   # release has time to be caught and yanked before we compile and ship it. An
   # explicit b#### tag (manual run) skips it. Per-run override via min_age_hours.
   UNSLOTH_LLAMA_MIN_RELEASE_AGE_HOURS: "6"
-  # The schedule entry that means "warm the CUDA caches, build nothing".
-  UNSLOTH_LLAMA_WARM_CRON: "13 14 * * *"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.inputs.tag || 'scheduled' }}
@@ -124,7 +109,6 @@ jobs:
       ggml_tree: ${{ steps.r.outputs.ggml_tree }}
       ggml_version: ${{ steps.r.outputs.ggml_version }}
       exists: ${{ steps.r.outputs.exists }}
-      warm_only: ${{ steps.w.outputs.warm_only }}
       # The CUDA matrices pass through the `warm` step, which stamps `shards`.
       cuda_matrix: ${{ steps.warm.outputs.cuda_matrix }}
       win_cuda_matrix: ${{ steps.warm.outputs.win_cuda_matrix }}
@@ -140,14 +124,6 @@ jobs:
       # in-place to merge the PRs.
       - name: Checkout (pr-set.json + mix merge workspace)
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
-      # Warm-only mode: the 14:13 schedule, or the warm_only dispatch input.
-      - id: w
-        run: |
-          WARM_ONLY=false
-          if [ '${{ github.event.schedule }}' = "$UNSLOTH_LLAMA_WARM_CRON" ] || [ '${{ inputs.warm_only }}' = 'true' ]; then WARM_ONLY=true; fi
-          echo "WARM_ONLY=$WARM_ONLY" >> "$GITHUB_ENV"
-          echo "warm_only=$WARM_ONLY" >> "$GITHUB_OUTPUT"
-          echo "warm_only=$WARM_ONLY"
       - id: r
         run: |
           set -euo pipefail
@@ -171,7 +147,6 @@ jobs:
               *) echo "refusing to publish operating_systems='$OS_LIST': both windows and ubuntu ROCm bundles are required. Use publish=false for a subset test." >&2; exit 1 ;;
             esac
           fi
-          [ "$WARM_ONLY" = true ] && AGE_H=0
           [ -n "$AGE_H" ] || AGE_H="${UNSLOTH_LLAMA_MIN_RELEASE_AGE_HOURS:-6}"
           if [ "$REQ" = "latest" ]; then
             # Newest published b#### build release that has been public for
@@ -586,7 +561,6 @@ jobs:
       commit: ${{ needs.resolve.outputs.commit }}
       matrix: ${{ needs.resolve.outputs.cuda_matrix }}
       warm_matrix: ${{ needs.resolve.outputs.cuda_warm_matrix }}
-      warm_only: ${{ needs.resolve.outputs.warm_only == 'true' }}
 
   build-windows-cuda:
     name: CUDA Windows
@@ -600,7 +574,6 @@ jobs:
       commit: ${{ needs.resolve.outputs.commit }}
       matrix: ${{ needs.resolve.outputs.win_cuda_matrix }}
       warm_matrix: ${{ needs.resolve.outputs.win_cuda_warm_matrix }}
-      warm_only: ${{ needs.resolve.outputs.warm_only == 'true' }}
     secrets: inherit
 
   # First of the two ccache prunes (scripts/unsloth/prune_ccache.sh has the
@@ -629,7 +602,7 @@ jobs:
   build-rocm:
     name: ROCm
     needs: resolve
-    if: ${{ (needs.resolve.outputs.exists != 'true' || github.event_name == 'workflow_dispatch') && needs.resolve.outputs.warm_only != 'true' }}
+    if: ${{ needs.resolve.outputs.exists != 'true' || github.event_name == 'workflow_dispatch' }}
     uses: ./.github/workflows/unsloth-prebuilt-rocm.yml
     with:
       tag: ${{ needs.resolve.outputs.tag }}
@@ -644,7 +617,7 @@ jobs:
   build-macos:
     name: macOS
     needs: resolve
-    if: ${{ (needs.resolve.outputs.exists != 'true' || github.event_name == 'workflow_dispatch') && needs.resolve.outputs.warm_only != 'true' }}
+    if: ${{ needs.resolve.outputs.exists != 'true' || github.event_name == 'workflow_dispatch' }}
     uses: ./.github/workflows/unsloth-prebuilt-macos.yml
     with:
       tag: ${{ needs.resolve.outputs.tag }}
@@ -655,7 +628,7 @@ jobs:
   build-cpu:
     name: CPU
     needs: resolve
-    if: ${{ (needs.resolve.outputs.exists != 'true' || github.event_name == 'workflow_dispatch') && needs.resolve.outputs.warm_only != 'true' }}
+    if: ${{ needs.resolve.outputs.exists != 'true' || github.event_name == 'workflow_dispatch' }}
     uses: ./.github/workflows/unsloth-prebuilt-cpu.yml
     with:
       tag: ${{ needs.resolve.outputs.tag }}
@@ -666,7 +639,7 @@ jobs:
   build-vulkan:
     name: Vulkan
     needs: resolve
-    if: ${{ (needs.resolve.outputs.exists != 'true' || github.event_name == 'workflow_dispatch') && needs.resolve.outputs.warm_only != 'true' }}
+    if: ${{ needs.resolve.outputs.exists != 'true' || github.event_name == 'workflow_dispatch' }}
     uses: ./.github/workflows/unsloth-prebuilt-vulkan.yml
     with:
       tag: ${{ needs.resolve.outputs.tag }}
@@ -688,7 +661,7 @@ jobs:
     # `needs:`: that step blocks until every sibling build job is finished and
     # exits non-zero unless all of them succeeded, so a failed leg still
     # publishes nothing. The installer needs the full bundle set or it'll fail.
-    if: ${{ (needs.resolve.outputs.exists != 'true' || github.event_name == 'workflow_dispatch') && needs.resolve.outputs.warm_only != 'true' }}
+    if: ${{ needs.resolve.outputs.exists != 'true' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-24.04
     # Consumed by the reclaim job below: 'true' only when THIS run's publish
     # step actually ran and succeeded.
@@ -1332,9 +1305,7 @@ jobs:
   alert:
     name: Report pipeline health
     needs: [resolve, build-cuda, build-windows-cuda, build-rocm, build-macos, build-cpu, build-vulkan, assemble]
-    # Not for the warm-only schedule: it builds no bundle, so there is no
-    # publish to miss.
-    if: ${{ always() && (github.event_name == 'schedule' || inputs.publish) && needs.resolve.outputs.warm_only != 'true' }}
+    if: ${{ always() && (github.event_name == 'schedule' || inputs.publish) }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -29,6 +29,14 @@ name: Unsloth prebuilt (full release)
 on:
   schedule:
     - cron: '13 20 * * *'      # ~1PM San Francisco PDT / ~12PM PST (UTC; not DST adjusted)
+    # Daytime warm, six hours ahead of the nightly: resolves the newest
+    # upstream tag with no aging window (which is exactly the tag the nightly
+    # will pick six hours later, when it has aged six hours), runs only the
+    # CUDA warm shards against it and saves their deltas. The nightly's shards
+    # then restore those deltas and compile just what changed since 14:13
+    # instead of since yesterday. No bundle is built, nothing is published,
+    # so the shipped bits cannot change; it is purely cache preparation.
+    - cron: '13 14 * * *'
   workflow_dispatch:
     inputs:
       tag:
@@ -72,6 +80,11 @@ on:
         default: false
         required: false
         type: boolean
+      warm_only:
+        description: 'Only run the CUDA warm shards and save their cache deltas (what the 14:13 UTC schedule does); no bundles, no publish'
+        default: false
+        required: false
+        type: boolean
 
 permissions:
   contents: write
@@ -82,6 +95,8 @@ env:
   # release has time to be caught and yanked before we compile and ship it. An
   # explicit b#### tag (manual run) skips it. Per-run override via min_age_hours.
   UNSLOTH_LLAMA_MIN_RELEASE_AGE_HOURS: "6"
+  # The schedule entry that means "warm the CUDA caches, build nothing".
+  UNSLOTH_LLAMA_WARM_CRON: "13 14 * * *"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.inputs.tag || 'scheduled' }}
@@ -109,6 +124,7 @@ jobs:
       ggml_tree: ${{ steps.r.outputs.ggml_tree }}
       ggml_version: ${{ steps.r.outputs.ggml_version }}
       exists: ${{ steps.r.outputs.exists }}
+      warm_only: ${{ steps.w.outputs.warm_only }}
       # The CUDA matrices pass through the `warm` step, which stamps `shards`.
       cuda_matrix: ${{ steps.warm.outputs.cuda_matrix }}
       win_cuda_matrix: ${{ steps.warm.outputs.win_cuda_matrix }}
@@ -124,6 +140,14 @@ jobs:
       # in-place to merge the PRs.
       - name: Checkout (pr-set.json + mix merge workspace)
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
+      # Warm-only mode: the 14:13 schedule, or the warm_only dispatch input.
+      - id: w
+        run: |
+          WARM_ONLY=false
+          if [ '${{ github.event.schedule }}' = "$UNSLOTH_LLAMA_WARM_CRON" ] || [ '${{ inputs.warm_only }}' = 'true' ]; then WARM_ONLY=true; fi
+          echo "WARM_ONLY=$WARM_ONLY" >> "$GITHUB_ENV"
+          echo "warm_only=$WARM_ONLY" >> "$GITHUB_OUTPUT"
+          echo "warm_only=$WARM_ONLY"
       - id: r
         run: |
           set -euo pipefail
@@ -147,6 +171,7 @@ jobs:
               *) echo "refusing to publish operating_systems='$OS_LIST': both windows and ubuntu ROCm bundles are required. Use publish=false for a subset test." >&2; exit 1 ;;
             esac
           fi
+          [ "$WARM_ONLY" = true ] && AGE_H=0
           [ -n "$AGE_H" ] || AGE_H="${UNSLOTH_LLAMA_MIN_RELEASE_AGE_HOURS:-6}"
           if [ "$REQ" = "latest" ]; then
             # Newest published b#### build release that has been public for
@@ -557,6 +582,7 @@ jobs:
       commit: ${{ needs.resolve.outputs.commit }}
       matrix: ${{ needs.resolve.outputs.cuda_matrix }}
       warm_matrix: ${{ needs.resolve.outputs.cuda_warm_matrix }}
+      warm_only: ${{ needs.resolve.outputs.warm_only == 'true' }}
 
   build-windows-cuda:
     name: CUDA Windows
@@ -570,6 +596,7 @@ jobs:
       commit: ${{ needs.resolve.outputs.commit }}
       matrix: ${{ needs.resolve.outputs.win_cuda_matrix }}
       warm_matrix: ${{ needs.resolve.outputs.win_cuda_warm_matrix }}
+      warm_only: ${{ needs.resolve.outputs.warm_only == 'true' }}
     secrets: inherit
 
   # First of the two ccache prunes (scripts/unsloth/prune_ccache.sh has the
@@ -598,7 +625,7 @@ jobs:
   build-rocm:
     name: ROCm
     needs: resolve
-    if: ${{ needs.resolve.outputs.exists != 'true' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ (needs.resolve.outputs.exists != 'true' || github.event_name == 'workflow_dispatch') && needs.resolve.outputs.warm_only != 'true' }}
     uses: ./.github/workflows/unsloth-prebuilt-rocm.yml
     with:
       tag: ${{ needs.resolve.outputs.tag }}
@@ -613,7 +640,7 @@ jobs:
   build-macos:
     name: macOS
     needs: resolve
-    if: ${{ needs.resolve.outputs.exists != 'true' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ (needs.resolve.outputs.exists != 'true' || github.event_name == 'workflow_dispatch') && needs.resolve.outputs.warm_only != 'true' }}
     uses: ./.github/workflows/unsloth-prebuilt-macos.yml
     with:
       tag: ${{ needs.resolve.outputs.tag }}
@@ -624,7 +651,7 @@ jobs:
   build-cpu:
     name: CPU
     needs: resolve
-    if: ${{ needs.resolve.outputs.exists != 'true' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ (needs.resolve.outputs.exists != 'true' || github.event_name == 'workflow_dispatch') && needs.resolve.outputs.warm_only != 'true' }}
     uses: ./.github/workflows/unsloth-prebuilt-cpu.yml
     with:
       tag: ${{ needs.resolve.outputs.tag }}
@@ -635,7 +662,7 @@ jobs:
   build-vulkan:
     name: Vulkan
     needs: resolve
-    if: ${{ needs.resolve.outputs.exists != 'true' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ (needs.resolve.outputs.exists != 'true' || github.event_name == 'workflow_dispatch') && needs.resolve.outputs.warm_only != 'true' }}
     uses: ./.github/workflows/unsloth-prebuilt-vulkan.yml
     with:
       tag: ${{ needs.resolve.outputs.tag }}
@@ -657,7 +684,7 @@ jobs:
     # `needs:`: that step blocks until every sibling build job is finished and
     # exits non-zero unless all of them succeeded, so a failed leg still
     # publishes nothing. The installer needs the full bundle set or it'll fail.
-    if: ${{ needs.resolve.outputs.exists != 'true' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ (needs.resolve.outputs.exists != 'true' || github.event_name == 'workflow_dispatch') && needs.resolve.outputs.warm_only != 'true' }}
     runs-on: ubuntu-24.04
     # Consumed by the reclaim job below: 'true' only when THIS run's publish
     # step actually ran and succeeded.
@@ -1301,7 +1328,9 @@ jobs:
   alert:
     name: Report pipeline health
     needs: [resolve, build-cuda, build-windows-cuda, build-rocm, build-macos, build-cpu, build-vulkan, assemble]
-    if: ${{ always() && (github.event_name == 'schedule' || inputs.publish) }}
+    # Not for the warm-only schedule: it builds no bundle, so there is no
+    # publish to miss.
+    if: ${{ always() && (github.event_name == 'schedule' || inputs.publish) && needs.resolve.outputs.warm_only != 'true' }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -109,8 +109,11 @@ jobs:
       ggml_tree: ${{ steps.r.outputs.ggml_tree }}
       ggml_version: ${{ steps.r.outputs.ggml_version }}
       exists: ${{ steps.r.outputs.exists }}
-      cuda_matrix: ${{ steps.r.outputs.cuda_matrix }}
-      win_cuda_matrix: ${{ steps.r.outputs.win_cuda_matrix }}
+      # The CUDA matrices pass through the `warm` step, which stamps `shards`.
+      cuda_matrix: ${{ steps.warm.outputs.cuda_matrix }}
+      win_cuda_matrix: ${{ steps.warm.outputs.win_cuda_matrix }}
+      cuda_warm_matrix: ${{ steps.warm.outputs.cuda_warm_matrix }}
+      win_cuda_warm_matrix: ${{ steps.warm.outputs.win_cuda_warm_matrix }}
       rocm_matrix: ${{ steps.r.outputs.rocm_matrix }}
       rocm_cutoff: ${{ steps.r.outputs.rocm_cutoff }}
       macos_matrix: ${{ steps.r.outputs.macos_matrix }}
@@ -409,6 +412,7 @@ jobs:
           # CUDA Windows reuses the x64 profiles (same arch lists / CUDA
           # versions), just on a Windows runner. arm64 has no CUDA Windows target.
           WIN_CUDA_INCLUDE="$(echo "$CUDA_INCLUDE" | jq -c '[.[] | select(.arch=="x64") | .runner="windows-2022"]')"
+
           [ -n "$GFX" ] || { echo "refusing empty gfx_target (would publish a CUDA-only release labeled CUDA + ROCm)" >&2; exit 1; }
           ROCM_MATRIX="$(jq -cn --arg g "$GFX" '{gfx_target: ($g | split(",") | map(gsub("^\\s+|\\s+$"; "")))}')"
 
@@ -443,6 +447,40 @@ jobs:
             echo "macos_matrix={\"include\":$MACOS_INCLUDE}"
           } >> "$GITHUB_OUTPUT"
           echo "Resolved $REQ -> $TAG ($COMMIT); prs=$PRS; source_artifact=${SRC_ARTIFACT:-none}; release exists=$EXISTS; only=$ONLY; gfx=$GFX"
+
+      # Warm shards for the CUDA children (see their headers): each profile row
+      # is dealt into `shards` parallel jobs that pre-compile a slice of the
+      # ggml-cuda objects through ccache. Sized by cold cost on run
+      # 34168016006: portable 189 min (3 shards), older/newer 55-104 min (2),
+      # legacy 22 min (none), arm64 portable 42 min (2). An empty string, not an
+      # empty include list, tells the child to skip the job.
+      # Its own step, not more script in `r`: GitHub caps one workflow string at
+      # 21000 chars and that step is at it. See check_workflow_scalars.py.
+      - name: Warm shard matrix for the CUDA children
+        id: warm
+        env:
+          CUDA_MATRIX: ${{ steps.r.outputs.cuda_matrix }}
+          WIN_CUDA_MATRIX: ${{ steps.r.outputs.win_cuda_matrix }}
+        run: |
+          set -euo pipefail
+          SHARDS='if .klass == "legacy" then 0 elif .klass == "portable" and .arch == "x64" then 3 else 2 end'
+          expand_warm() {
+            jq -c ".include | [.[] | . as \$r | ($SHARDS) as \$k | select(\$k > 0) | range(\$k) as \$s | \$r + {shards: \$k, shard: \$s}]"
+          }
+          [ -n "${CUDA_MATRIX:-}" ] || CUDA_MATRIX='{"include":[]}'
+          [ -n "${WIN_CUDA_MATRIX:-}" ] || WIN_CUDA_MATRIX='{"include":[]}'
+          CUDA_WARM="$(printf '%s' "$CUDA_MATRIX" | expand_warm)"
+          WIN_CUDA_WARM="$(printf '%s' "$WIN_CUDA_MATRIX" | expand_warm)"
+          # The build rows learn their own shard count too: the build job
+          # restores exactly that many shard caches before it merges them.
+          with_shards() { jq -c "{include: [.include[] | . + {shards: ($SHARDS)}]}"; }
+          {
+            echo "cuda_matrix=$(printf '%s' "$CUDA_MATRIX" | with_shards)"
+            echo "win_cuda_matrix=$(printf '%s' "$WIN_CUDA_MATRIX" | with_shards)"
+            [ "$CUDA_WARM" = "[]" ] && echo "cuda_warm_matrix=" || echo "cuda_warm_matrix={\"include\":$CUDA_WARM}"
+            [ "$WIN_CUDA_WARM" = "[]" ] && echo "win_cuda_warm_matrix=" || echo "win_cuda_warm_matrix={\"include\":$WIN_CUDA_WARM}"
+          } >> "$GITHUB_OUTPUT"
+          echo "warm shards: linux $(jq length <<<"$CUDA_WARM"), windows $(jq length <<<"$WIN_CUDA_WARM")"
 
       # A bad pin resolution can still build fine, so it must be caught before the source artifact ships. See merge_checks.py.
       # Its own step, not more script in `resolve`: GitHub caps one workflow string at 21000 chars and that step is near it. See check_workflow_scalars.py.
@@ -518,6 +556,7 @@ jobs:
       source_artifact: ${{ needs.resolve.outputs.source_artifact }}
       commit: ${{ needs.resolve.outputs.commit }}
       matrix: ${{ needs.resolve.outputs.cuda_matrix }}
+      warm_matrix: ${{ needs.resolve.outputs.cuda_warm_matrix }}
 
   build-windows-cuda:
     name: CUDA Windows
@@ -530,7 +569,31 @@ jobs:
       source_artifact: ${{ needs.resolve.outputs.source_artifact }}
       commit: ${{ needs.resolve.outputs.commit }}
       matrix: ${{ needs.resolve.outputs.win_cuda_matrix }}
+      warm_matrix: ${{ needs.resolve.outputs.win_cuda_warm_matrix }}
     secrets: inherit
+
+  # First of the two ccache prunes (scripts/unsloth/prune_ccache.sh has the
+  # whole rationale): before any leg restores, so the run starts from one
+  # generation per prefix and old + new fit under the limit while it builds.
+  # Never on the assemble waiter's critical path and never a reason to fail a
+  # release; the waiter excludes this job by name.
+  prune-ccache:
+    name: Prune superseded ccache generations
+    needs: resolve
+    if: ${{ needs.resolve.outputs.exists != 'true' || github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    continue-on-error: true
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Checkout build tooling (this repo)
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
+      - name: Prune
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash scripts/unsloth/prune_ccache.sh --keep 1 --limit-gb 75
 
   build-rocm:
     name: ROCm
@@ -630,6 +693,12 @@ jobs:
           PREFIXES=('CUDA / ' 'CUDA Windows / ' 'ROCm / ' 'macOS / ' 'CPU / ' 'Vulkan / ')
           SELF='Assemble metadata + publish'
           ALERT='Report pipeline health'
+          # Housekeeping and best-effort jobs that must never gate a publish:
+          # the start-of-run ccache prune, and the CUDA children's warm shards
+          # ("CUDA / warm x64/cuda12-portable 0/3"), which only pre-fill the
+          # compiler cache for the real build legs.
+          PRUNE='Prune superseded ccache generations'
+          WARM=' / warm '
 
           POLL=60
           DEADLINE=$(( $(date +%s) + 330 * 60 ))
@@ -657,12 +726,28 @@ jobs:
             # Everything in the run except this job and the alert job that
             # reports on it. `resolve` stays in the set; it is already a
             # `needs:`, so it is a free consistency check.
-            SIBS="$(printf '%s\n' "$JOBS" | awk -F'\t' -v self="$SELF" -v alert="$ALERT" 'NF && $1 != self && $1 != alert')"
+            SIBS="$(printf '%s\n' "$JOBS" | awk -F'\t' -v self="$SELF" -v alert="$ALERT" -v prune="$PRUNE" -v warm="$WARM" \
+              'NF && $1 != self && $1 != alert && $1 != prune && index($1, warm) == 0')"
 
-            MISSING=""
+            # Two kinds of "not there yet". A child with no job record at all
+            # is the startup race and is fatal after STARTUP_DEADLINE. A child
+            # whose only records are warm shards is a CUDA child whose build
+            # legs sit behind `needs: warm`: GitHub creates those records only
+            # once the shards finish (52 minutes on a cold Windows profile,
+            # staging run 34205486511), so that case waits on the run's own
+            # deadline instead. Without the split, a run with warm shards
+            # either dies at 45 minutes or, worse, sees a moment where every
+            # existing record is complete and publishes without the builds.
+            MISSING=""; UNSCHEDULED=""
             for p in "${PREFIXES[@]}"; do
-              printf '%s\n' "$SIBS" | awk -F'\t' -v p="$p" 'index($1, p) == 1 { found = 1 } END { exit !found }' \
-                || MISSING="${MISSING} '${p}'"
+              if printf '%s\n' "$SIBS" | awk -F'\t' -v p="$p" 'index($1, p) == 1 { found = 1 } END { exit !found }'; then
+                continue
+              fi
+              if printf '%s\n' "$JOBS" | awk -F'\t' -v p="$p" 'index($1, p) == 1 { found = 1 } END { exit !found }'; then
+                UNSCHEDULED="${UNSCHEDULED} '${p}'"
+              else
+                MISSING="${MISSING} '${p}'"
+              fi
             done
             if [ -n "$MISSING" ]; then
               if [ "$(date +%s)" -gt "$STARTUP_DEADLINE" ]; then
@@ -670,6 +755,15 @@ jobs:
                 exit 1
               fi
               echo "waiting for job records to appear for:${MISSING}"
+              sleep "$POLL"
+              continue
+            fi
+            if [ -n "$UNSCHEDULED" ]; then
+              if [ "$(date +%s)" -gt "$DEADLINE" ]; then
+                echo "ERROR: timed out before the build legs of${UNSCHEDULED} were scheduled behind their warm shards" >&2
+                exit 1
+              fi
+              echo "warm shards still running, build legs not yet scheduled for:${UNSCHEDULED}"
               sleep "$POLL"
               continue
             fi
@@ -1177,81 +1271,29 @@ jobs:
             echo "| delete failures | $failed |"
           } >> "$GITHUB_STEP_SUMMARY"
 
+      # The prune script lives in the tree; nothing above in this job needed a
+      # checkout. Read-only clone, no token left behind.
+      - name: Checkout build tooling (this repo)
+        if: ${{ needs.assemble.outputs.published == 'true' }}
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
+        with:
+          path: tooling
+          persist-credentials: false
+
       # ── Keep the ccache budget inside the repo limit ──
       #
-      # ccache entries are immutable, so every run writes a NEW cache per
-      # (cuda, os, profile) and finds the previous one by restore-keys prefix.
-      # restore-keys returns only the MOST RECENT match, so older generations can
-      # never be selected again -- they are pure landfill. Measured 2026-08-08:
-      # 122 caches / 31.72 GiB, of which only 40 / 9.13 GiB were reachable.
-      #
-      # That matters for build time, not tidiness. The repo cache limit is 50 GB
-      # and there are ~40 prefixes; once the total hits the limit GitHub evicts by
-      # its own LRU, which can take a LIVE cache. A partial cache is far worse
-      # than none: measured locally over 513 real translation units, capping a
-      # cache to 30% of what the build needs drops the hit rate to 14.2% and
-      # flips hits from direct to preprocessed -- the exact 3-direct /
-      # 52-preprocessed signature seen in CI when the cap was 500 MB, which cost
-      # a 204-minute build instead of 54.
-      #
-      # Keeping 2 rather than 1: the second generation is the fallback when a job
-      # dies before saving, which is precisely the hole that forces a cold build.
+      # Second of the two prunes; the first runs right after `resolve`. See
+      # scripts/unsloth/prune_ccache.sh for the whole rationale. Published
+      # runs only, as before: a cancelled run's children may not have written
+      # their caches yet, and pruning against a half-written set could drop a
+      # live generation -- a partial cache is worse than a stale one.
       - name: Prune superseded ccache generations
-        # Unchanged trigger: this job now runs on every outcome for artifact
-        # cleanup, but cache pruning stays on published runs only. A cancelled
-        # run's children may not have written their caches yet, and pruning
-        # "superseded" generations against a half-written set could drop a live
-        # one -- a partial cache is worse than a stale one.
         if: ${{ needs.assemble.outputs.published == 'true' }}
         # Never fail a published release over cache housekeeping.
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
-          KEEP: 2
-        run: |
-          set -euo pipefail
-          repo="$GITHUB_REPOSITORY"
-          all="$RUNNER_TEMP/caches.tsv"
-          gh api --paginate "repos/$repo/actions/caches?per_page=100" \
-            -q '.actions_caches[] | "\(.id)\t\(.created_at)\t\(.size_in_bytes)\t\(.key)"' > "$all" || true
-          total=$(awk -F'\t' '{s+=$3} END {printf "%d", s+0}' "$all")
-          echo "$(grep -c . "$all" || true) caches, $(( total / 1073741824 )) GiB"
-
-          # Group by the restore-keys prefix: the key minus its -<tag>- suffix.
-          # Newest first, so anything past $KEEP is unreachable by restore-keys.
-          # The ROCm version comes off too, else every weekly toolchain becomes its own group and keeps 2 caches that can never hit again.
-          freed=0; deleted=0
-          while IFS=$'\t' read -r id created size key; do
-            [ -z "${id:-}" ] && continue
-            pre="$(printf '%s' "$key" | sed -E 's/-b[0-9]+(-mix-[0-9a-f]+)?-?$//; s/-[0-9]+\.[0-9]+\.[0-9]+(a|rc)[0-9]+$//')"
-            printf '%s\t%s\t%s\t%s\n' "$pre" "$created" "$id" "$size"
-          done < "$all" | sort -t"$(printf '\t')" -k1,1 -k2,2r > "$RUNNER_TEMP/grouped.tsv"
-
-          prev=""; n=0
-          while IFS=$'\t' read -r pre created id size; do
-            [ -z "${pre:-}" ] && continue
-            if [ "$pre" != "$prev" ]; then prev="$pre"; n=1; else n=$(( n + 1 )); fi
-            [ "$n" -le "$KEEP" ] && continue
-            if gh api -X DELETE "repos/$repo/actions/caches/$id" --silent < /dev/null 2>/dev/null; then
-              freed=$(( freed + size )); deleted=$(( deleted + 1 ))
-            fi
-          done < "$RUNNER_TEMP/grouped.tsv"
-
-          after=$(( total - freed ))
-          echo "pruned $deleted superseded caches, freed $(( freed / 1073741824 )) GiB"
-          {
-            echo "### ccache budget"
-            echo ""
-            echo "| metric | value |"
-            echo "| --- | --- |"
-            echo "| kept per prefix | $KEEP |"
-            echo "| caches pruned | $deleted |"
-            echo "| freed | $(( freed / 1073741824 )) GiB |"
-            echo "| cache total after | $(( after / 1073741824 )) GiB of 50 GB |"
-          } >> "$GITHUB_STEP_SUMMARY"
-          if [ "$after" -gt 42949672960 ]; then
-            echo "::warning::ccache total is $(( after / 1073741824 )) GiB of the 50 GB repo limit; at the limit GitHub evicts by LRU and a partially evicted cache collapses the hit rate. Lower KEEP to 1, or raise the limit."
-          fi
+        run: bash tooling/scripts/unsloth/prune_ccache.sh --keep 1 --limit-gb 75
 
   # Without this a failed scheduled run is silent: GitHub emails only whoever
   # last touched the cron file, which is how three nightlies failed unnoticed.

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -448,17 +448,10 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           echo "Resolved $REQ -> $TAG ($COMMIT); prs=$PRS; source_artifact=${SRC_ARTIFACT:-none}; release exists=$EXISTS; only=$ONLY; gfx=$GFX"
 
-      # Warm shards for the CUDA children (see their headers): each profile row
-      # is dealt into `shards` parallel jobs that pre-compile a slice of the
-      # ggml-cuda objects through ccache. Sized by cold cost on run
-      # 34168016006: Windows portable 189 / 138 min (4 shards; it is the
-      # critical path and 1.6x slower than Linux per object), Linux x64
-      # portable 117 / 103 min (3), older/newer 55-104 min (2), legacy 22 min
-      # (none), arm64 portable 42 min (2). The children restore up to four
-      # shards. An empty string, not an empty include list, tells the child to
-      # skip the job.
-      # Its own step, not more script in `r`: GitHub caps one workflow string at
-      # 21000 chars and that step is at it. See check_workflow_scalars.py.
+      # Warm shards for the CUDA children: each profile row is dealt into `shards` jobs that
+      # pre-compile a slice of ggml-cuda through ccache; the children restore up to four. An
+      # empty string, not an empty include list, tells the child to skip the job. Its own step:
+      # GitHub caps one workflow string at 21000 chars and `r` is at it (check_workflow_scalars.py).
       - name: Warm shard matrix for the CUDA children
         id: warm
         env:
@@ -466,16 +459,11 @@ jobs:
           WIN_CUDA_MATRIX: ${{ steps.r.outputs.win_cuda_matrix }}
         run: |
           set -euo pipefail
-          # Warm shards are DISABLED for now (every profile 0): the nightly runs
-          # its 42 jobs as before and the CUDA children skip their `warm` job.
-          # The caching fixes in this branch (ccache 4.13, content check,
-          # cache sizes, one generation per prefix, redist toolkit) do not
-          # depend on them. To enable, restore the measured sizing:
+          # Warm shards are DISABLED (every profile 0); the caching fixes do not depend on them.
+          # To re-enable, the sizing measured on run 34168016006:
           #   SHARDS='if .klass == "legacy" then 0 elif .klass == "portable" and .arch == "x64" then 3 else 2 end'
           #   WIN_SHARDS='if .klass == "legacy" then 0 elif .klass == "portable" then 4 else 2 end'
-          # (staging run 34205486511: cuda12-older cold leg 100 -> 64 min on
-          # Windows, 53 -> 43 on Linux; every CUDA object a direct hit in the
-          # build after the shard merge).
+          # (staging run 34205486511: cuda12-older cold leg 100 -> 64 min Windows, 53 -> 43 Linux).
           SHARDS='0'
           WIN_SHARDS='0'
           expand_warm() { # $1 = shard rule
@@ -485,8 +473,7 @@ jobs:
           [ -n "${WIN_CUDA_MATRIX:-}" ] || WIN_CUDA_MATRIX='{"include":[]}'
           CUDA_WARM="$(printf '%s' "$CUDA_MATRIX" | expand_warm "$SHARDS")"
           WIN_CUDA_WARM="$(printf '%s' "$WIN_CUDA_MATRIX" | expand_warm "$WIN_SHARDS")"
-          # The build rows learn their own shard count too: the build job
-          # restores exactly that many shard caches before it merges them.
+          # Build rows carry their shard count: the build restores exactly that many shard caches.
           with_shards() { jq -c "{include: [.include[] | . + {shards: ($1)}]}"; }
           {
             echo "cuda_matrix=$(printf '%s' "$CUDA_MATRIX" | with_shards "$SHARDS")"
@@ -586,11 +573,8 @@ jobs:
       warm_matrix: ${{ needs.resolve.outputs.win_cuda_warm_matrix }}
     secrets: inherit
 
-  # First of the two ccache prunes (scripts/unsloth/prune_ccache.sh has the
-  # whole rationale): before any leg restores, so the run starts from one
-  # generation per prefix and old + new fit under the limit while it builds.
-  # Never on the assemble waiter's critical path and never a reason to fail a
-  # release; the waiter excludes this job by name.
+  # First of two ccache prunes (see scripts/unsloth/prune_ccache.sh): one generation per prefix
+  # at run start so old + new fit under the limit. Never gates the waiter, which excludes it by name.
   prune-ccache:
     name: Prune superseded ccache generations
     needs: resolve
@@ -707,10 +691,8 @@ jobs:
           PREFIXES=('CUDA / ' 'CUDA Windows / ' 'ROCm / ' 'macOS / ' 'CPU / ' 'Vulkan / ')
           SELF='Assemble metadata + publish'
           ALERT='Report pipeline health'
-          # Housekeeping and best-effort jobs that must never gate a publish:
-          # the start-of-run ccache prune, and the CUDA children's warm shards
-          # ("CUDA / warm x64/cuda12-portable 0/3"), which only pre-fill the
-          # compiler cache for the real build legs.
+          # Best-effort jobs that never gate a publish: the start-of-run ccache prune and the
+          # CUDA warm shards ("CUDA / warm x64/cuda12-portable 0/3").
           PRUNE='Prune superseded ccache generations'
           WARM=' / warm '
 
@@ -743,15 +725,11 @@ jobs:
             SIBS="$(printf '%s\n' "$JOBS" | awk -F'\t' -v self="$SELF" -v alert="$ALERT" -v prune="$PRUNE" -v warm="$WARM" \
               'NF && $1 != self && $1 != alert && $1 != prune && index($1, warm) == 0')"
 
-            # Two kinds of "not there yet". A child with no job record at all
-            # is the startup race and is fatal after STARTUP_DEADLINE. A child
-            # whose only records are warm shards is a CUDA child whose build
-            # legs sit behind `needs: warm`: GitHub creates those records only
-            # once the shards finish (52 minutes on a cold Windows profile,
-            # staging run 34205486511), so that case waits on the run's own
-            # deadline instead. Without the split, a run with warm shards
-            # either dies at 45 minutes or, worse, sees a moment where every
-            # existing record is complete and publishes without the builds.
+            # Two kinds of "not there yet": no job record at all is the startup race, fatal
+            # after STARTUP_DEADLINE; only warm records means a CUDA child whose build legs sit
+            # behind `needs: warm` and get records once the shards finish (52 min cold, staging
+            # run 34205486511), so that waits on the run deadline. Without the split a shard
+            # night dies at 45 minutes or publishes while every existing record is complete.
             MISSING=""; UNSCHEDULED=""
             for p in "${PREFIXES[@]}"; do
               if printf '%s\n' "$SIBS" | awk -F'\t' -v p="$p" 'index($1, p) == 1 { found = 1 } END { exit !found }'; then
@@ -1285,8 +1263,7 @@ jobs:
             echo "| delete failures | $failed |"
           } >> "$GITHUB_STEP_SUMMARY"
 
-      # The prune script lives in the tree; nothing above in this job needed a
-      # checkout. Read-only clone, no token left behind.
+      # Nothing above needed a checkout; read-only clone, no token left behind.
       - name: Checkout build tooling (this repo)
         if: ${{ needs.assemble.outputs.published == 'true' }}
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
@@ -1296,11 +1273,8 @@ jobs:
 
       # ── Keep the ccache budget inside the repo limit ──
       #
-      # Second of the two prunes; the first runs right after `resolve`. See
-      # scripts/unsloth/prune_ccache.sh for the whole rationale. Published
-      # runs only, as before: a cancelled run's children may not have written
-      # their caches yet, and pruning against a half-written set could drop a
-      # live generation -- a partial cache is worse than a stale one.
+      # Second prune (the first follows `resolve`). Published runs only: a cancelled run's
+      # children may not have saved yet, and pruning a half-written set could drop a live generation.
       - name: Prune superseded ccache generations
         if: ${{ needs.assemble.outputs.published == 'true' }}
         # Never fail a published release over cache housekeeping.

--- a/.github/workflows/unsloth-prebuilt.yml
+++ b/.github/workflows/unsloth-prebuilt.yml
@@ -476,9 +476,12 @@ jobs:
       # Warm shards for the CUDA children (see their headers): each profile row
       # is dealt into `shards` parallel jobs that pre-compile a slice of the
       # ggml-cuda objects through ccache. Sized by cold cost on run
-      # 34168016006: portable 189 min (3 shards), older/newer 55-104 min (2),
-      # legacy 22 min (none), arm64 portable 42 min (2). An empty string, not an
-      # empty include list, tells the child to skip the job.
+      # 34168016006: Windows portable 189 / 138 min (4 shards; it is the
+      # critical path and 1.6x slower than Linux per object), Linux x64
+      # portable 117 / 103 min (3), older/newer 55-104 min (2), legacy 22 min
+      # (none), arm64 portable 42 min (2). The children restore up to four
+      # shards. An empty string, not an empty include list, tells the child to
+      # skip the job.
       # Its own step, not more script in `r`: GitHub caps one workflow string at
       # 21000 chars and that step is at it. See check_workflow_scalars.py.
       - name: Warm shard matrix for the CUDA children
@@ -489,19 +492,20 @@ jobs:
         run: |
           set -euo pipefail
           SHARDS='if .klass == "legacy" then 0 elif .klass == "portable" and .arch == "x64" then 3 else 2 end'
-          expand_warm() {
-            jq -c ".include | [.[] | . as \$r | ($SHARDS) as \$k | select(\$k > 0) | range(\$k) as \$s | \$r + {shards: \$k, shard: \$s}]"
+          WIN_SHARDS='if .klass == "legacy" then 0 elif .klass == "portable" then 4 else 2 end'
+          expand_warm() { # $1 = shard rule
+            jq -c ".include | [.[] | . as \$r | ($1) as \$k | select(\$k > 0) | range(\$k) as \$s | \$r + {shards: \$k, shard: \$s}]"
           }
           [ -n "${CUDA_MATRIX:-}" ] || CUDA_MATRIX='{"include":[]}'
           [ -n "${WIN_CUDA_MATRIX:-}" ] || WIN_CUDA_MATRIX='{"include":[]}'
-          CUDA_WARM="$(printf '%s' "$CUDA_MATRIX" | expand_warm)"
-          WIN_CUDA_WARM="$(printf '%s' "$WIN_CUDA_MATRIX" | expand_warm)"
+          CUDA_WARM="$(printf '%s' "$CUDA_MATRIX" | expand_warm "$SHARDS")"
+          WIN_CUDA_WARM="$(printf '%s' "$WIN_CUDA_MATRIX" | expand_warm "$WIN_SHARDS")"
           # The build rows learn their own shard count too: the build job
           # restores exactly that many shard caches before it merges them.
-          with_shards() { jq -c "{include: [.include[] | . + {shards: ($SHARDS)}]}"; }
+          with_shards() { jq -c "{include: [.include[] | . + {shards: ($1)}]}"; }
           {
-            echo "cuda_matrix=$(printf '%s' "$CUDA_MATRIX" | with_shards)"
-            echo "win_cuda_matrix=$(printf '%s' "$WIN_CUDA_MATRIX" | with_shards)"
+            echo "cuda_matrix=$(printf '%s' "$CUDA_MATRIX" | with_shards "$SHARDS")"
+            echo "win_cuda_matrix=$(printf '%s' "$WIN_CUDA_MATRIX" | with_shards "$WIN_SHARDS")"
             [ "$CUDA_WARM" = "[]" ] && echo "cuda_warm_matrix=" || echo "cuda_warm_matrix={\"include\":$CUDA_WARM}"
             [ "$WIN_CUDA_WARM" = "[]" ] && echo "win_cuda_warm_matrix=" || echo "win_cuda_warm_matrix={\"include\":$WIN_CUDA_WARM}"
           } >> "$GITHUB_OUTPUT"

--- a/scripts/unsloth/prune_ccache.sh
+++ b/scripts/unsloth/prune_ccache.sh
@@ -59,8 +59,11 @@ echo "$(grep -c . "$all" || true) caches, $(gib "$total") GiB total: ccache $(gi
 
 # Group by the restore-keys prefix: the key minus its -<tag>- suffix, plus the
 # -<run id>-<attempt> suffix the non-CUDA legs append so a same-tag retry can
-# save an improved cache. The ROCm version comes off too, else every weekly
-# toolchain becomes its own group and keeps a cache that can never hit again.
+# save an improved cache. The ROCm toolchain version stays in the group
+# because it is in the restore prefix: a rocm_version=latest dispatch followed
+# by the weekly nightly would otherwise leave the newer toolchain's cache as
+# the only survivor, one the weekly legs cannot restore. A retired toolchain's
+# caches are removed by GitHub's 7-day unused-cache expiry instead.
 # Grouped per (ref, version) as well: a branch cannot restore a sibling's
 # cache and a path change mints a new version, so ranking across them would
 # let one scope evict another's only usable entry.
@@ -68,7 +71,7 @@ grouped="$tmp/grouped.tsv"; : > "$grouped"
 while IFS=$'\t' read -r id created size ref ver key; do
   [ -z "${id:-}" ] && continue
   case "$key" in ccache-*) ;; *) continue ;; esac
-  pre="$(printf '%s' "$key" | sed -E 's/-[0-9]+-[0-9]+$//; s/-b[0-9]+(-mix-[0-9a-f]+)?-?$//; s/-[0-9]+\.[0-9]+\.[0-9]+(a|rc)[0-9]+$//')"
+  pre="$(printf '%s' "$key" | sed -E 's/-[0-9]+-[0-9]+$//; s/-b[0-9]+(-mix-[0-9a-f]+)?-?$//')"
   [ "$pre" = "$key" ] && continue
   printf '%s\t%s\t%s\t%s\n' "$ref|$ver|$pre" "$created" "$id" "$size" >> "$grouped"
 done < "$all"

--- a/scripts/unsloth/prune_ccache.sh
+++ b/scripts/unsloth/prune_ccache.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+# Prune superseded ccache generations from this repository's Actions cache.
+#
+# ccache entries are immutable, so every run writes a NEW cache per
+# (backend, os, profile) and finds the previous one by restore-keys prefix.
+# restore-keys returns only the MOST RECENT match, so older generations can
+# never be selected again -- they are pure landfill. Measured 2026-08-08:
+# 122 caches / 31.72 GiB, of which only 40 / 9.13 GiB were reachable.
+# Measured 2026-09-08: 76 caches / 46.8 GB, exactly two generations of 38
+# prefixes (25.0 + 21.8 GB), against a limit that was then 50 GB.
+#
+# That matters for build time, not tidiness. Once the total hits the repo
+# limit GitHub evicts by its own LRU, which can take a LIVE cache. A partial
+# cache is far worse than none: measured locally over 513 real translation
+# units, capping a cache to 30% of what the build needs drops the hit rate to
+# 14.2% and flips hits from direct to preprocessed -- the exact 3-direct /
+# 52-preprocessed signature seen in CI when the cap was 500 MB, which cost a
+# 204-minute build instead of 54.
+#
+# Runs twice per release: once right after `resolve`, before any leg restores,
+# and once after publish. Keeping ONE generation per prefix is safe at run
+# start because the prefix restore only ever returns the newest entry, and a
+# leg whose last save failed still has its previous entry as the newest of
+# its own prefix. Peak usage during a run is then old + new generation.
+#
+# Keys that are not ccache-* (the sccache/<hash> per-object entries the CUDA
+# legs write) are reported but never touched: GitHub's per-entry LRU and
+# 7-day expiry are their retention policy.
+#
+# Usage: prune_ccache.sh [--keep N] [--limit-gb N] [--dry-run]
+#   GH_TOKEN with actions:write on GITHUB_REPOSITORY; writes GITHUB_STEP_SUMMARY if set.
+set -euo pipefail
+
+KEEP=1; LIMIT_GB=75; DRY=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --keep) KEEP="$2"; shift 2 ;;
+    --limit-gb) LIMIT_GB="$2"; shift 2 ;;
+    --dry-run) DRY=1; shift ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+case "$KEEP" in [1-9]|[1-9][0-9]) ;; *) echo "invalid --keep $KEEP" >&2; exit 2 ;; esac
+
+repo="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+tmp="$(mktemp -d)"
+all="$tmp/caches.tsv"
+gh api --paginate "repos/$repo/actions/caches?per_page=100" \
+  -q '.actions_caches[] | "\(.id)\t\(.created_at)\t\(.size_in_bytes)\t\(.ref)\t\(.version)\t\(.key)"' > "$all" || true
+
+gib() { awk -v b="${1:-0}" 'BEGIN { printf "%.1f", b / 1073741824 }'; }
+total=$(awk -F'\t' '{s+=$3} END {printf "%d", s+0}' "$all")
+cc_total=$(awk -F'\t' '$6 ~ /^ccache-/ {s+=$3} END {printf "%d", s+0}' "$all")
+sc_total=$(awk -F'\t' '$6 !~ /^ccache-/ {s+=$3} END {printf "%d", s+0}' "$all")
+sc_count=$(awk -F'\t' '$6 !~ /^ccache-/' "$all" | grep -c . || true)
+echo "$(grep -c . "$all" || true) caches, $(gib "$total") GiB total: ccache $(gib "$cc_total") GiB, other (sccache etc.) $(gib "$sc_total") GiB in $sc_count entries"
+
+# Group by the restore-keys prefix: the key minus its -<tag>- suffix, plus the
+# -<run id>-<attempt> suffix the non-CUDA legs append so a same-tag retry can
+# save an improved cache. The ROCm version comes off too, else every weekly
+# toolchain becomes its own group and keeps a cache that can never hit again.
+# Grouped per (ref, version) as well: a branch cannot restore a sibling's
+# cache and a path change mints a new version, so ranking across them would
+# let one scope evict another's only usable entry.
+grouped="$tmp/grouped.tsv"; : > "$grouped"
+while IFS=$'\t' read -r id created size ref ver key; do
+  [ -z "${id:-}" ] && continue
+  case "$key" in ccache-*) ;; *) continue ;; esac
+  pre="$(printf '%s' "$key" | sed -E 's/-[0-9]+-[0-9]+$//; s/-b[0-9]+(-mix-[0-9a-f]+)?-?$//; s/-[0-9]+\.[0-9]+\.[0-9]+(a|rc)[0-9]+$//')"
+  [ "$pre" = "$key" ] && continue
+  printf '%s\t%s\t%s\t%s\n' "$ref|$ver|$pre" "$created" "$id" "$size" >> "$grouped"
+done < "$all"
+sort -t"$(printf '\t')" -k1,1 -k2,2r -o "$grouped" "$grouped"
+
+prev=""; n=0; freed=0; deleted=0
+while IFS=$'\t' read -r pre created id size; do
+  [ -z "${pre:-}" ] && continue
+  if [ "$pre" != "$prev" ]; then prev="$pre"; n=1; else n=$(( n + 1 )); fi
+  [ "$n" -le "$KEEP" ] && continue
+  if [ "$DRY" = 1 ]; then
+    echo "would delete $id ($(gib "$size") GiB) ${pre##*|}"
+    freed=$(( freed + size )); deleted=$(( deleted + 1 )); continue
+  fi
+  # </dev/null or gh eats the loop's stdin and the sweep stops after one.
+  if gh api -X DELETE "repos/$repo/actions/caches/$id" --silent < /dev/null 2>/dev/null; then
+    freed=$(( freed + size )); deleted=$(( deleted + 1 ))
+  fi
+done < "$grouped"
+
+after=$(( total - freed ))
+verb="pruned"; [ "$DRY" = 1 ] && verb="would prune"
+echo "$verb $deleted superseded ccache generations, $(gib "$freed") GiB; $(gib "$after") GiB of $LIMIT_GB GB remains"
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo "### ccache budget"
+    echo ""
+    echo "| metric | value |"
+    echo "| --- | --- |"
+    echo "| kept per prefix | $KEEP |"
+    echo "| ccache generations $verb | $deleted |"
+    echo "| freed | $(gib "$freed") GiB |"
+    echo "| ccache after | $(gib $(( cc_total - freed ))) GiB |"
+    echo "| sccache and other entries | $(gib "$sc_total") GiB in $sc_count |"
+    echo "| cache total after | $(gib "$after") GiB of $LIMIT_GB GB |"
+  } >> "$GITHUB_STEP_SUMMARY"
+fi
+# 80% of the limit: above this the next generation lands on GitHub's LRU.
+if [ "$after" -gt $(( LIMIT_GB * 1000000000 * 8 / 10 )) ]; then
+  echo "::warning::cache total is $(gib "$after") GiB of the $LIMIT_GB GB repo limit; at the limit GitHub evicts by LRU and a partially evicted ccache collapses the hit rate. Raise the limit or shrink the CUDA max-size caps."
+fi

--- a/scripts/unsloth/prune_ccache.sh
+++ b/scripts/unsloth/prune_ccache.sh
@@ -3,31 +3,14 @@
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
 # Prune superseded ccache generations from this repository's Actions cache.
 #
-# ccache entries are immutable, so every run writes a NEW cache per
-# (backend, os, profile) and finds the previous one by restore-keys prefix.
-# restore-keys returns only the MOST RECENT match, so older generations can
-# never be selected again -- they are pure landfill. Measured 2026-08-08:
-# 122 caches / 31.72 GiB, of which only 40 / 9.13 GiB were reachable.
-# Measured 2026-09-08: 76 caches / 46.8 GB, exactly two generations of 38
-# prefixes (25.0 + 21.8 GB), against a limit that was then 50 GB.
+# Entries are immutable, so every run writes a NEW cache per (backend, os, profile) and
+# restore-keys returns only the newest match: older generations are landfill. At the repo limit
+# GitHub evicts by its own LRU and can take a LIVE cache; a partial cache is worse than none
+# (a cache capped to 30% of need hit 14.2% and cost a 204-minute build instead of 54).
 #
-# That matters for build time, not tidiness. Once the total hits the repo
-# limit GitHub evicts by its own LRU, which can take a LIVE cache. A partial
-# cache is far worse than none: measured locally over 513 real translation
-# units, capping a cache to 30% of what the build needs drops the hit rate to
-# 14.2% and flips hits from direct to preprocessed -- the exact 3-direct /
-# 52-preprocessed signature seen in CI when the cap was 500 MB, which cost a
-# 204-minute build instead of 54.
-#
-# Runs twice per release: once right after `resolve`, before any leg restores,
-# and once after publish. Keeping ONE generation per prefix is safe at run
-# start because the prefix restore only ever returns the newest entry, and a
-# leg whose last save failed still has its previous entry as the newest of
-# its own prefix. Peak usage during a run is then old + new generation.
-#
-# Keys that are not ccache-* (the sccache/<hash> per-object entries the CUDA
-# legs write) are reported but never touched: GitHub's per-entry LRU and
-# 7-day expiry are their retention policy.
+# Runs after `resolve` and again after publish. One generation per prefix is safe at run start
+# because the prefix restore only returns the newest entry; peak usage during a run is
+# old + new. Keys that are not ccache-* are reported, never touched.
 #
 # Usage: prune_ccache.sh [--keep N] [--limit-gb N] [--dry-run]
 #   GH_TOKEN with actions:write on GITHUB_REPOSITORY; writes GITHUB_STEP_SUMMARY if set.
@@ -57,16 +40,10 @@ sc_total=$(awk -F'\t' '$6 !~ /^ccache-/ {s+=$3} END {printf "%d", s+0}' "$all")
 sc_count=$(awk -F'\t' '$6 !~ /^ccache-/' "$all" | grep -c . || true)
 echo "$(grep -c . "$all" || true) caches, $(gib "$total") GiB total: ccache $(gib "$cc_total") GiB, other (sccache etc.) $(gib "$sc_total") GiB in $sc_count entries"
 
-# Group by the restore-keys prefix: the key minus its -<tag>- suffix, plus the
-# -<run id>-<attempt> suffix the non-CUDA legs append so a same-tag retry can
-# save an improved cache. The ROCm toolchain version stays in the group
-# because it is in the restore prefix: a rocm_version=latest dispatch followed
-# by the weekly nightly would otherwise leave the newer toolchain's cache as
-# the only survivor, one the weekly legs cannot restore. A retired toolchain's
-# caches are removed by GitHub's 7-day unused-cache expiry instead.
-# Grouped per (ref, version) as well: a branch cannot restore a sibling's
-# cache and a path change mints a new version, so ranking across them would
-# let one scope evict another's only usable entry.
+# Group by restore prefix: the key minus -<tag>- and -<run id>-<attempt>. The ROCm toolchain
+# version stays in because the restore prefix has it: a rocm_version=latest dispatch before the
+# weekly nightly would otherwise leave only a cache the weekly legs cannot restore (retired
+# toolchains age out via GitHub's 7-day expiry). Per (ref, version) too: a branch cannot restore a sibling's cache.
 grouped="$tmp/grouped.tsv"; : > "$grouped"
 while IFS=$'\t' read -r id created size ref ver key; do
   [ -z "${id:-}" ] && continue


### PR DESCRIPTION
## Why

Run 34168016006 took 3 h 46 min. The critical path was `CUDA Windows / x64/cuda12-portable`: 7 min of toolkit install and 189 min of nvcc, with the Linux twin at 117 min. The ccache hit rate looked healthy (84%), but every one of the ~140 ggml-cuda translation units missed, because the daily base bump had touched `ggml-cuda/common.cuh`, which every `.cu` includes and which upstream edits about six times a month. Each template-instance TU costs 2-8 min for the 8 portable arches on a 4 vCPU runner, and `-j 3` is already the memory ceiling. No cache setting changes that: the work is real, and the only lever left without larger runners is running it on more runners at once.

Cache storage was also at 46.8 GB of the old 50 GB limit: two full generations of every ccache prefix by design, plus a transient third one written before the end-of-run pruner ran.

## What changes

**Warm shards for the CUDA legs** (`unsloth-prebuilt-cuda.yml`, `unsloth-prebuilt-cuda-windows.yml`, two new composite actions under `.github/actions/`). `resolve` stamps a shard count per profile (portable 3, older and newer 2, legacy 0) and emits a warm matrix. Each warm job restores the profile's newest ccache generation, compiles a round-robin 1/N slice of the ggml-cuda objects, and saves only the cache files newer than a stamp taken after the restore as a small `ccache-shard<N>-...` delta (about 100 MB, not another copy of the generation). The build job restores the generation plus every shard delta, lays the deltas over its cache newest-file-wins (results are content addressed; a manifest a shard rewrote is a superset of the one it restored, and the slices are disjoint), then runs the full build exactly as before. Shards are best effort: `continue-on-error`, the build runs `if: !cancelled()`, and a dead shard only means the build compiles more itself.

**CUDA toolkit from the NVIDIA redist CDN for CUDA 12.8.0 too**, the way the 13.3 leg already did it. Jimver's network install took 4-5 min per Linux job and 7-8 min per Windows job; the redist path takes 1-2 min, and with a warm shard ahead of every build the install now sits on the critical path twice. `choco install ninja` is replaced by a check of the image's Ninja.

**ccache tuning everywhere**: ccache 4.13 from the action's pinned binary on every OS (apt on ubuntu-22.04 ships 4.5.1), `compiler_check=content` (the toolkit is re-extracted every run, so mtime identity can miss a byte-identical nvcc), the documented safe sloppiness set, `compression_level=6`, `--evict-older-than 7d`, `max_size` 4G for portable and 3G for the other CUDA profiles (Windows portable sat at 100.7% of its old 2G). Save keys carry `-<run_id>-<attempt>` so a retry of the same tag can save an improved cache; restore prefixes are unchanged.

**Budget under the 75 GB limit**: new `scripts/unsloth/prune_ccache.sh`, run as a `prune-ccache` job at run start and again in `reclaim`, keeps one generation per `(ref, version, prefix)`. At run start the older generation is unreachable by construction (the restore prefix returns the newest), and the always-save on every leg covers holes. Each shard is its own prefix. Non-`ccache-*` keys are never touched.

**Assemble waiter**: GitHub does not create a build job's record until `needs: warm` is satisfied, which on a cold Windows profile is 50+ min, past the waiter's 45 min startup deadline. A child whose only records are warm shards now waits on the run's main deadline. This also closes a window where every existing record could be complete before the build job appeared.

## Measured

Local lab on this repo's CUDA objects (`temp/cache_lab`, b10830 to b10840, the exact churn the slow night saw):

- sccache 0.17 with per-arch cicc/ptxas caching was tried first and rejected: the churn rebuild took 710 s vs ccache's 698 s, a warm rebuild 111 s vs 1 s, and cross-profile sharing was 0% because nvcc passes `__CUDA_ARCH_LIST__` into every preprocess and ggml-cuda reads it. On a windows-2022 probe its GitHub Actions backend got 0% hits even on a second job of the identical tree.
- Delta shard merge: generation from b10830, two shards each compiling half of b10840, deltas 42 MB and 35 MB, merged full build 143/143 CUDA direct hits in 4 s.
- Windows Defender exclusion A/B on windows-2022 (cold ggml-cuda, 2 arches): 1675 s with the scan on, 1764 s with `Add-MpPreference` exclusions. Not adopted; the runner image already disables real-time scanning.
- `nvcc --threads 2` with `-j 2`: 5% under `-j 3`, not adopted.

End to end on a staging copy of this repo (`only_profile=cuda12-older`, `publish=false`), cold cache then a second run on the same tag:

| leg | before (run 34168016006) | cold with shards | warm |
|---|---|---|---|
| Linux x64 cuda12-older toolkit + configure | 4.4 min | 1.7 min | 2.0 min |
| Linux x64 cuda12-older compile path | 48.7 min | max(26.7, 33.1) + 8.5 min | 2.8 + 0.5 min |
| Windows x64 cuda12-older toolkit + configure | 7.3 min | 3.1 min | 1.9 min |
| Windows x64 cuda12-older compile path | 92.4 min | max(43.2, 51.9) + 8.9 min | 2.9 + 0.6 min |

Every CUDA object was a direct hit in the build job after the shard merge (151 of 151 on both OSes cold, 99.7% of all objects warm). The waiter logged "warm shards still running, build legs not yet scheduled" and then "all 26 build jobs finished and succeeded". Portable profiles get 3 shards, so the cold Windows portable leg should land near 60-70 min instead of 189.

## Not done, on purpose

- `GGML_CUDA_COMPRESSION_MODE=balance` saves 10-17% of nvcc time per TU (123 s vs 148 s on mmq-instance-q4_0) but triples the shipped CUDA library size. That is a product decision, not a CI one.
- Daytime warming of the next tag so the nightly sees a one-commit delta would remove most of the remaining cold cost; it is a separate workflow and a separate PR.
