### PR TITLE
Build glslc without a precompiled header so the arm64 Vulkan leg survives runner image updates

### DIFF
--- a/.github/workflows/unsloth-prebuilt-vulkan.yml
+++ b/.github/workflows/unsloth-prebuilt-vulkan.yml
@@ -166,11 +166,18 @@ jobs:
           echo "59c0c478f2f40a076e610587d099e39ed059cb7319fe464f8ba1bd07c6bf02c5  $archive" | sha256sum -c -
           mkdir -p "$source"
           tar -xzf "$archive" -C "$source"
+          # ENABLE_PCH=OFF: glslang builds a clang precompiled header, and ccache
+          # hands the cached .pch back on the next run. Clang validates a PCH by
+          # the mtime of every system header it saw, so the first run after the
+          # runner image reinstalls linux-libc-dev fails with "has been modified
+          # since the precompiled header was built" (run 34459747884). Without the
+          # PCH every object is an ordinary ccache hit and the build is unchanged.
           cmake -S "$source" -B "$source/build" -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DSHADERC_SKIP_TESTS=ON \
             -DSHADERC_SKIP_EXAMPLES=ON \
             -DSHADERC_SKIP_COPYRIGHT_CHECK=ON \
+            -DENABLE_PCH=OFF \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           cmake --build "$source/build" --target glslc_exe -j "$(nproc)"


### PR DESCRIPTION
## Why

Run 34459747884 (the first prebuilt run after #212) failed on `Vulkan / linux/arm64` in the `Build glslc (arm64)` step:

```
fatal error: file '/usr/include/asm-generic/errno-base.h' has been modified since the precompiled header
'.../third_party/glslang/glslang/CMakeFiles/glslang.dir/cmake_pch.hxx.pch' was built: mtime changed (was 1786107474, now 1786125007)
```

glslang builds a clang precompiled header (`ENABLE_PCH` defaults to ON) and the shaderc build runs under ccache, so the `.pch` produced by the previous run (restore key `ccache-vulkan-linux-arm64-b10883-mix-bea84f7-34437354177-1`) came back as a cache hit. Clang validates a PCH against the mtime of every system header it saw when it was built, and the arm64 runner image had reinstalled `linux-libc-dev` between the two runs, so every translation unit that includes the PCH is rejected. The `include_file_mtime` sloppiness only covers ccache's own lookup; it cannot stop clang from checking the header mtimes recorded inside the PCH. The x64 leg does not build glslc (it installs the LunarG package), which is why only arm64 failed.

The same failure will recur on the first arm64 run after every runner image refresh, and re-running the job cannot help because the same cache is restored.

## What changes

`-DENABLE_PCH=OFF` on the shaderc configure. Without the PCH every glslang object is an ordinary ccache entry keyed on preprocessed content, which is exactly what the rest of the Vulkan build already relies on. The glslc binary is unchanged; the cold build is a few seconds slower on 285 objects, the warm build is the same.

## Validation

- `ENABLE_PCH` is the glslang option in the pinned shaderc 2025.2 tarball (`third_party/glslang/CMakeLists.txt:123`, consumed by `glslang_pch()` at line 272).
- Workflow YAML parses.
