### PR TITLE
Repin ggml-org/llama.cpp#25731 (TML Inkling) at 946fc11d1 after the upstream parsers and ggml_prec refactors

### DIFF
--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -19,7 +19,7 @@
   ],
   "prs": [
     "https://github.com/ggml-org/llama.cpp/pull/24423/commits/168b21adfb36f740989284c9d73a5ccabf679e46",
-    "https://github.com/ggml-org/llama.cpp/pull/25731/commits/1066edc3a533b036f630750d9c2c74ca95ff397e",
+    "https://github.com/ggml-org/llama.cpp/pull/25731/commits/946fc11d1afb1e6cd316e853f1b23487754a74b9",
     "https://github.com/unslothai/llama.cpp/pull/70/commits/883f2c9ba78f3847148454adf025da29385fff3e",
     "https://github.com/unslothai/llama.cpp/pull/61/commits/46cbf0e95786fe8f5b7c0e86d57aaf8f8eceea7f",
     "https://github.com/unslothai/llama.cpp/pull/95/commits/3db8cb5b2e9bf291057b9f19960e8601a162da81",


### PR DESCRIPTION
## Why

The nightly on b10865 (run 34287079907) stopped in `resolve`: pin 2, ggml-org/llama.cpp#25731 @ `1066edc3a`, no longer merged. Two upstream changes landed between the PR's base (Sep 7) and b10865:

- #27764 (`895c045fd`) moved every model-specific `common_chat_params_init_*` out of `common/chat.cpp` into `common/parsers/<model>.cpp`. The PR inserted `init_inkling` into chat.cpp at the spot the refactor emptied, which is an edit/delete conflict the additive resolver refuses by design.
- #26675 (`5a6caa05f`) renumbered `enum ggml_prec` into a ranked scale, added `ggml_prec_set_acc`, and deprecated `ggml_mul_mat_set_prec` / `ggml_flash_attn_ext_set_prec`. The PR adds `GGML_PREC_F32_PEDANTIC` and declares `ggml_flash_attn_ext_banded` on the same lines.

## What changed on the PR branch (danielhanchen/llama.cpp:add-inkling, 1066edc3a -> 946fc11d1)

1. `d3a67005d` Merge upstream master. `common_chat_params_init_inkling` moves to `common/parsers/inkling.cpp` (body unchanged, `static` dropped), declared in `parsers.h`, listed in `sources.cmake`; chat.cpp keeps only the 7-line detection branch. `GGML_PREC_F32_PEDANTIC` joins the new ranked enum at 5, below `GGML_PREC_F32`, because it is the stricter contract (lower rank = stricter in the new scheme; 11 would have read as looser than F32). The `ggml_flash_attn_ext_banded` declaration stays next to the flash attention API.
2. `946fc11d1` Every deprecated setter call becomes `ggml_prec_set_acc` (the macOS leg builds with `LLAMA_FATAL_WARNINGS=ON` and no deprecation opt-out, so this is required, not cosmetic), `ggml_prec_set_acc` accepts `GGML_OP_FLASH_ATTN_EXT_BANDED`, and the backends that compared the accumulator slot with `== GGML_PREC_F32` (CUDA cuBLAS compute type, CPU and spacemit flash attention, Vulkan flash attention) compare by rank so a pedantic request never falls to a lower-precision path. The CUDA `mul_mat_id` slice carries the acc and src precision slots, and `ggml_cuda_mul_mat_id_needs_sync` gets the same pedantic gate as `ggml_cuda_mul_mat_id` (a pedantic mmf-eligible F32 expert matmul would otherwise trip its assertion).

PR delta against its base: 64 files / +4093 -124 before, 70 files / +4120 -126 after. The six extra files are the three parser registrations plus the three backend comparison fixes.

## Verification

Local, on the rebased branch:

| gate | result |
|---|---|
| CPU build, `LLAMA_FATAL_WARNINGS=ON`, tests on | clean |
| `test-chat` (8 Inkling cases among them), `test-chat-peg-parser`, `test-chat-template` | pass |
| `test-backend-ops test -b CUDA0 -o FLASH_ATTN_EXT_BANDED` | 13/13 |
| `test-backend-ops test -b CUDA0 -o MUL_MAT` / `MUL_MAT_ID` / `FLASH_ATTN_EXT` | 1288/1288, 880/880, 2959/2959 |
| `test-flash-attn-bias`, `test-flash-attn-generic-hash` | pass |
| `test-llama-archs -a inkling -s 1234` | OK |
| `test-mtmd-impl test_projector_registry` | pass |
| `unsloth/Inkling-Small-GGUF` UD-IQ1_S, two prompts, temp 0, 48 tokens, CUDA and CPU, pinned build vs rebased build | byte-identical text |

Mix, all 13 pins in `pr-set.json` order with the new pin, reproduced with the resolve job's own git commands:

| base | result |
|---|---|
| b10865 | merges; additive add/add only on `llama-arch.{cpp,h}`, `llama-model-saver.cpp`, `test-llama-archs.cpp` (#25731) and `tools/mtmd/CMakeLists.txt` (#70); `merge_checks` OK; `pin_contract` all 13 intact |
| b10870 | same |

Script tests (`test_additive_merge`, `test_pin_merge`, `test_merge_checks`, `test_sync_deletes`, `test_carry_vintage`, `test_pin_contract`, `test_feature_matrix`) pass; every pin is covered by `feature-checks.json`.