### PR TITLE
Pin unslothai/llama.cpp#210 (server-side preemption and exact concurrency) at afd3248b82

### DIFF
--- a/scripts/unsloth/feature-checks.json
+++ b/scripts/unsloth/feature-checks.json
@@ -99,6 +99,7 @@
     "unslothai#149": "GGML_CUDA_ENABLE_UNIFIED_MEMORY=0 env parsing; needs a CUDA or HIP host, and no runner in the pipeline has one",
     "unslothai#152": "per-run mmap of a context's tensors; a memory-layout change with no observable output difference",
     "unslothai#157": "cudaMemcpyDefault in the ggml_cuda_cpy 2D fast path; needs a CUDA host",
-    "unslothai#158": "ROCm_Host compute buffer type on HIP integrated GPUs; needs a ROCm host"
+    "unslothai#158": "ROCm_Host compute buffer type on HIP integrated GPUs; needs a ROCm host",
+    "unslothai#210": "server-side KV preemption (--preempt-ram, --preempt-async) and opt-in exact concurrency (--exact-concurrency); the server parks and restores slots and pins per-sequence output, which no arch, backend-op or mtmd probe can observe. Covered by test-exact-geometry and the server preemption tests carried in unslothai#197, which need a CUDA host for the exact path"
   }
 }

--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -31,6 +31,6 @@
     "https://github.com/unslothai/llama.cpp/pull/144/commits/a9e9c3c5fed8a0bb5cc617532d0d16b8f59c13e0",
     "https://github.com/unslothai/llama.cpp/pull/152/commits/b2b5ed9ff86427a530b762a45d3fdbd453bcd4e8",
     "https://github.com/unslothai/llama.cpp/pull/176/commits/09ce1a4d2939844e211f7b4d30a296f4c1aed9a8",
-    "https://github.com/unslothai/llama.cpp/pull/210/commits/7eb9cb780741dda641c321ccf16daa84725ee4e9"
+    "https://github.com/unslothai/llama.cpp/pull/210/commits/d8daa8fc514ac964eff151bff299c9fe8bfda131"
   ]
 }

--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -31,6 +31,6 @@
     "https://github.com/unslothai/llama.cpp/pull/144/commits/a9e9c3c5fed8a0bb5cc617532d0d16b8f59c13e0",
     "https://github.com/unslothai/llama.cpp/pull/152/commits/b2b5ed9ff86427a530b762a45d3fdbd453bcd4e8",
     "https://github.com/unslothai/llama.cpp/pull/176/commits/09ce1a4d2939844e211f7b4d30a296f4c1aed9a8",
-    "https://github.com/unslothai/llama.cpp/pull/210/commits/5b66acb4d7904f231d264f685fca13cc3c840ea1"
+    "https://github.com/unslothai/llama.cpp/pull/210/commits/41abdfb23111fbcbf1bace38fb4655ed8cc7cc72"
   ]
 }

--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -31,6 +31,6 @@
     "https://github.com/unslothai/llama.cpp/pull/144/commits/a9e9c3c5fed8a0bb5cc617532d0d16b8f59c13e0",
     "https://github.com/unslothai/llama.cpp/pull/152/commits/b2b5ed9ff86427a530b762a45d3fdbd453bcd4e8",
     "https://github.com/unslothai/llama.cpp/pull/176/commits/09ce1a4d2939844e211f7b4d30a296f4c1aed9a8",
-    "https://github.com/unslothai/llama.cpp/pull/210/commits/d8daa8fc514ac964eff151bff299c9fe8bfda131"
+    "https://github.com/unslothai/llama.cpp/pull/210/commits/5b66acb4d7904f231d264f685fca13cc3c840ea1"
   ]
 }

--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -31,6 +31,6 @@
     "https://github.com/unslothai/llama.cpp/pull/144/commits/a9e9c3c5fed8a0bb5cc617532d0d16b8f59c13e0",
     "https://github.com/unslothai/llama.cpp/pull/152/commits/b2b5ed9ff86427a530b762a45d3fdbd453bcd4e8",
     "https://github.com/unslothai/llama.cpp/pull/176/commits/09ce1a4d2939844e211f7b4d30a296f4c1aed9a8",
-    "https://github.com/unslothai/llama.cpp/pull/210/commits/2176de1adffe533396a1359d03fe8dd4a9ce1310"
+    "https://github.com/unslothai/llama.cpp/pull/210/commits/0beed5117d54d7f99f7b3ec41fe8248b018ae4c6"
   ]
 }

--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -30,6 +30,7 @@
     "https://github.com/unslothai/llama.cpp/pull/149/commits/b65a2dce12c14a489e19a059cb6ee59112f1b733",
     "https://github.com/unslothai/llama.cpp/pull/144/commits/a9e9c3c5fed8a0bb5cc617532d0d16b8f59c13e0",
     "https://github.com/unslothai/llama.cpp/pull/152/commits/b2b5ed9ff86427a530b762a45d3fdbd453bcd4e8",
-    "https://github.com/unslothai/llama.cpp/pull/176/commits/09ce1a4d2939844e211f7b4d30a296f4c1aed9a8"
+    "https://github.com/unslothai/llama.cpp/pull/176/commits/09ce1a4d2939844e211f7b4d30a296f4c1aed9a8",
+    "https://github.com/unslothai/llama.cpp/pull/210/commits/afd3248b8270bf4aa66f5f3fb0e2c9cbc64337a1"
   ]
 }

--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -31,6 +31,6 @@
     "https://github.com/unslothai/llama.cpp/pull/144/commits/a9e9c3c5fed8a0bb5cc617532d0d16b8f59c13e0",
     "https://github.com/unslothai/llama.cpp/pull/152/commits/b2b5ed9ff86427a530b762a45d3fdbd453bcd4e8",
     "https://github.com/unslothai/llama.cpp/pull/176/commits/09ce1a4d2939844e211f7b4d30a296f4c1aed9a8",
-    "https://github.com/unslothai/llama.cpp/pull/210/commits/3e7d9530ac7cf9c21b30e97e6ca2901659cfda6c"
+    "https://github.com/unslothai/llama.cpp/pull/210/commits/2176de1adffe533396a1359d03fe8dd4a9ce1310"
   ]
 }

--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -31,6 +31,6 @@
     "https://github.com/unslothai/llama.cpp/pull/144/commits/a9e9c3c5fed8a0bb5cc617532d0d16b8f59c13e0",
     "https://github.com/unslothai/llama.cpp/pull/152/commits/b2b5ed9ff86427a530b762a45d3fdbd453bcd4e8",
     "https://github.com/unslothai/llama.cpp/pull/176/commits/09ce1a4d2939844e211f7b4d30a296f4c1aed9a8",
-    "https://github.com/unslothai/llama.cpp/pull/210/commits/62cf502303c970f4782f822592d2d72f031df5ae"
+    "https://github.com/unslothai/llama.cpp/pull/210/commits/17a0f3b9678618ccbaa3887e3d179edd4a32fd57"
   ]
 }

--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -31,6 +31,6 @@
     "https://github.com/unslothai/llama.cpp/pull/144/commits/a9e9c3c5fed8a0bb5cc617532d0d16b8f59c13e0",
     "https://github.com/unslothai/llama.cpp/pull/152/commits/b2b5ed9ff86427a530b762a45d3fdbd453bcd4e8",
     "https://github.com/unslothai/llama.cpp/pull/176/commits/09ce1a4d2939844e211f7b4d30a296f4c1aed9a8",
-    "https://github.com/unslothai/llama.cpp/pull/210/commits/0beed5117d54d7f99f7b3ec41fe8248b018ae4c6"
+    "https://github.com/unslothai/llama.cpp/pull/210/commits/7eb9cb780741dda641c321ccf16daa84725ee4e9"
   ]
 }

--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -31,6 +31,6 @@
     "https://github.com/unslothai/llama.cpp/pull/144/commits/a9e9c3c5fed8a0bb5cc617532d0d16b8f59c13e0",
     "https://github.com/unslothai/llama.cpp/pull/152/commits/b2b5ed9ff86427a530b762a45d3fdbd453bcd4e8",
     "https://github.com/unslothai/llama.cpp/pull/176/commits/09ce1a4d2939844e211f7b4d30a296f4c1aed9a8",
-    "https://github.com/unslothai/llama.cpp/pull/210/commits/17a0f3b9678618ccbaa3887e3d179edd4a32fd57"
+    "https://github.com/unslothai/llama.cpp/pull/210/commits/1d5548978df86d27a3099f463120f0c30e1aca16"
   ]
 }

--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -31,6 +31,6 @@
     "https://github.com/unslothai/llama.cpp/pull/144/commits/a9e9c3c5fed8a0bb5cc617532d0d16b8f59c13e0",
     "https://github.com/unslothai/llama.cpp/pull/152/commits/b2b5ed9ff86427a530b762a45d3fdbd453bcd4e8",
     "https://github.com/unslothai/llama.cpp/pull/176/commits/09ce1a4d2939844e211f7b4d30a296f4c1aed9a8",
-    "https://github.com/unslothai/llama.cpp/pull/210/commits/1d5548978df86d27a3099f463120f0c30e1aca16"
+    "https://github.com/unslothai/llama.cpp/pull/210/commits/15bcc6c7a8bb5bbb732b904f28449c8be1fed2b9"
   ]
 }

--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -31,6 +31,6 @@
     "https://github.com/unslothai/llama.cpp/pull/144/commits/a9e9c3c5fed8a0bb5cc617532d0d16b8f59c13e0",
     "https://github.com/unslothai/llama.cpp/pull/152/commits/b2b5ed9ff86427a530b762a45d3fdbd453bcd4e8",
     "https://github.com/unslothai/llama.cpp/pull/176/commits/09ce1a4d2939844e211f7b4d30a296f4c1aed9a8",
-    "https://github.com/unslothai/llama.cpp/pull/210/commits/afd3248b8270bf4aa66f5f3fb0e2c9cbc64337a1"
+    "https://github.com/unslothai/llama.cpp/pull/210/commits/62cf502303c970f4782f822592d2d72f031df5ae"
   ]
 }

--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -31,6 +31,6 @@
     "https://github.com/unslothai/llama.cpp/pull/144/commits/a9e9c3c5fed8a0bb5cc617532d0d16b8f59c13e0",
     "https://github.com/unslothai/llama.cpp/pull/152/commits/b2b5ed9ff86427a530b762a45d3fdbd453bcd4e8",
     "https://github.com/unslothai/llama.cpp/pull/176/commits/09ce1a4d2939844e211f7b4d30a296f4c1aed9a8",
-    "https://github.com/unslothai/llama.cpp/pull/210/commits/15bcc6c7a8bb5bbb732b904f28449c8be1fed2b9"
+    "https://github.com/unslothai/llama.cpp/pull/210/commits/3e7d9530ac7cf9c21b30e97e6ca2901659cfda6c"
   ]
 }

--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -31,6 +31,6 @@
     "https://github.com/unslothai/llama.cpp/pull/144/commits/a9e9c3c5fed8a0bb5cc617532d0d16b8f59c13e0",
     "https://github.com/unslothai/llama.cpp/pull/152/commits/b2b5ed9ff86427a530b762a45d3fdbd453bcd4e8",
     "https://github.com/unslothai/llama.cpp/pull/176/commits/09ce1a4d2939844e211f7b4d30a296f4c1aed9a8",
-    "https://github.com/unslothai/llama.cpp/pull/210/commits/41abdfb23111fbcbf1bace38fb4655ed8cc7cc72"
+    "https://github.com/unslothai/llama.cpp/pull/210/commits/ae195390599e1ea8c4dbcc6b1d8ec77f5db90c3a"
   ]
 }


### PR DESCRIPTION
Adds one pin: unslothai/llama.cpp#210 at 15bcc6c7a8, the tree of #197 (server-side preemption: parking a slot instead of ending every conversation when the KV cache fills, per-request park and resume notices, asynchronous parks, the opt-in exact concurrency mode) composed with the pinned commit of ggml-org#25731 so it merges after it on b10871. #197 carries #184, #190 and #192 in its history, so those are not pinned; #194 is superseded by #197 (its code fixes were ported) and conflicts with it, so it is not pinned either.

Every preemption process in the pinned tree is off by default: `--preempt-ram` defaults to 0 (a server without the flag behaves exactly as upstream, unified cache included) and exact concurrency is an environment opt-in. Studio passes `--preempt-ram` explicitly when it wants the server to park.

Also records unslothai#210 under `unchecked` in feature-checks.json: a server park has no arch, backend-op or mtmd probe surface; the feature is covered by test-exact-geometry and the server preemption tests in #197, which need a CUDA host for the exact path.

Reproduced the preflight's resolve loop (fresh clone of upstream at the base tag, every pin fetched and merged in listed order with diff3, additive_merge.py on conflict, then merge_checks.py and pin_contract.py) on b10871, the base the preflight resolves at the time of writing:

```
ok ggml-org/llama.cpp#24423
ok ggml-org/llama.cpp#25731 (additive resolve)
ok unslothai/llama.cpp#70 (additive resolve)
ok unslothai/llama.cpp#61
ok unslothai/llama.cpp#95
ok ggml-org/llama.cpp#27754
ok unslothai/llama.cpp#137
ok unslothai/llama.cpp#158
ok unslothai/llama.cpp#157
ok unslothai/llama.cpp#149
ok unslothai/llama.cpp#144
ok unslothai/llama.cpp#152
ok unslothai/llama.cpp#176
ok unslothai/llama.cpp#210 (additive resolve)
merge_checks: clean
pin_contract: all 14 pins are intact in the merged tree
```

The new pin's two residual hunks are pure add/add against earlier pins (the CUDA proc-address table entry next to #24423's, the exact-concurrency refusals in llama-memory-hybrid.cpp next to the kpool-dirty blocks), which additive_merge.py resolves.

Why the pin is composed with inkling rather than a single commit on the tag: inkling's pinned commit edits the mul_mat dispatch #197 restructured (its `f32_pedantic` guards) and adds declarations and a test struct at the same insertion points, a modify/modify overlap additive_merge.py cannot resolve. The pin commit therefore has the inkling pin as its second parent, with the guard folded into `ggml_cuda_mul_mat_path`, so the composed merge has one base. The cost: #210 has to be recomposed whenever ggml-org#25731 is repinned or dropped, which the repin bot does not do on its own.
