### PR TITLE
Repin GLM-5-Next (#27754) to the head that builds under fatal warnings

### DIFF
--- a/scripts/unsloth/pr-set.json
+++ b/scripts/unsloth/pr-set.json
@@ -23,7 +23,7 @@
     "https://github.com/unslothai/llama.cpp/pull/70/commits/883f2c9ba78f3847148454adf025da29385fff3e",
     "https://github.com/unslothai/llama.cpp/pull/61/commits/46cbf0e95786fe8f5b7c0e86d57aaf8f8eceea7f",
     "https://github.com/unslothai/llama.cpp/pull/95/commits/3db8cb5b2e9bf291057b9f19960e8601a162da81",
-    "https://github.com/ggml-org/llama.cpp/pull/27754/commits/b9b8207fcfc2962093b9466df7af4ff29c2a81ef",
+    "https://github.com/ggml-org/llama.cpp/pull/27754/commits/d94f44e79aa219d8057e8de21f95360a187ebf41",
     "https://github.com/unslothai/llama.cpp/pull/137/commits/4e1865e34ec5f6ca39403215c89129c13731be70",
     "https://github.com/unslothai/llama.cpp/pull/158/commits/abfc45b9cb21eae4848cb82196e659f42c9a8341",
     "https://github.com/unslothai/llama.cpp/pull/157/commits/6c6da89266ba7839d825c9997782af4f4d26b81b",


### PR DESCRIPTION
## Why

Nightly run 34412786914 (base b10881) did not publish: both macOS legs failed in the build step and assemble refused to publish.

```
src/models/glm5next.cpp:412:5: error: 'ggml_mul_mat_set_prec' is deprecated: use ggml_prec_set_acc() instead [-Werror,-Wdeprecated-declarations]
```

Upstream deprecated the precision setters in ggml-org/llama.cpp#26675, and the macOS prebuilt legs build with `LLAMA_FATAL_WARNINGS=ON` under clang. The offending file comes from pin 6, ggml-org/llama.cpp#27754 (branch `unslothai:glm5next/upstream`), which was 252 commits behind upstream master.

## What changed on the pin

- `2af9da2d5` merges upstream master into `glm5next/upstream` (clean, no conflicts).
- `d94f44e79` switches the one call at `src/models/glm5next.cpp:412` to `ggml_prec_set_acc(w, GGML_PREC_F32)`. Same op_params slot, same F32 accumulation for the indexer weights.

This PR moves `scripts/unsloth/pr-set.json` entry 6 from `b9b8207fc` to `d94f44e79`.

## Evidence

- Fatal-warnings build of the merged pin: `llama`, `llama-cli`, `test-llama-archs` build clean; `test-llama-archs -a glm5next -s 1234` reports OK (0.00e+00).
- Local replay of the resolve loop on b10881 with the updated pin set: all 13 pins merge (Inkling and mtmd CMakeLists via additive merge as before), `merge_checks.py` clean, `pin_contract.py` OK, mix head `ee659afe2`.
- `grep` over the mixed tree for `ggml_mul_mat_set_prec(` and `ggml_flash_attn_ext_set_prec(` outside the ggml headers: zero call sites left.

## After merge

Tonight's schedule picks up master. To recover the b10881 release earlier, re-run the failed jobs of run 34412786914 after this lands.