### PR TITLE
glm5next: avoid soft_max gridDim.y overflow in the indexer

### DIFF
--- a/src/models/glm5next.cpp
+++ b/src/models/glm5next.cpp
@@ -383,7 +383,9 @@ ggml_tensor * llama_model_glm5next::graph::build_indexer(
     ggml_tensor * ape = ggml_cont(ctx0, ggml_transpose(ctx0, layer.indexer_comp_ape));
     gate_t = ggml_add(ctx0, gate_t, ggml_reshape_4d(ctx0, ape, r, d_idx, 1, 1));
 
-    ggml_tensor * probs = ggml_soft_max(ctx0, gate_t);
+    // count new pools along ne1: soft_max launches gridDim.y = ne2, capped at 65535, and 262144/4 = 65536
+    ggml_tensor * probs = ggml_soft_max(ctx0, ggml_reshape_2d(ctx0, gate_t, r, d_idx*n_new_max*n_stream));
+    probs = ggml_reshape_4d(ctx0, probs, r, d_idx, n_new_max, n_stream);
     cb(probs, "indexer_pool_probs", il);
 
     ggml_tensor * pool_new = ggml_sum_rows(ctx0, ggml_mul(ctx0, keys_t, probs));

--- a/src/models/glm5next.cpp
+++ b/src/models/glm5next.cpp
@@ -383,7 +383,7 @@ ggml_tensor * llama_model_glm5next::graph::build_indexer(
     ggml_tensor * ape = ggml_cont(ctx0, ggml_transpose(ctx0, layer.indexer_comp_ape));
     gate_t = ggml_add(ctx0, gate_t, ggml_reshape_4d(ctx0, ape, r, d_idx, 1, 1));
 
-    // count new pools along ne1: soft_max launches gridDim.y = ne2, capped at 65535, and 262144/4 = 65536
+    // soft_max maps ne2/ne3 to gridDim.y/z (65535 cap); fold into ne1
     ggml_tensor * probs = ggml_soft_max(ctx0, ggml_reshape_2d(ctx0, gate_t, r, d_idx*n_new_max*n_stream));
     probs = ggml_reshape_4d(ctx0, probs, r, d_idx, n_new_max, n_stream);
     cb(probs, "indexer_pool_probs", il);


### PR DESCRIPTION
## Overview

Reshape k-pool indexer gate logits before `ggml_soft_max` so `n_new_max` does not map to `gridDim.y`, which is capped at 65535 on CUDA. During k-pool rebuild at long context (`n_kv >= 262144`, `kpool = 4`), `n_new_max` reaches 65538 and the launch aborts with `SOFT_MAX failed`.

Fold `n_new_max` and `n_stream` into `ne1` via `ggml_reshape_2d`, then reshape back to 4D for downstream `mul` / `sum_rows`. Same pattern as `qwen4exp.cpp`.

Stacked on ggml-org/llama.cpp#27754.

## Additional information

Related: ggml-org/llama.cpp#27773, timkhronos/llama.cpp#11, ggml-org/llama.cpp#27901

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - assisted implementation and review; I understand the change and can maintain it.